### PR TITLE
Fix a regex misktake on base_rules/modsecurity_crs_50_outbound.conf line 135

### DIFF
--- a/base_rules/modsecurity_crs_50_outbound.conf
+++ b/base_rules/modsecurity_crs_50_outbound.conf
@@ -132,7 +132,7 @@ SecRule RESPONSE_STATUS "!^404$" \
 	SecRule RESPONSE_BODY "\bServer Error in.{0,50}?\bApplication\b" "t:none,capture,setvar:'tx.msg=%{rule.msg}',setvar:tx.outbound_anomaly_score=+%{tx.error_anomaly_score},setvar:tx.anomaly_score=+%{tx.error_anomaly_score},setvar:tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}"
 
 # Directory Listing
-SecRule RESPONSE_BODY "(?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Index of|>[To Parent Directory]<\/[Aa]><br>)" \
+SecRule RESPONSE_BODY "(?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Index of|>\[To Parent Directory\]<\/[Aa]><br>)" \
         "phase:4,rev:'2',ver:'OWASP_CRS/2.2.6',maturity:'9',accuracy:'9',t:none,capture,ctl:auditLogParts=+E,block,msg:'Directory Listing',logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',id:'970013',tag:'OWASP_CRS/LEAKAGE/INFO_DIRECTORY_LISTING',tag:'WASCTC/WASC-13',tag:'OWASP_TOP_10/A6',tag:'PCI/6.5.6',severity:'3',setvar:'tx.msg=%{rule.msg}',setvar:tx.outbound_anomaly_score=+%{tx.error_anomaly_score},setvar:tx.anomaly_score=+%{tx.error_anomaly_score},setvar:tx.%{rule.id}-OWASP_CRS/LEAKAGE/INFO-%{matched_var_name}=%{tx.0}"
 
 SecMarker END_OUTBOUND_CHECK             


### PR DESCRIPTION
The '[' and ']' was not escaped, so the regex is wrong.
