### PR TITLE
Bug fixes to session hijacking

### DIFF
--- a/optional_rules/modsecurity_crs_16_session_hijacking.conf
+++ b/optional_rules/modsecurity_crs_16_session_hijacking.conf
@@ -22,7 +22,7 @@
 SecMarker BEGIN_SESSION_STARTUP
 
 SecRule REQUEST_COOKIES:'/(j?sessionid|(php)?sessid|(asp|jserv|jw)?session[-_]?(id)?|cf(id|token)|sid)/' ".*" "chain,phase:1,id:'981054',t:none,block,log,msg:'Invalid SessionID Submitted.',setsid:%{matched_var},setvar:tx.sessionid=%{matched_var},skipAfter:END_SESSION_STARTUP"
-        SecRule SESSION:VALID "!@eq 1" "t:none,setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},setvar:tx.%{rule.id}-WEB_ATTACK/INVALID_SESSIONID-%{matched_var_name}=%{tx.0}"
+        SecRule SESSION:IS_NEW "@eq 1" "t:none,setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},setvar:tx.%{rule.id}-WEB_ATTACK/INVALID_SESSIONID-%{matched_var_name}=%{tx.0}"
 
 SecRule &REQUEST_COOKIES:'/(j?sessionid|(php)?sessid|(asp|jserv|jw)?session[-_]?(id)?|cf(id|token)|sid)/' "@eq 0" "phase:1,id:'981055',t:none,nolog,pass,skipAfter:END_SESSION_STARTUP"
 
@@ -41,7 +41,7 @@ SecMarker END_SESSION_STARTUP
 #
 # This rule will identify the outbound Set-Cookie SessionID data and capture it in a setsid
 #
-SecRule RESPONSE_HEADERS:/Set-Cookie2?/ "(?i:(j?sessionid|(php)?sessid|(asp|jserv|jw)?session[-_]?(id)?|cf(id|token)|sid)=([^\s].*?)\;\s?)" "chain,phase:3,id:'981062',t:none,pass,nolog,capture,setsid:%{TX.6},setvar:session.sessionid=%{TX.6},setvar:tx.ip=%{remote_addr},setvar:tx.ua=%{request_headers.user-agent},setvar:session.valid=1"
+SecRule RESPONSE_HEADERS:/Set-Cookie2?/ "(?i:(j?sessionid|(php)?sessid|(asp|jserv|jw)?session[-_]?(id)?|cf(id|token)|sid).*?=([^\s].*?)\;\s?)" "chain,phase:3,id:'981062',t:none,pass,nolog,capture,setsid:%{TX.6},setvar:session.sessionid=%{TX.6},setvar:tx.ip=%{remote_addr},setvar:tx.ua=%{request_headers.user-agent}"
 	SecRule UNIQUE_ID "(.*)" "t:none,t:sha1,t:hexEncode,capture,setvar:session.csrf_token=%{TX.1}"
 
 SecRule REMOTE_ADDR "^(\d{1,3}\.\d{1,3}\.\d{1,3}\.)"  "chain,phase:3,id:'981063',capture,t:none,nolog,pass"


### PR DESCRIPTION
Some cookies did not match in RESPONSE_HEADERS:/Set-Cookie2?/ but did match in REQUEST_COOKIES. ie ASPSESSIONIDXXX.

Also there was a bug related to comparisons on collection keys that do
not exist. When a request contains a cookie that has not been saved to
the SESSION collection before, the intention is for tx.anomaly_score
to be incremented by 5 (critical) and the rest of the checks skipped,
but this does not happen. Any test on a collection key that does not
exist always returns false. This means the test on SESSION:VALID "!@eq
1" returns false, when the intention is for it to return true if the
session cookie has not been seen before.  And the following rules in
the block are run which triggers 981059,981060,981061 to return true
since it is a new session collection withou ip_hash or ua_hash keys.
