### PR TITLE
modsecurity_crs_47_common_exceptions.conf: drop apache User-Agent signat...

### DIFF
--- a/base_rules/modsecurity_crs_47_common_exceptions.conf
+++ b/base_rules/modsecurity_crs_47_common_exceptions.conf
@@ -23,7 +23,7 @@ SecRule REQUEST_LINE "^GET /$" "chain,phase:2,id:'981020',t:none,pass,nolog"
 #
 SecRule REQUEST_LINE "^(GET /|OPTIONS \*) HTTP/1.0$" "chain,phase:2,id:'981021',t:none,pass,nolog"
 	SecRule REMOTE_ADDR "^(127\.0\.0\.|\:\:)1$" "chain,t:none"
-		SecRule REQUEST_HEADERS:User-Agent "^Apache.*\(internal dummy connection\)$" "t:none,t:none,chain"
+		SecRule REQUEST_HEADERS:User-Agent "^.*\(internal dummy connection\)$" "t:none,t:none,chain"
                 	SecRule TX:'/PROTOCOL_VIOLATION\\\/MISSING_HEADER/' ".*" "chain,setvar:tx.missing_header=+1,setvar:tx.missing_header_%{tx.missing_header}=%{matched_var_name}"
                         	SecRule TX:'/MISSING_HEADER_/' "TX\:(.*)" "capture,t:none,setvar:!tx.%{tx.1}"
 


### PR DESCRIPTION
...ure for dummy connection

When the apache HTTP Server manages its child processes, it sends a simple HTTP request back to itself.
This request will appear in the access_log file with the remote address set to the loop-back interface
and if you log the User-Agent string you will see the server signature followed by "(internal dummy connection)"
on non-SSL servers. modsecurity_crs_47_common_exceptions already contain a chained rule for skipping
the apache internal dummy connection if the connection is from the lookback address.

But if the administrator has set the directive SecServerSignature
to one of the ./modsecurity_35_bad_robots.data, for example chinaclaw, the skip rule for the internal dummy connection is not used,
because in that case the User-Agent is defined by the valued of the SecServerSignature, and
not contain the value Apache: in this case the rule 990012 will fire wrongly.
Therefore, because the skip rule it is applied already to connection from 127.0.0.1,
so it is sufficently safe, don't cause any problem to eliminate the "Apache" control also on the User-Agent variables.
It is very similar to a standard iptables setup in which it is common to put a catchall ACCEPT rule
on the loopback interface.
