### PR TITLE
Catch only TX:12345-... variables 

### DIFF
--- a/base_rules/modsecurity_crs_49_inbound_blocking.conf
+++ b/base_rules/modsecurity_crs_49_inbound_blocking.conf
@@ -26,7 +26,7 @@ SecRule TX:ANOMALY_SCORE "@gt 0" \
     "chain,phase:2,id:'981176',t:none,deny,log,msg:'Inbound Anomaly Score Exceeded (Total Score: %{TX.ANOMALY_SCORE}, SQLi=%{TX.SQL_INJECTION_SCORE}, XSS=%{TX.XSS_SCORE}): Last Matched Message: %{tx.msg}',logdata:'Last Matched Data: %{matched_var}',setvar:tx.inbound_tx_msg=%{tx.msg},setvar:tx.inbound_anomaly_score=%{tx.anomaly_score}"
         SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_level}" chain
                 SecRule TX:ANOMALY_SCORE_BLOCKING "@streq on" chain
-                        SecRule TX:/^\d/ "(.*)"
+                        SecRule TX:/^\d+\-/ "(.*)"
 
 # Alert and Block on a specific attack category such as SQL Injection
 #


### PR DESCRIPTION
Error messages misleading with TX.0 in it when it should be TX:00000-..
for example
Expanded "TX:/^\d/" to "TX:0|TX:981245-Detects basic SQL authentication bypass attempts 2/3-OWASP_CRS/WEB_ATTACK/SQLI-ARGS:TESTARGS"
Then TX:0 matches. If you want this information for further processing it is not useful to get TX:0 because it has no information which rule matched.
