### PR TITLE
superfluous single quote which will cause syntax error on line 121 in modsecurity_crs_55_application_defects.conf

### DIFF
--- a/optional_rules/modsecurity_crs_55_application_defects.conf
+++ b/optional_rules/modsecurity_crs_55_application_defects.conf
@@ -118,7 +118,7 @@ Header edit Set-Cookie "^((?i:(_?(COOKIE|TOKEN)|atlassian.xsrf.token|[aj]?sessio
 # - http://websecuritytool.codeplex.com/wikipage?title=Checks#http-cache-control-header-no-store
 #
 SecRule &GLOBAL:CHECK_CACHE_CONTROL "@eq 0" "phase:5,t:none,nolog,pass,id:'981239',setvar:global.check_cache_control=0"
-SecRule GLOBAL:CHECK_CACHE_CONTROL "@le 10" "chain,phase:5,id:'900046'',t:none,pass,log,auditlog,msg:'AppDefect: Cache-Control Response Header Missing \'no-store\' flag.',logdata:'Cache-Control: %{response_headers.cache-control}',tag:'WASCTC/WASC-15',tag:'MISCONFIGURATION',tag:'http://websecuritytool.codeplex.com/wikipage?title=Checks#http-cache-control-header-no-store'"
+SecRule GLOBAL:CHECK_CACHE_CONTROL "@le 10" "chain,phase:5,id:'900046',t:none,pass,log,auditlog,msg:'AppDefect: Cache-Control Response Header Missing \'no-store\' flag.',logdata:'Cache-Control: %{response_headers.cache-control}',tag:'WASCTC/WASC-15',tag:'MISCONFIGURATION',tag:'http://websecuritytool.codeplex.com/wikipage?title=Checks#http-cache-control-header-no-store'"
 	SecRule RESPONSE_HEADERS:Cache-Control "!@contains no-store" "t:none,t:lowercase,setvar:global.check_cache_control=+1,expirevar:global.check_cache_control=86400"
 
 


### PR DESCRIPTION
```
# service apache2 restart
Syntax error on line 121 of /etc/modsecurity/enabled_rules/modsecurity_crs_55_application_defects.conf:
Error parsing actions: Unknown action: '
Action 'configtest' failed.
The Apache error log may have more information.
   ...fail!
```
