### PR TITLE
Outbound CC checks are broken due to missing capture

### DIFF
--- a/optional_rules/modsecurity_crs_25_cc_known.conf
+++ b/optional_rules/modsecurity_crs_25_cc_known.conf
@@ -59,49 +59,49 @@ SecAction "phase:4,id:'981081',t:none,pass,nolog,skipAfter:END_KNOWN_CC_OUTBOUND
 
 # GSA SmartPay
 SecRule RESPONSE_BODY|RESPONSE_HEADERS:Location "@verifyCC (?:^|[^\d])(?<!google_ad_client = \"pub-)((?:5568|4(?:486|716))\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{4}|8699\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{3})(?:[^\d]|$)" \
-        "chain,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'GSA SmartPay Card Number sent from site to user',id:'920020',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
+        "chain,capture,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'GSA SmartPay Card Number sent from site to user',id:'920020',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
         SecRule TX:1 "(\d{4}\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{1,4})" "chain,capture,setvar:tx.ccdata=%{tx.1}"
                 SecRule TX:CCDATA "^(\d{4}\-?)" "capture,setvar:tx.ccdata_begin=%{tx.1},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},setvar:tx.%{rule.id}-LEAKAGE/CC-%{matched_var_name}=%{tx.0}"
 
 # MasterCard
 SecRule RESPONSE_BODY|RESPONSE_HEADERS:Location "@verifyCC (?:^|[^\d])(?<!google_ad_client = \"pub-)(5[1-5]\d{2}\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{4})(?:[^\d]|$)" \
-	"chain,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'MasterCard Credit Card Number sent from site to user',id:'920006',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
+	"chain,capture,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'MasterCard Credit Card Number sent from site to user',id:'920006',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
         SecRule TX:1 "(\d{4}\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{1,4})" "chain,capture,setvar:tx.ccdata=%{tx.1}"
                 SecRule TX:CCDATA "^(\d{4}\-?)" "capture,setvar:tx.ccdata_begin=%{tx.1},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},setvar:tx.%{rule.id}-LEAKAGE/CC-%{matched_var_name}=%{tx.0}"        
 
 # Visa
 SecRule RESPONSE_BODY|RESPONSE_HEADERS:Location "@verifyCC (?:^|[^\d])(?<!google_ad_client = \"pub-)(4\d{3}\-?\d{4}\-?\d{2}\-?\d{2}\-?\d(?:\d{3})??)(?:[^\d]|$)" \
-	"chain,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'Visa Credit Card Number sent from site to user',id:'920008',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
+	"chain,capture,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'Visa Credit Card Number sent from site to user',id:'920008',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
         SecRule TX:1 "(\d{4}\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{1,4})" "chain,capture,setvar:tx.ccdata=%{tx.1}"
                 SecRule TX:CCDATA "^(\d{4}\-?)" "capture,setvar:tx.ccdata_begin=%{tx.1},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},setvar:tx.%{rule.id}-LEAKAGE/CC-%{matched_var_name}=%{tx.0}"
 
 # American Express
 SecRule RESPONSE_BODY|RESPONSE_HEADERS:Location "@verifyCC (?:^|[^\d])(?<!google_ad_client = \"pub-)(3[47]\d{2}\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{3})(?:[^\d]|$)" \
-	"chain,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'American Express Credit Card Number sent from site to user',id:'920010',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
+	"chain,capture,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'American Express Credit Card Number sent from site to user',id:'920010',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
         SecRule TX:1 "(\d{4}\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{1,4})" "chain,capture,setvar:tx.ccdata=%{tx.1}"
                 SecRule TX:CCDATA "^(\d{4}\-?)" "capture,setvar:tx.ccdata_begin=%{tx.1},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},setvar:tx.%{rule.id}-LEAKAGE/CC-%{matched_var_name}=%{tx.0}"
 
 # Diners Club
 SecRule RESPONSE_BODY|RESPONSE_HEADERS:Location "@verifyCC (?:^|[^\d])(?<!google_ad_client = \"pub-)((?:30[0-5]|3[68]\d)\d\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{2})(?:[^\d]|$)" \
-	"chain,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'Diners Club Credit Card Number sent from site to user',id:'920012',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
+	"chain,capture,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'Diners Club Credit Card Number sent from site to user',id:'920012',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
         SecRule TX:1 "(\d{4}\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{1,4})" "chain,capture,setvar:tx.ccdata=%{tx.1}"
                 SecRule TX:CCDATA "^(\d{4}\-?)" "capture,setvar:tx.ccdata_begin=%{tx.1},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},setvar:tx.%{rule.id}-LEAKAGE/CC-%{matched_var_name}=%{tx.0}"
 
 # enRoute
 #SecRule RESPONSE_BODY|RESPONSE_HEADERS:Location "(?:^|[^\d])(?<!google_ad_client = \"pub-)(2(?:014|149)\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{2}|55\d{2}\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{3})(?:[^\d]|$)" \
-#	"chain,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'enRoute Credit Card Number sent from site to user',id:'920014',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
+#	"chain,capture,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'enRoute Credit Card Number sent from site to user',id:'920014',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
 #        SecRule TX:1 "(\d{4}\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{1,4})" "chain,capture,setvar:tx.ccdata=%{tx.1}"
 #                SecRule TX:CCDATA "^(\d{4}\-?)" "capture,setvar:tx.ccdata_begin=%{tx.1},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},setvar:tx.%{rule.id}-LEAKAGE/CC-%{matched_var_name}=%{tx.0}"
 
 # Discover
 SecRule RESPONSE_BODY|RESPONSE_HEADERS:Location "@verifyCC (?:^|[^\d])(?<!google_ad_client = \"pub-)(6(?:011|5\d{2})\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{4})(?:[^\d]|$)" \
-	"chain,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'Discover Credit Card Number sent from site to user',id:'920016',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
+	"chain,capture,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'Discover Credit Card Number sent from site to user',id:'920016',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
         SecRule TX:1 "(\d{4}\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{1,4})" "chain,capture,setvar:tx.ccdata=%{tx.1}"
                 SecRule TX:CCDATA "^(\d{4}\-?)" "capture,setvar:tx.ccdata_begin=%{tx.1},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},setvar:tx.%{rule.id}-LEAKAGE/CC-%{matched_var_name}=%{tx.0}"
 
 # JCB
 SecRule RESPONSE_BODY|RESPONSE_HEADERS:Location "@verifyCC (?:^|[^\d])(?<!google_ad_client = \"pub-)(3\d{3}\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{4}|(?:1800|21(?:31|00))\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{3})(?:[^\d]|$)" \
-	"chain,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'JCB Credit Card Number sent from site to user',id:'920018',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
+	"chain,capture,logdata:'Start of CC #: %{tx.ccdata_begin}***...',phase:4,t:none,ctl:auditLogParts=-E,block,msg:'JCB Credit Card Number sent from site to user',id:'920018',tag:'WASCTC/5.2',tag:'PCI/3.3',severity:'1'"
         SecRule TX:1 "(\d{4}\-?\d{4}\-?\d{2}\-?\d{2}\-?\d{1,4})" "chain,capture,setvar:tx.ccdata=%{tx.1}"
                 SecRule TX:CCDATA "^(\d{4}\-?)" "capture,setvar:tx.ccdata_begin=%{tx.1},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},setvar:tx.%{rule.id}-LEAKAGE/CC-%{matched_var_name}=%{tx.0}"
 


### PR DESCRIPTION
Hi Ryan,

I found last year that the outbound credit card checks weren't functioning properly because the top rule in the chain wasn't capturing output.  I've had custom rules that fixed this for a while, but figured they should make their way into the official repository.

Thanks
