### PR TITLE
Fix trailing whitespace

### DIFF
--- a/base_rules/10-REQUEST-IP-REPUTATION.conf
+++ b/base_rules/10-REQUEST-IP-REPUTATION.conf
@@ -60,7 +60,7 @@ SecRule IP:PREVIOUS_RBL_CHECK "@eq 1" \
   phase:request,\
   nolog,\
   pass,\
-  t:none,\ 
+  t:none,\
   skipAfter:END_RBL_LOOKUP"
 
 #


### PR DESCRIPTION
Fixed a trailing whitespace in base_rules/10-REQUEST-IP-REPUTATION.conf
