### PR TITLE
Change phase from "request" to 1 for rule 900012

### DIFF
--- a/modsecurity_crs_10_setup.conf.example
+++ b/modsecurity_crs_10_setup.conf.example
@@ -311,7 +311,7 @@ SecAction \
 #
 SecAction \
  "id:'900012',\
-  phase:request,\
+  phase:1,\
   nolog,\
   pass,\
   t:none,\


### PR DESCRIPTION
The tx.allowed_methods macro is needed in phase 1 but the config file
only sets it in phase 2 (request). This always triggers rule 960032 in
base_rules/modsecurity_crs_30_http_policy.conf.
