### PR TITLE
Added string match for 960020 to adhere strictly to RFC. Closes #158.

### DIFF
--- a/base_rules/modsecurity_crs_20_protocol_violations.conf
+++ b/base_rules/modsecurity_crs_20_protocol_violations.conf
@@ -396,7 +396,7 @@ SecRule REQUEST_HEADERS:Expect "@contains 100-continue" \
 # -=[ References ]=-
 # http://www.bad-behavior.ioerror.us/documentation/how-it-works/
 #	
-SecRule &REQUEST_HEADERS:Pragma "@eq 1" "chain,phase:2,rev:'1',ver:'OWASP_CRS/2.2.9',maturity:'6',accuracy:'8',t:none,block,msg:'Pragma Header requires Cache-Control Header for HTTP/1.1 requests.',severity:'5',id:'960020',tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ'"
+SecRule &REQUEST_HEADERS:Pragma "@eq 1" "chain,phase:2,rev:'2',ver:'OWASP_CRS/2.2.9',maturity:'6',accuracy:'8',t:none,block,msg:'Pragma Header requires Cache-Control Header for HTTP/1.1 requests.',severity:'5',id:'960020',tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ'"
 	SecRule REQUEST_HEADERS:Pragma "@strmatch no-cache" "chain"
 		SecRule &REQUEST_HEADERS:Cache-Control "@eq 0" "chain"
 			SecRule REQUEST_PROTOCOL "@streq HTTP/1.1" "setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}"


### PR DESCRIPTION
Tested with following header combinations:

Rule Fires:
curl -XGET -H "Pragma: no-cache" http://127.0.0.1/
curl -XGET -H "Pragma: no-cache" -H "Cache-Contro: no-cache" http://127.0.0.1/

Rule Misses:
curl -XGET -H "Pragma: no-cache" -H "Cache-Control: no-cache" http://127.0.0.1/
curl -XGET -H "Pragma: no-cache" -H "Cache-Control: no-cach" http://127.0.0.1/
curl -XGET -H "Pragma: no-cach" -H "Cache-Contro: no-cach" http://127.0.0.1/
