### PR TITLE
Enable embedded mode, Session test before setvars

### DIFF
--- a/optional_rules/modsecurity_crs_16_session_hijacking.conf
+++ b/optional_rules/modsecurity_crs_16_session_hijacking.conf
@@ -41,11 +41,12 @@ SecMarker END_SESSION_STARTUP
 #
 # This rule will identify the outbound Set-Cookie SessionID data and capture it in a setsid
 #
-SecRule RESPONSE_HEADERS:/Set-Cookie2?/ "(?i:(j?sessionid|(php)?sessid|(asp|jserv|jw)?session[-_]?(id)?|cf(id|token)|sid).*?=([^\s].*?)\;\s?)" "chain,phase:3,id:'981062',t:none,pass,nolog,capture,setsid:%{TX.6},setvar:session.sessionid=%{TX.6},setvar:tx.ip=%{remote_addr},setvar:tx.ua=%{request_headers.user-agent}"
+SecRule RESPONSE_HEADERS:/Set-Cookie2?/ "(?i:(j?sessionid|(php)?sessid|(asp|jserv|jw)?session[-_]?(id)?|cf(id|token)|sid).*?=([^\s].*?)\;\s?)" "chain,phase:5,id:'981062',t:none,pass,nolog,capture,setsid:%{TX.6},setvar:session.sessionid=%{TX.6},setvar:tx.ip=%{remote_addr},setvar:tx.ua=%{request_headers.user-agent}"
 	SecRule UNIQUE_ID "(.*)" "t:none,t:sha1,t:hexEncode,capture,setvar:session.csrf_token=%{TX.1}"
 
-SecRule REMOTE_ADDR "^(\d{1,3}\.\d{1,3}\.\d{1,3}\.)"  "chain,phase:3,id:'981063',capture,t:none,nolog,pass"
-	SecRule TX:1 ".*" "t:sha1,t:hexEncode,setvar:session.ip_hash=%{matched_var}"
-SecRule REQUEST_HEADERS:User-Agent ".*" "phase:3,id:'981064',t:none,t:sha1,t:hexEncode,nolog,pass,setvar:session.ua_hash=%{matched_var}"
+SecRule &SESSION:SESSIONID "@eq 1" "chain,phase:5,id:'981063',nolog,pass,t:none"
+        SecRule REMOTE_ADDR "^(\d{1,3}\.\d{1,3}\.\d{1,3}\.)"  "chain,nolog,capture,t:none"
+        SecRule TX:1 ".*" "chain,t:sha1,t:hexEncode,setvar:session.ip_hash=%{matched_var}"
 
-
+SecRule &SESSION:SESSIONID "@eq 1" "chain,phase:5,id:'981064',nolog,pass,t:none"
+        SecRule REQUEST_HEADERS:User-Agent ".*" "t:none,t:sha1,t:hexEncode,nolog,setvar:session.ua_hash=%{matched_var}"


### PR DESCRIPTION
**Issue 1**
The last two rules (981063 and 981064, lines 47 and 49) will try to setvar even when the SESSION collection hasn't yet been initialized (e.g. for session-less users, like bots or anonymous users).
This results in two "collection does not exist" errors per transaction.

**Issue 2**
I also noticed that because I run Modsecurity in embedded mode, a lot of response headers aren't yet released" by Apache on phase 3.
That includes the **Set-Cookie header**, which is vital for rule 981062 (Session initialization).

Proposed resolution:
- Move execution of rules 981062 (Session creation), 981063 and 981064 (IP and UA Hash creation) to phase 5:
  Since they are all non-disruptive, and because the Set-Cookie response headers are only available at the logging phase for embedded installs, this enables successful session initialization for all install modes.
- Execute rules 981063 and 981064 with a session existence test:
  - That way, IP and UA hashes are only created for an existing session, or one that was just created by the previous 981062 rule, and there are no more errors for session-less navigation.
  - Proposed session existence test:  
    SecRule &SESSION:SESSIONID "@eq 1" "chain..."
  - Apparently, it's important that this test be the first in chain, so as to prevent the errors showing up (maybe the rule is parsed without being executed when further down the chain? I'm not sure...)
