### PR TITLE
Wrongful "chain" action

### DIFF
--- a/optional_rules/modsecurity_crs_16_session_hijacking.conf
+++ b/optional_rules/modsecurity_crs_16_session_hijacking.conf
@@ -46,7 +46,7 @@ SecRule RESPONSE_HEADERS:/Set-Cookie2?/ "(?i:(j?sessionid|(php)?sessid|(asp|jser
 
 SecRule &SESSION:SESSIONID "@eq 1" "chain,phase:5,id:'981063',nolog,pass,t:none"
         SecRule REMOTE_ADDR "^(\d{1,3}\.\d{1,3}\.\d{1,3}\.)"  "chain,nolog,capture,t:none"
-        SecRule TX:1 ".*" "chain,t:sha1,t:hexEncode,setvar:session.ip_hash=%{matched_var}"
+        SecRule TX:1 ".*" "t:sha1,t:hexEncode,setvar:session.ip_hash=%{matched_var}"
 
 SecRule &SESSION:SESSIONID "@eq 1" "chain,phase:5,id:'981064',nolog,pass,t:none"
         SecRule REQUEST_HEADERS:User-Agent ".*" "t:none,t:sha1,t:hexEncode,nolog,setvar:session.ua_hash=%{matched_var}"


### PR DESCRIPTION
The chain action on line 49 was causing rule 981064 to act as chained, which would make its dsiruptive actions illegal, and the two chains useless...
