### PR TITLE
Update scanners-user-agents.txt

### DIFF
--- a/rules/scanners-user-agents.txt
+++ b/rules/scanners-user-agents.txt
@@ -31,6 +31,8 @@ inspath [path disclosure finder
 internet ninja
 jaascois
 zmeu
+LWP
+masscan
 metis
 morfeus fucking scanner
 mozilla/4.0 (compatible)
@@ -54,6 +56,8 @@ prog.customcrawler
 prowebwalker
 pymills-spider/
 python-httplib2
+python-requests
+Python-urllib
 qualys was
 s.t.a.l.k.e.r.
 security scan


### PR DESCRIPTION
Using results from my webapp honey pot, these were user-agent strings that conducted scans or exploit attempts over the last year. 
This excludes scanners that appear to be from academic institutions.
masscan/1.0 (https://github.com/robertdavidgraham/masscan)
https://github.com/robertdavidgraham/masscan/search?utf8=%E2%9C%93&q=user-agent

LWP::Simple/6.00 libwww-perl/6.07 - with Shellshock exploit attempts
Python-urllib - with Shellshock exploit attempts
python-requests - with Shellshock exploit attempts
libwww-perl - with Shellshock exploit attempts