### PR TITLE
Fixed PHP tag bypass

### DIFF
--- a/base_rules/modsecurity_crs_40_generic_attacks.conf
+++ b/base_rules/modsecurity_crs_40_generic_attacks.conf
@@ -226,7 +226,7 @@ SecRule TX:PM_SCORE "@eq 0" "phase:2,id:'981134',rev:'2',ver:'OWASP_CRS/2.2.9',m
 	# PHP injection
 	#
 	
-	SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "<\?(?!xml)" \
+	SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "<\?(?!xml\s)" \
 	        "phase:2,rev:'2',ver:'OWASP_CRS/2.2.9',maturity:'9',accuracy:'9',capture,t:none,t:htmlEntityDecode,t:compressWhitespace,t:lowercase,ctl:auditLogParts=+E,block,msg:'PHP Injection Attack',id:'959151',severity:'2',tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',tag:'WASCTC/WASC-15',tag:'OWASP_TOP_10/A6',tag:'PCI/6.5.2',tag:'WASCTC/WASC-25',tag:'OWASP_TOP_10/A1',tag:'OWASP_AppSensor/CIE4',tag:'PCI/6.5.2',setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}"
 		
 	SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i)(?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scanf|write|open|read)|gz(?:(?:encod|writ)e|compress|open|read)|s(?:ession_start|candir)|read(?:(?:gz)?file|dir)|move_uploaded_file|(?:proc_|bz)open|call_user_func)|\$_(?:(?:pos|ge)t|session))\b" \


### PR DESCRIPTION
Hey. It is possible to bypass the regular expression to detect the PHP tag if short_open_tag is enabled.

Example:

    <?xml_parser_create();

This can be fixed by checking for a whitespace after `xml`.