### PR TITLE
V3.0.0 dev with added var static resources

### DIFF
--- a/modsecurity_crs_10_setup.conf.example
+++ b/modsecurity_crs_10_setup.conf.example
@@ -348,6 +348,7 @@ SecAction \
   pass,\
   t:none,\
   setvar:'tx.allowed_methods=GET HEAD POST OPTIONS', \
+  setvar:'tx.static_resources=jpg|jpeg|png|gif|js|css|ico', \ 
   setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json', \
   setvar:'tx.allowed_http_versions=HTTP/0.9 HTTP/1.0 HTTP/1.1', \
   setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/', \

--- a/rules/REQUEST-12-DOS-PROTECTION.conf
+++ b/rules/REQUEST-12-DOS-PROTECTION.conf
@@ -36,14 +36,14 @@ SecRule IP:DOS_BLOCK "@eq 1" "phase:5,id:'981046',t:none,nolog,pass,skipAfter:EN
 # DOS Counter
 # Count the number of requests to non-static resoures
 # 
-SecRule REQUEST_BASENAME "!\.(jpe?g|png|gif|js|css|ico)$" "phase:5,id:'981047',t:none,nolog,pass,setvar:ip.dos_counter=+1"
+SecRule REQUEST_BASENAME "!\.(%{tx.static_resources})$" "phase:5,id:'981047',t:none,t:lowercase,nolog,pass,setvar:ip.dos_counter=+1"
 
 #
 # Check DOS Counter
 # If the request count is greater than or equal to user settings,
 # we then set the burst counter
 # 
-SecRule IP:DOS_COUNTER "@gt %{tx.dos_counter_threshold}" "phase:5,id:'981048',t:none,nolog,pass,t:none,setvar:ip.dos_burst_counter=+1,expirevar:ip.dos_burst_counter=%{tx.dos_burst_time_slice},setvar:!ip.dos_counter"
+SecRule IP:DOS_COUNTER "@gt %{tx.dos_counter_threshold}" "phase:5,id:'981048',t:none,nolog,pass,setvar:ip.dos_burst_counter=+1,expirevar:ip.dos_burst_counter=%{tx.dos_burst_time_slice},setvar:!ip.dos_counter"
 
 #
 # Check DOS Burst Counter and set Block


### PR DESCRIPTION
This has static resources listed in the setup.conf as a var. Additionally it fixes a bug with t:none appearing twice in rule 981048. These issues were reported by Barry Pollard