### PR TITLE
Fixed bug in file injection regex

### DIFF
--- a/base_rules/modsecurity_crs_40_generic_attacks.conf
+++ b/base_rules/modsecurity_crs_40_generic_attacks.conf
@@ -201,7 +201,7 @@ SecRule TX:PM_SCORE "@eq 0" "phase:2,id:'981134',rev:'2',ver:'OWASP_CRS/2.2.9',m
 	#
 	# File Injection
 	#
-	SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?:\b(?:\.(?:ht(?:access|passwd|group)|www_?acl)|global\.asa|httpd\.conf|boot\.ini)\b|\/etc\/)" \
+	SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?:(?<!\w)(?:\.(?:ht(?:access|passwd|group)|www_?acl)|global\.asa|httpd\.conf|boot\.ini)\b|\/etc\/)" \
 		"phase:2,rev:'3',ver:'OWASP_CRS/2.2.9',maturity:'9',accuracy:'9',capture,t:none,t:cmdLine,ctl:auditLogParts=+E,block,msg:'Remote File Access Attempt',id:'950005',tag:'OWASP_CRS/WEB_ATTACK/FILE_INJECTION',tag:'WASCTC/WASC-33',tag:'OWASP_TOP_10/A4',tag:'PCI/6.5.4',logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',severity:'2',setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-%{matched_var_name}=%{tx.0}"
 
 	SecMarker END_FILE_INJECTION


### PR DESCRIPTION
The current regex for file injections has a bug. It checks for a word boundary before `.htaccess`, `.htpasswd`, `.htgroup` and `.www_acl`. This will not match in the desired way, because the dot is not part of `\w`. Use a lookbehind instead.

Demonstration:

* [Word boundary](https://regex101.com/r/jV4dZ1/1)
* [Lookbehind](https://regex101.com/r/qD5rE1/1)