### PR TITLE
Split out project honeypot into a number of user controllable categories

### DIFF
--- a/modsecurity_crs_10_setup.conf.example
+++ b/modsecurity_crs_10_setup.conf.example
@@ -278,6 +278,20 @@ SecAction \
 # Ref: https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#wiki-SecHttpBlKey
 # 
 # SecHttpBlKey XXXXXXXXXXXXXXXXX
+#
+# Project Honeypot returns multiple different malicious IP types. You may specify which you
+# want to block by enabled or disabling the types below. This rule should be enabled when
+# the Project Honeypot API key is enabled. By default all malicious types will be blocked.
+#
+#SecAction "id:'900025', \
+  phase:1, \
+  nolog,\
+  pass,\
+  t:none,\
+  setvar:tx.block_search_ip=1, \
+  setvar:tx.block_suspicious_ip=1, \
+  setvar:tx.block_harvester_ip=1, \
+  setvar:tx.block_spammer_ip=1"
 
 
 #

--- a/rules/REQUEST-10-IP-REPUTATION.conf
+++ b/rules/REQUEST-10-IP-REPUTATION.conf
@@ -103,22 +103,98 @@ SecRule IP:PREVIOUS_RBL_CHECK "@eq 1" \
 # Ref: https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#wiki-SecHttpBlKey
 # 
 SecRule TX:REAL_IP "@rbl dnsbl.httpbl.org" \
-  "msg:'HTTP Blacklist match for client IP.',\
-  severity:'CRITICAL',\
-  id:'981138',\
+  "id:'981138',\
   phase:request,\
-  block,\
-  t:none,\
+  capture,\
+  nolog,pass,t:none, \
   tag:'IP_REPUTATON/MALICIOUS_CLIENT',\
-  setvar:'tx.msg=%{rule.msg}',\
-  setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-  setvar:tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var},\
-  setvar:ip.block=1,\
-  expirevar:ip.block=%{tx.block_duration},\
-  setvar:'ip.block_reason=%{rule.msg}',\
-  setvar:ip.previous_rbl_check=1,\
-  expirevar:ip.previous_rbl_check=86400,\
-  skipAfter:END_RBL_CHECK"
+  chain,\
+  setvar:tx.httpbl_msg=%{tx.0}"
+        SecRule TX:httpbl_msg "RBL lookup of .*?.dnsbl.httpbl.org succeeded at TX:checkip. (.*?): .*" \
+          "t:none,\
+          capture,\
+          setvar:tx.httpbl_msg=%{tx.1}"
+
+# The following regexs are generated based off re_operators.c
+SecRule TX:block_search_ip "@eq 1" \
+   "msg:'HTTP Blacklist match for search engine IP',  \
+   severity:'CRITICAL', \
+   id:981141,\
+   phase:request,\
+   block,\
+   t:none,\
+   tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
+   chain,\
+   skipAfter:END_RBL_CHECK"
+        SecRule TX:httpbl_msg "Search Egine" \
+           "setvar:'tx.msg=%{rule.msg}',\
+           setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+           setvar:tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var},\
+           setvar:ip.block=1,\
+           expirevar:ip.block=%{tx.block_duration},\
+           setvar:'ip.block_reason=%{rule.msg}',\
+           setvar:ip.previous_rbl_check=1,\
+           expirevar:ip.previous_rbl_check=86400"
+
+SecRule TX:block_spammer_ip "@eq 1" \
+   "msg:'HTTP Blacklist match for spammer IP',\
+   severity:'CRITICAL',\
+   id:981142,\
+   phase:request,\
+   block,\
+   t:none,\
+   tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
+   chain,\
+   skipAfter:END_RBL_CHECK"
+        SecRule TX:httpbl_msg "(?i)^.*? spammer .*?$" \
+           "setvar:'tx.msg=%{rule.msg}',\
+           setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+           setvar:tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var},\
+           setvar:ip.block=1,\
+           expirevar:ip.block=%{tx.block_duration},\
+           setvar:'ip.block_reason=%{rule.msg}',\
+           setvar:ip.previous_rbl_check=1,\
+           expirevar:ip.previous_rbl_check=86400"
+
+SecRule TX:block_suspicious_ip "@eq 1" \
+   "msg:'HTTP Blacklist match for suspicious IP',\
+   severity:'CRITICAL',\
+   id:981143,\
+   phase:request,\
+   block,\
+   t:none,\
+   tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
+   chain,\
+   skipAfter:END_RBL_CHECK"
+        SecRule TX:httpbl_msg "(?i)^.*? suspicious .*?$" \
+           "setvar:'tx.msg=%{rule.msg}',\
+           setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+           setvar:tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var},\
+           setvar:ip.block=1,\
+           expirevar:ip.block=%{tx.block_duration},\
+           setvar:'ip.block_reason=%{rule.msg}',\
+           setvar:ip.previous_rbl_check=1,\
+           expirevar:ip.previous_rbl_check=86400"
+
+SecRule TX:block_harvester_ip "@eq 1" \
+   "msg:'HTTP Blacklist match for harvester IP',\
+   severity:'CRITICAL',\
+   id:981144,\
+   phase:request,\
+   block,\
+   t:none,\
+   tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
+   chain,\
+   skipAfter:END_RBL_CHECK"
+        SecRule TX:httpbl_msg "(?i)^.*? harvester .*?$" \
+           "setvar:'tx.msg=%{rule.msg}',\
+           setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+           setvar:tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var},\
+           setvar:ip.block=1,\
+           expirevar:ip.block=%{tx.block_duration},\
+           setvar:'ip.block_reason=%{rule.msg}',\
+           setvar:ip.previous_rbl_check=1,\
+           expirevar:ip.previous_rbl_check=86400"
 
 SecAction \
   "id:'981139',\


### PR DESCRIPTION
THIS MUST BE TESTED FIRST. The goal of this is to allow users to control which IP blacklists they block. Turns out most users want to allow search bots. This configuration will allow them to configure what the blacklist blocks.