### PR TITLE
Adding new request smuggling / header injection rules to REQUEST-21-P…

### DIFF
--- a/rules/REQUEST-21-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-21-PROTOCOL-ATTACK.conf
@@ -47,6 +47,40 @@ SecRule REQUEST_HEADERS:'/(Content-Length|Transfer-Encoding)/' "," \
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/REQUEST_SMUGGLING-%{matched_var_name}=%{tx.0}"
 
 #
+# -=[ HTTP Request Smuggling ]=-
+#
+# [ Rule Logic ]
+# This rule looks for a CR/LF character in combination with a HTTP / WEBDAV method name.
+# This would point to an attempt to inject a 2nd request into the request, thus bypassing
+# tests carried out on the primary request.
+#
+# [ References ]
+# http://projects.webappsec.org/HTTP-Request-Smuggling
+#
+SecRule ARGS_NAMES|ARGS|XML:/* "(?:\n|\r)+(?:get|post|head|options|connect|put|delete|trace|propfind|propatch|mkcol|copy|move|lock|unlock)\s+" \
+	"msg:'HTTP Request Smuggling Attack',\
+	phase:request,\
+	id:'950915',\
+	rev:'1',\
+	ver:'OWASP_CRS/3.0.0',\
+	maturity:'5',\
+	accuracy:'5',\
+	severity:'CRITICAL',\
+	capture,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-protocol',\
+	t:none,t:htmlEntityDecode,t:lowercase,\
+	ctl:auditLogParts=+E,\
+	block,\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/REQUEST-SMUGGLING-%{matched_var_name}=%{tx.0}"
+
+#
 # -=[ HTTP Response Splitting ]=-
 #
 # [ Rule Logic ]
@@ -104,4 +138,114 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESPONSE_SPLITTING-%{matched_var_name}=%{tx.0}"
+
+#
+# -=[ HTTP Header Injection ]=-
+#
+# [ Rule Logic ]
+# These rules look for Carriage Return (CR) %0d and Linefeed (LF) %0a characters,
+# on their own or in combination with header field names.
+# These characters may cause problems if the data is returned in a respones header
+# and interpreted by the client.
+# The rules are similar to rules defending against the HTTP Request Splitting and
+# Request Smuggling rules.
+#
+# [ References ]
+# https://en.wikipedia.org/wiki/HTTP_header_injection
+#
+SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "(\n|\r)" \
+	"msg:'HTTP Header Injection Attack via headers',\
+	phase:request,\
+	id:'950912',\
+	rev:'1',\
+	ver:'OWASP_CRS/3.0.0',\
+	maturity:'5',\
+	accuracy:'5',\
+	severity:'CRITICAL',\
+	capture,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-protocol',\
+	t:none,t:htmlEntityDecode,t:lowercase,\
+	ctl:auditLogParts=+E,\
+	block,\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}"
+
+
+SecRule ARGS_NAMES|ARGS_GET "(\n|\r)" \
+	"msg:'HTTP Header Injection Attack via payload (CR/LF deteced)',\
+	phase:request,\
+	id:'950913',\
+	rev:'1',\
+	ver:'OWASP_CRS/3.0.0',\
+	maturity:'5',\
+	accuracy:'5',\
+	severity:'CRITICAL',\
+	capture,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-protocol',\
+	t:none,t:htmlEntityDecode,t:lowercase,\
+	ctl:auditLogParts=+E,\
+	block,\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}"
+
+
+SecRule ARGS_NAMES|ARGS|XML:/* "(?:\n|\r)+(?:\s+|location|refresh|(?:set-)?cookie|(X-)?(?:forwarded-(?:for|host|server)|host|via|remote-ip|remote-addr|originating-IP))\s*:" \
+	"msg:'HTTP Header Injection Attack via payload (CR/LF and header-name detected)',\
+	phase:request,\
+	id:'950914',\
+	rev:'1',\
+	ver:'OWASP_CRS/3.0.0',\
+	maturity:'5',\
+	accuracy:'5',\
+	severity:'CRITICAL',\
+	capture,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-protocol',\
+	t:none,t:htmlEntityDecode,t:lowercase,\
+	ctl:auditLogParts=+E,\
+	block,\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}"
+
+# The rule 950916 generates a lot of false positives (> 1% of requests on a given sample).
+# Disabling it or moving it to a section of paranoid rules would make sense.
+SecRule ARGS_POST|XML:/* "(\n|\r)" \
+	"msg:'HTTP Header Injection Attack via payload (CR/LF detected)',\
+	phase:request,\
+	id:'950916',\
+	rev:'1',\
+	ver:'OWASP_CRS/3.0.0',\
+	maturity:'5',\
+	accuracy:'5',\
+	severity:'NOTICE',\
+	capture,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-protocol',\
+	t:none,t:htmlEntityDecode,t:lowercase,\
+	ctl:auditLogParts=+E,\
+	block,\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:'tx.http_violation_score=+%{tx.notice_anomaly_score}',\
+	setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}"
 


### PR DESCRIPTION
### 950915:	Detecting Carriage Returns in any sort of parameters
followed by suspicious HTTP method names.

Like the previous rules, this is legitimate, but
still suspiscious.

False positives rate:
Based on 156 M requests from approximately 90 services,
we did not receive any positives at all.

Example call triggering the rule:
$> curl -v -d "data=
GET /foo" 'http://www.example.com/index.html'


Proposed Severity: Critical (-> 5 points)



### 950912: Detecting Carriage Returns in Request Header names and Request Headers.
This rule assumes there is no point in having a CR or LF in any
http header names (obviously), but also http header values.

False positives rate:
Based on 156 M requests from approximately 90 services,
we received 18K positives. That means 0.0117% Requests 
triggered positives.

When investigating the positives, over 90% relate to cookies.

Example call triggering the rule: 
$> curl -v -H "Cookie: footer=Cheers,%0A%0DSam" 'http://www.example.com/index.html'

Proposed Severity: Critical (-> 5 points)



### 950913: Detecting Carriage Returns in argument names and in query strings.

Again, it is easy to see, that CRs and LFs have no place in these
spots.

False positives rate:
Based on 156 M requests from approximately 90 services,
we received 17K positives. That means 0.0108% requests 
triggered positives.

When investing the positives, 90% of the positives boil
down to an extensive filter string issued in a strange search
language. Another 5% relate to a query string send within
one service and the query string contained a mail
address with CRs.

Example call triggering the rule: 
$> curl -v -d "da
ta=foo" http://www.example.com/index.html

Proposed Severity: Critical (-> 5 points)



### 950914:	Detecting Carriage Returns in any sort of parameter values
followed by suspicious HTTP Request header names.

This includes Request Body and naturally this is where we
have to expect false positives even with benign applications.
Still, to bring a CR / LF and then start the new Line with
"Refresh" is suspicious and bears for further investigation.

False positives rate:
Based on 156 M requests from approximately 90 services,
we received 150 positives. That means 0.0009% requests
triggered positives.

Example call triggering the rule: 
$> curl -v -d "data=
location: foo" 'http://www.example.com/index.html'

Proposed Severity: Critical (-> 5 points)

One could settle on Error here too, but false positives are
actually quite rare, so I do not think it is worth to go
for 4 points, as hardly anything in the core rules gives
4 points, there clearly is a 5 points habit. So this is
what I suggest.


And finally the isolated CR / LF in the request body:

### 950916:	Detecing Carriage Returns in the request body

This is frequently encountered and only mildly 
suspicious. Still, in most applications, most
http request parameters will be free from CRs / LFs
and the latter characters will only be found in
certain fields. So this might at least be an
optional rule useful for the most paranoid of
all administrators interesting in the tuning
involved with this rule.

False positives rate:
Based on 156 M requests from approximately 90 services,
we received 1.89 M positives. That means 1.213% requests
triggered positives.

Example call triggering the rule:
$> curl -v -d "data=
abc" 'http://www.example.com/index.html'

Proposed Severity: Notice (-> 2 points)
