### PR TITLE
update for rule id 960012

### DIFF
--- a/base_rules/modsecurity_crs_20_protocol_violations.conf
+++ b/base_rules/modsecurity_crs_20_protocol_violations.conf
@@ -293,14 +293,15 @@ SecRule REQUEST_METHOD "^(?:GET|HEAD)$" \
 # header is also present.
 #
 # -=[ References ]=-
-# http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5
+# http://www.w3.org/Protocols/HTTP/1.0/spec.html#POST
+# http://www.w3.org/Protocols/HTTP/1.0/spec.html#Content-Length
 # 
 SecRule REQUEST_METHOD "^POST$" \
   "msg:'POST request missing Content-Length Header.',\
   severity:'4',\
   id:'960012',\
   ver:'OWASP_CRS/2.2.9',\
-  rev:'1',\
+  rev:'2',\
   maturity:'9',\
   accuracy:'9',\
   phase:1,\
@@ -310,10 +311,12 @@ SecRule REQUEST_METHOD "^POST$" \
   tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
   tag:'CAPEC-272',\
   chain"
+  	SecRule REQUEST_PROTOCOL "^HTTP/1\.0$" \
+  	  "chain"
         SecRule &REQUEST_HEADERS:Content-Length "@eq 0" \
           "t:none,\
           setvar:'tx.msg=%{rule.msg}',\
-          setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+          setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
           setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
 
 

--- a/base_rules/modsecurity_crs_21_protocol_anomalies.conf
+++ b/base_rules/modsecurity_crs_21_protocol_anomalies.conf
@@ -106,3 +106,37 @@ SecRule REQUEST_HEADERS:Host "^[\d.:]+$" "phase:2,rev:'2',ver:'OWASP_CRS/2.2.9',
 #SecRule RESPONSE_STATUS ^400$ "t:none,phase:5,chain,pass,msg:'Invalid request',id:'960913',severity:'4'"
 #SecRule WEBSERVER_ERROR_LOG !ModSecurity "t:none,setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},setvar:tx.leakage_score=+%{tx.notice_anomaly_score},setvar:tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{matched_var}"
 
+#
+# Require Content-Length to be provided with every POST request in a HTTP/1.1 request.
+#
+# -=[ Rule Logic ]=-
+# This chained rule checks if the request method is POST, if so, it checks that a Content-Length
+# header is present in case a Transfer-Encoding header is missing.
+#
+# -=[ References ]=-
+# http://httpwg.github.io/specs/rfc7230.html#header.content-length
+# 
+SecRule REQUEST_METHOD "^POST$" \
+  "msg:'HTTP/1.1 POST request missing Content-Length Header and missing Transfer-Encoding header.',\
+  severity:'4',\
+  id:'960013',\
+  ver:'OWASP_CRS/2.2.9',\
+  rev:'1',\
+  maturity:'9',\
+  accuracy:'9',\
+  phase:1,\
+  block,\
+  logdata:'%{matched_var}',\
+  t:none,\
+  tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
+  tag:'CAPEC-272',\
+  chain"
+        SecRule REQUEST_PROTOCOL "^HTTP/1\.1$" \
+          "chain"
+        SecRule &REQUEST_HEADERS:Transfer-Encoding "@eq 0" \
+          "chain"
+        SecRule &REQUEST_HEADERS:Content-Length "@eq 0" \
+          "t:none,\
+          setvar:'tx.msg=%{rule.msg}',\
+          setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+          setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}'"


### PR DESCRIPTION
- rule id 960012 updated to actual HTTP protocol specifications (this version is only valid for HTTP/1.0)
- a similary rule (with rule id 960013) was added to modsecurity_crs_21_protocol_anomalies.conf with a check for request protocol HTTP/1.1 and if a Transfer-Encoding header is missing
- changes done to reduce false positives and to fix [Issue 267](https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/267)