### PR TITLE
Disabling default tx.high_risk_country_codes and fixing broken rule 910100

### DIFF
--- a/modsecurity_crs_10_setup.conf.example
+++ b/modsecurity_crs_10_setup.conf.example
@@ -243,25 +243,17 @@ SecGeoLookupDb util/geo-location/GeoLiteCity.dat
 #
 # -=[ High Risk Fraud Countries ]=-
 # 
-# Rules in the IP Reputation file will check the client against a list of HIGH Risk
-# country codes. These countries were identified by ClearCommerce:
+# Rules in the IP Reputation file can check the client against a list of HIGH Risk
+# country codes. These countries have to be defined in the variable 
+# tx.high_risk_country_codes.
 #
-# - Ukraine
-# - Indonesia
-# - Yugoslavia
-# - Lithuania
-# - Egypt
-# - Romania
-# - Bulgaria
-# - Turkey
-# - Russia
-# - Pakistan
-# - Malaysia
+# If you are sure, you are not getting any legitimate requests from a given 
+# country, then you can disable all access from that country via this variable.
+# The rule performing the test has the rule id 910100.
 #
-# Additionally, based on WAF alert analysis reports, China is also included.
+# By default, the list is empty. A list used by some sites is the following:
 #
-# If you have legitimate customers originating from one of these countries, you should
-# remove it from this list.
+# setvar:'tx.high_risk_country_codes=UA ID YU LT EG RO BG TR RU PK MY CN'"
 #
 SecAction \
  "id:'900022',\
@@ -269,7 +261,7 @@ SecAction \
   nolog,\
   pass,\
   t:none,\
-  setvar:'tx.high_risk_country_codes=UA ID YU LT EG RO BG TR RU PK MY CN'"
+  setvar:'tx.high_risk_country_codes='"
 
 #
 # -- [[ Project Honeypot HTTP Blacklist API Key ]] --------------------------------------------------------

--- a/rules/REQUEST-10-IP-REPUTATION.conf
+++ b/rules/REQUEST-10-IP-REPUTATION.conf
@@ -45,7 +45,7 @@ SecRule IP:BLOCK "@eq 1" \
 #
 # This rule does a GeoIP resolution on the client IP address.
 #
-SecRule TX:REAL_IP "@geoLookup" \
+SecRule TX:HIGH_RISK_COUNTRY_CODES "!^$" \
  "msg:'Client IP is from a HIGH Risk Country Location.',\
   severity:'WARNING',\
   id:'910100',\
@@ -59,13 +59,15 @@ SecRule TX:REAL_IP "@geoLookup" \
   tag:'reputation-Malicious IP',\
   tag:'IP_REPUTATION/GEO_LOCATION',\
   chain"
-  SecRule GEO:COUNTRY_CODE "@pm %{tx.high_risk_country_codes}" \
-   "setvar:'tx.msg=%{rule.msg}',\
-    setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-    setvar:tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var},\
-    setvar:ip.block=1,\
-    expirevar:ip.block=%{tx.block_duration},\
-    setvar:'ip.block_reason=%{rule.msg}'"
+  SecRule TX:REAL_IP "@geoLookup" \
+   "chain"
+    SecRule GEO:COUNTRY_CODE "@within %{tx.high_risk_country_codes}" \
+     "setvar:'tx.msg=%{rule.msg}',\
+      setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+      setvar:tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var},\
+      setvar:ip.block=1,\
+      expirevar:ip.block=%{tx.block_duration},\
+      setvar:'ip.block_reason=%{rule.msg}'"
 
 #
 # -=[ IP Reputation Checks ]=-


### PR DESCRIPTION
- New empty tx.high_risk_country_codes by default
- Better documentation
- GeoIP Lookup is only performed if tx.high_risk_country_codes
- Replaced @pm operator with @within as @pm does not perform macro expansion. Rule was thus broken in thus inactive
  (-> Also updated the reference manual with a note with regards to @pm macro expansion)