### PR TITLE
Remove redundant actions from some rules

### DIFF
--- a/base_rules/modsecurity_crs_30_http_policy.conf
+++ b/base_rules/modsecurity_crs_30_http_policy.conf
@@ -28,7 +28,7 @@
 #      methods. If that is not the case with your environment, you are advised 
 #      to edit the line or uncomment it.
 #
-SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" "phase:1,t:none,block,msg:'Method is not allowed by policy',logdata:'%{matched_var}',severity:'2',rev:'2',ver:'OWASP_CRS/2.2.9',maturity:'9',accuracy:'9',id:'960032',tag:'OWASP_CRS/POLICY/METHOD_NOT_ALLOWED',tag:'WASCTC/WASC-15',tag:'OWASP_TOP_10/A6',tag:'OWASP_AppSensor/RE1',tag:'PCI/12.1',logdata:'%{matched_var}',setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},setvar:tx.%{rule.id}-OWASP_CRS/POLICY/METHOD_NOT_ALLOWED-%{matched_var_name}=%{matched_var}" 
+SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" "phase:1,t:none,block,msg:'Method is not allowed by policy',severity:'2',rev:'2',ver:'OWASP_CRS/2.2.9',maturity:'9',accuracy:'9',id:'960032',tag:'OWASP_CRS/POLICY/METHOD_NOT_ALLOWED',tag:'WASCTC/WASC-15',tag:'OWASP_TOP_10/A6',tag:'OWASP_AppSensor/RE1',tag:'PCI/12.1',logdata:'%{matched_var}',setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},setvar:tx.%{rule.id}-OWASP_CRS/POLICY/METHOD_NOT_ALLOWED-%{matched_var_name}=%{matched_var}"
 
 
 # Restrict which content-types we accept.

--- a/base_rules/modsecurity_crs_41_sql_injection_attacks.conf
+++ b/base_rules/modsecurity_crs_41_sql_injection_attacks.conf
@@ -88,7 +88,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 #
 # SQL Keyword Anomaly Scoring
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pm select show top distinct from dual where group by order having limit offset union rownum as (case" "phase:2,id:'981300',t:none,t:urlDecodeUni,t:lowercase,nolog,pass,nolog,setvar:'tx.sqli_select_statement=%{tx.sqli_select_statement} %{matched_var}'"
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pm select show top distinct from dual where group by order having limit offset union rownum as (case" "phase:2,id:'981300',t:none,t:urlDecodeUni,t:lowercase,pass,nolog,setvar:'tx.sqli_select_statement=%{tx.sqli_select_statement} %{matched_var}'"
 SecRule TX:SQLI_SELECT_STATEMENT "@containsWord select" "phase:2,id:'981301',t:none,pass,nolog,setvar:tx.sqli_select_statement_count=+1,setvar:tx.sql_injection_score=+1"
 SecRule TX:SQLI_SELECT_STATEMENT "@containsWord show" "phase:2,id:'981302',t:none,pass,nolog,setvar:tx.sqli_select_statement_count=+1,setvar:tx.sql_injection_score=+1"
 SecRule TX:SQLI_SELECT_STATEMENT "@containsWord top" "phase:2,id:'981303',t:none,pass,nolog,setvar:tx.sqli_select_statement_count=+1,setvar:tx.sql_injection_score=+1"

--- a/base_rules/modsecurity_crs_50_outbound.conf
+++ b/base_rules/modsecurity_crs_50_outbound.conf
@@ -59,7 +59,7 @@ SecRule RESPONSE_STATUS "^500$" "phase:4,rev:'2',ver:'OWASP_CRS/2.2.9',maturity:
 SecRule RESPONSE_BODY "<title>JSP compile error<\/title>" "t:none,capture,setvar:'tx.msg=%{rule.msg}',setvar:tx.outbound_anomaly_score=+%{tx.error_anomaly_score},setvar:tx.anomaly_score=+%{tx.error_anomaly_score},setvar:tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}"
 
 # File or Directory Names Leakage
-SecRule RESPONSE_BODY "href\s?=[\s\"\']*[A-Za-z]\:\x5c([^\"\']+)" "phase:4,rev:'2',ver:'OWASP_CRS/2.2.9',maturity:'9',accuracy:'9',chain,capture,t:none,capture,ctl:auditLogParts=+E,block,msg:'File or Directory Names Leakage',logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',id:'970011',tag:'OWASP_CRS/LEAKAGE/INFO_FILE',tag:'WASCTC/WASC-13',tag:'OWASP_TOP_10/A6',tag:'PCI/6.5.6',severity:'3'"
+SecRule RESPONSE_BODY "href\s?=[\s\"\']*[A-Za-z]\:\x5c([^\"\']+)" "phase:4,rev:'2',ver:'OWASP_CRS/2.2.9',maturity:'9',accuracy:'9',chain,t:none,capture,ctl:auditLogParts=+E,block,msg:'File or Directory Names Leakage',logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',id:'970011',tag:'OWASP_CRS/LEAKAGE/INFO_FILE',tag:'WASCTC/WASC-13',tag:'OWASP_TOP_10/A6',tag:'PCI/6.5.6',severity:'3'"
 SecRule TX:1 "!program files\x5cmicrosoft office\x5c(?:office|templates)" "t:none,capture,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:tx.outbound_anomaly_score=+%{tx.error_anomaly_score},setvar:tx.anomaly_score=+%{tx.error_anomaly_score},setvar:tx.%{rule.id}-OWASP_CRS/LEAKAGE/INFO-%{matched_var_name}=%{tx.0}"
 
 #


### PR DESCRIPTION
Removes duplicate actions from rules, shouldn't alter rule behavior in any way.

960032: Duplicate logdata:'%{matched_var}'
981300: Duplicate nolog
970011: Duplicate capture