### PR TITLE
paranoia mode phase 2 - adding base rules

### DIFF
--- a/rules/REQUEST-20-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-20-PROTOCOL-ENFORCEMENT.conf
@@ -501,26 +501,6 @@ SecRule REQUEST_URI "\%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
         setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
         setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
 
-SecRule ARGS "\%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
-  "phase:request,\
-   rev:'2',\
-   ver:'OWASP_CRS/3.0.0',\
-   maturity:'6',\
-   accuracy:'8',\
-   t:none,\
-   block,\
-   msg:'Multiple URL Encoding Detected',\
-   id:'920230',\
-   tag:'application-multi',\
-   tag:'language-multi',\
-   tag:'platform-multi',\
-   tag:'attack-protocol',\
-   tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
-   severity:'WARNING',\
-   setvar:'tx.msg=%{rule.msg}',\
-   setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
-   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
-
 SecRule REQUEST_HEADERS:Content-Type "^(application\/x-www-form-urlencoded|text\/xml)(?:;(?:\s?charset\s?=\s?[\w\d\-]{1,18})?)??$" \
   "phase:request,\
    rev:'2',\
@@ -711,35 +691,6 @@ SecMarker END_HOST_CHECK
 # These rules will first check to see if an Accept header is present.
 # The second check is to see if an Accept header exists but is empty.
 #
-
-SecRule &REQUEST_HEADERS:Accept "@eq 0" \
-  "msg:'Request Missing an Accept Header',\
-   chain,\
-   phase:request,\
-   rev:'3',\
-   ver:'OWASP_CRS/3.0.0',\
-   maturity:'9',\
-   accuracy:'8',\
-   t:none,\
-   pass,\
-   severity:'NOTICE',\
-   id:'920300',\
-   tag:'application-multi',\
-   tag:'language-multi',\
-   tag:'platform-multi',\
-   tag:'attack-protocol',\
-   tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_ACCEPT',\
-   tag:'WASCTC/WASC-21',\
-   tag:'OWASP_TOP_10/A7',\
-   tag:'PCI/6.5.10',\
-   skipAfter:END_ACCEPT_CHECK"
-     SecRule REQUEST_METHOD "!^OPTIONS$" \
-       "chain"
-	  SecRule REQUEST_HEADERS:User-Agent "!@pm AppleWebKit Android" \
-	    "t:none,\
-            setvar:'tx.msg=%{rule.msg}',\
-            setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
-            setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
 
 SecRule REQUEST_HEADERS:Accept "^$" \
   "msg:'Request Has an Empty Accept Header',\
@@ -957,32 +908,6 @@ SecRule &TX:ARG_LENGTH "@eq 1" \
         setvar:tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{matched_var_name}=%{matched_var}"
 
 #
-# Maximum number of arguments in request limited
-#
-SecRule &TX:MAX_NUM_ARGS "@eq 1" \
-  "chain,\
-   phase:request,\
-   t:none,\
-   block,\
-   msg:'Too many arguments in request',\
-   id:'920380',\
-   severity:'WARNING',\
-   rev:'2',\
-   ver:'OWASP_CRS/3.0.0',\
-   maturity:'9',\
-   accuracy:'9',\
-   tag:'application-multi',\
-   tag:'language-multi',\
-   tag:'platform-multi',\
-   tag:'attack-protocol',\
-   tag:'OWASP_CRS/POLICY/SIZE_LIMIT'"
-     SecRule &ARGS "@gt %{tx.max_num_args}" \
-       "t:none,\
-        setvar:'tx.msg=%{rule.msg}',\
-        setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
-        setvar:tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{matched_var_name}=%{matched_var}"
-
-#
 # Limit arguments total length
 #
 SecRule &TX:TOTAL_ARG_LENGTH "@eq 1" \
@@ -1128,38 +1053,6 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
    setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
    setvar:tx.%{rule.id}-OWASP_CRS/POLICY/PROTOCOL_NOT_ALLOWED-%{matched_var_name}=%{matched_var}" 
 
-#
-# Restrict file extension
-#
-SecRule REQUEST_BASENAME "\.(.*)$" \
-  "chain,\
-   capture,\
-   phase:request,\
-   t:none,t:urlDecodeUni,t:lowercase,\
-   block,\
-   msg:'URL file extension is restricted by policy',\
-   severity:'CRITICAL',\
-   rev:'2',\
-   ver:'OWASP_CRS/3.0.0',\
-   maturity:'9',\
-   accuracy:'9',\
-   id:'920440',\
-   logdata:'%{TX.0}',\
-   tag:'application-multi',\
-   tag:'language-multi',\
-   tag:'platform-multi',\
-   tag:'attack-protocol',\
-   tag:'OWASP_CRS/POLICY/EXT_RESTRICTED',\
-   tag:'WASCTC/WASC-15',\
-   tag:'OWASP_TOP_10/A7',\
-   tag:'PCI/6.5.10',logdata:'%{TX.0}',\
-   setvar:tx.extension=.%{tx.1}/"
-     SecRule TX:EXTENSION "@within %{tx.restricted_extensions}" \
-       "t:none,\
-        setvar:'tx.msg=%{rule.msg}',\
-        setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
-        setvar:tx.%{rule.id}-OWASP_CRS/POLICY/EXT_RESTRICTED-%{matched_var_name}=%{matched_var}"
-
 
 
 # 
@@ -1204,6 +1097,118 @@ SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:920014,nolog,pass,skipAfter:END-RE
 #
 # -= Paranoia Level 2 =- (apply only when tx.paranoia_level is sufficiently high: 2 or higher)
 #
+
+
+SecRule ARGS "\%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
+  "phase:request,\
+   rev:'2',\
+   ver:'OWASP_CRS/3.0.0',\
+   maturity:'6',\
+   accuracy:'8',\
+   t:none,\
+   block,\
+   msg:'Multiple URL Encoding Detected',\
+   id:'920230',\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
+   tag:'paranoia-level/2',\
+   severity:'WARNING',\
+   setvar:'tx.msg=%{rule.msg}',\
+   setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
+   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
+
+SecRule &REQUEST_HEADERS:Accept "@eq 0" \
+  "msg:'Request Missing an Accept Header',\
+   chain,\
+   phase:request,\
+   rev:'3',\
+   ver:'OWASP_CRS/3.0.0',\
+   maturity:'9',\
+   accuracy:'8',\
+   t:none,\
+   pass,\
+   severity:'NOTICE',\
+   id:'920300',\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_ACCEPT',\
+   tag:'WASCTC/WASC-21',\
+   tag:'OWASP_TOP_10/A7',\
+   tag:'PCI/6.5.10',\
+   tag:'paranoia-level/2',\
+   skipAfter:END_ACCEPT_CHECK"
+     SecRule REQUEST_METHOD "!^OPTIONS$" \
+       "chain"
+	  SecRule REQUEST_HEADERS:User-Agent "!@pm AppleWebKit Android" \
+	    "t:none,\
+            setvar:'tx.msg=%{rule.msg}',\
+            setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+            setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
+
+#
+# Maximum number of arguments in request limited
+#
+SecRule &TX:MAX_NUM_ARGS "@eq 1" \
+  "chain,\
+   phase:request,\
+   t:none,\
+   block,\
+   msg:'Too many arguments in request',\
+   id:'920380',\
+   severity:'WARNING',\
+   rev:'2',\
+   ver:'OWASP_CRS/3.0.0',\
+   maturity:'9',\
+   accuracy:'9',\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'OWASP_CRS/POLICY/SIZE_LIMIT',\
+   tag:'paranoia-level/2'"
+     SecRule &ARGS "@gt %{tx.max_num_args}" \
+       "t:none,\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+        setvar:tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{matched_var_name}=%{matched_var}"
+
+#
+# Restrict file extension
+#
+SecRule REQUEST_BASENAME "\.(.*)$" \
+  "chain,\
+   capture,\
+   phase:request,\
+   t:none,t:urlDecodeUni,t:lowercase,\
+   block,\
+   msg:'URL file extension is restricted by policy',\
+   severity:'CRITICAL',\
+   rev:'2',\
+   ver:'OWASP_CRS/3.0.0',\
+   maturity:'9',\
+   accuracy:'9',\
+   id:'920440',\
+   logdata:'%{TX.0}',\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'OWASP_CRS/POLICY/EXT_RESTRICTED',\
+   tag:'WASCTC/WASC-15',\
+   tag:'OWASP_TOP_10/A7',\
+   tag:'PCI/6.5.10',logdata:'%{TX.0}',\
+   tag:'paranoia-level/2',\
+   setvar:tx.extension=.%{tx.1}/"
+     SecRule TX:EXTENSION "@within %{tx.restricted_extensions}" \
+       "t:none,\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
+        setvar:tx.%{rule.id}-OWASP_CRS/POLICY/EXT_RESTRICTED-%{matched_var_name}=%{matched_var}"
 
 
 

--- a/rules/REQUEST-21-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-21-PROTOCOL-ATTACK.conf
@@ -236,6 +236,14 @@ SecRule ARGS_NAMES|ARGS|XML:/* "(?:\n|\r)+(?:\s+|location|refresh|(?:set-)?cooki
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}"
 
+
+
+SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:1,id:921013,nolog,pass,skipAfter:END-REQUEST-21-PROTOCOL-ATTACK"
+SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:921014,nolog,pass,skipAfter:END-REQUEST-21-PROTOCOL-ATTACK"
+#
+# -= Paranoia Level 2 =- (apply only when tx.paranoia_level is sufficiently high: 2 or higher)
+#
+
 # The rule 950916 generates a lot of false positives (> 1% of requests on a given sample).
 # This rule is by default set to pass such that it only contributes to anamoly mode, change the action to block (from pass) for more paranoid installs.
 SecRule ARGS_POST|XML:/* "(\n|\r)" \
@@ -252,6 +260,7 @@ SecRule ARGS_POST|XML:/* "(\n|\r)" \
 	tag:'language-multi',\
 	tag:'platform-multi',\
 	tag:'attack-protocol',\
+        tag:'paranoia-level/2',\
 	t:none,t:htmlEntityDecode,t:lowercase,\
 	ctl:auditLogParts=+E,\
 	pass,\
@@ -260,14 +269,6 @@ SecRule ARGS_POST|XML:/* "(\n|\r)" \
 	setvar:'tx.http_violation_score=+%{tx.notice_anomaly_score}',\
 	setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}"
-
-
-
-SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:1,id:921013,nolog,pass,skipAfter:END-REQUEST-21-PROTOCOL-ATTACK"
-SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:921014,nolog,pass,skipAfter:END-REQUEST-21-PROTOCOL-ATTACK"
-#
-# -= Paranoia Level 2 =- (apply only when tx.paranoia_level is sufficiently high: 2 or higher)
-#
 
 
 

--- a/rules/REQUEST-31-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-31-APPLICATION-ATTACK-RFI.conf
@@ -105,6 +105,14 @@ SecRule ARGS "^(?i)(?:ft|htt)ps?(.*?)\?+$" \
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RFI-%{matched_var_name}=%{tx.0}"
 
+
+
+SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:1,id:931013,nolog,pass,skipAfter:END-REQUEST-31-APPLICATION-ATTACK-RFI"
+SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:931014,nolog,pass,skipAfter:END-REQUEST-31-APPLICATION-ATTACK-RFI"
+#
+# -= Paranoia Level 2 =- (apply only when tx.paranoia_level is sufficiently high: 2 or higher)
+#
+
 SecRule ARGS "^(?:ht|f)tps?://(.*)$" \
 	"chain,\
 	phase:request,\
@@ -124,20 +132,13 @@ SecRule ARGS "^(?:ht|f)tps?://(.*)$" \
         tag:'language-multi',\
         tag:'platform-multi',\
         tag:'attack-remote file inclusion',\
-	tag:'OWASP_CRS/WEB_ATTACK/RFI'"
+	tag:'OWASP_CRS/WEB_ATTACK/RFI',\
+	tag:'paranoia-mode/2'"
         	SecRule TX:1 "!@beginsWith %{request_headers.host}" \
 			"setvar:'tx.msg=%{rule.msg}',\
 			setvar:tx.rfi_score=+%{tx.critical_anomaly_score},\
 			setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 			setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RFI-%{matched_var_name}=%{tx.1}"
-
-
-
-SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:1,id:931013,nolog,pass,skipAfter:END-REQUEST-31-APPLICATION-ATTACK-RFI"
-SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:931014,nolog,pass,skipAfter:END-REQUEST-31-APPLICATION-ATTACK-RFI"
-#
-# -= Paranoia Level 2 =- (apply only when tx.paranoia_level is sufficiently high: 2 or higher)
-#
 
 
 

--- a/rules/REQUEST-31-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-31-APPLICATION-ATTACK-RFI.conf
@@ -133,7 +133,7 @@ SecRule ARGS "^(?:ht|f)tps?://(.*)$" \
         tag:'platform-multi',\
         tag:'attack-remote file inclusion',\
 	tag:'OWASP_CRS/WEB_ATTACK/RFI',\
-	tag:'paranoia-mode/2'"
+	tag:'paranoia-level/2'"
         	SecRule TX:1 "!@beginsWith %{request_headers.host}" \
 			"setvar:'tx.msg=%{rule.msg}',\
 			setvar:tx.rfi_score=+%{tx.critical_anomaly_score},\

--- a/rules/REQUEST-42-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-42-APPLICATION-ATTACK-SQLI.conf
@@ -69,102 +69,6 @@ SecRule ARGS|REQUEST_COOKIES|QUERY_STRING|REQUEST_FILENAME "@detectSQLi" \
 
 
 #
-# -=[ String Termination/Statement Ending Injection Testing ]=-
-#
-# Identifies common initial SQLi probing requests where attackers insert/append
-# quote characters to the existing normal payload to see how the app/db responds.
-#
-SecRule ARGS_NAMES|ARGS|XML:/* "(^[\"'`;]+|[\"'`]+$)" \
-  "phase:request,\
-   rev:'4',\
-   ver:'OWASP_CRS/3.0.0',\
-   maturity:'9',\
-   accuracy:'8',\
-   capture,\
-   t:none,t:utf8toUnicode,t:urlDecodeUni,\
-   block,\
-   msg:'SQL Injection Attack: Common Injection Testing Detected',\
-   id:'942110',\
-   logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-   severity:'CRITICAL',\
-   tag:'application-multi',\
-   tag:'language-mutli',\
-   tag:'platform-multi',\
-   tag:'attack-sqli',\
-   tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-   tag:'WASCTC/WASC-19',\
-   tag:'OWASP_TOP_10/A1',\
-   tag:'OWASP_AppSensor/CIE1',\
-   tag:'PCI/6.5.2',\
-   setvar:'tx.msg=%{rule.msg}',\
-   setvar:tx.sql_injection_score=+%{tx.warning_anomaly_score},\
-   setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
-   setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}"
-
-
-#
-# -=[ SQL Operators ]=-
-#
-SecRule ARGS_NAMES|ARGS|XML:/* "(?i:(\!\=|\&\&|\|\||>>|<<|>=|<=|<>|<=>|\bxor\b|\brlike\b|\bregexp\b|\bisnull\b)|(?:not\s+between\s+0\s+and)|(?:is\s+null)|(like\s+null)|(?:(?:^|\W)in[+\s]*\([\s\d\"]+[^()]*\))|(?:\bxor\b|<>|rlike(?:\s+binary)?)|(?:regexp\s+binary))" \
-	"phase:request,\
-	rev:'3',\
-	ver:'OWASP_CRS/3.0.0',\
-	maturity:'9',\
-	accuracy:'8',\
-	capture,\
-	t:none,t:utf8toUnicode,t:urlDecodeUni,\
-	block,\
-	msg:'SQL Injection Attack: SQL Operator Detected',\
-	id:'942120',\
-	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	severity:'CRITICAL',\
-	tag:'application-multi',\
-	tag:'language-mutli',\
-	tag:'platform-multi',\
- 	tag:'attack-sqli',\
-	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-	tag:'WASCTC/WASC-19',\
-	tag:'OWASP_TOP_10/A1',\
-	tag:'OWASP_AppSensor/CIE1',\
-	tag:'PCI/6.5.2',\
-	setvar:'tx.msg=%{rule.msg}',\
-	setvar:tx.sql_injection_score=+%{tx.notice_anomaly_score},\
-	setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
-	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}"
-
-
-#
-# -=[ SQL Tautologies ]=-
-#
-SecRule ARGS_NAMES|ARGS|XML:/* "(?i:([\s'\"`\(\)]*?)([\d\w]++)([\s'\"`\(\)]*?)(?:(?:=|<=>|r?like|sounds\s+like|regexp)([\s'\"`\(\)]*?)\2|(?:!=|<=|>=|<>|<|>|\^|is\s+not|not\s+like|not\s+regexp)([\s'\"`\(\)]*?)(?!\2)([\d\w]+)))" \
-	"phase:request,\
-	rev:'2',\
-	ver:'OWASP_CRS/3.0.0',\
-	maturity:'9',\
-	accuracy:'8',\
-	capture,\
-	multiMatch,t:none,t:urlDecodeUni,t:replaceComments,\
-	block,\
-	msg:'SQL Injection Attack: SQL Tautology Detected.',\
-	id:'942130',\
-	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	severity:'CRITICAL',\
-	tag:'application-multi',\
-	tag:'language-mutli',\
-	tag:'platform-multi',\
-	tag:'attack-sqli',\
-	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-	tag:'WASCTC/WASC-19',\
-	tag:'OWASP_TOP_10/A1',\
-	tag:'OWASP_AppSensor/CIE1',\
-	tag:'PCI/6.5.2',\
-	setvar:'tx.msg=%{rule.msg}',\
-	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
-	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}"
-
-
-#
 # -=[ Detect DB Names ]=-
 #
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:m(?:s(?:ysaccessobjects|ysaces|ysobjects|ysqueries|ysrelationships|ysaccessstorage|ysaccessxml|ysmodules|ysmodules2|db)|aster\.\.sysdatabases|ysql\.db)|s(?:ys(?:\.database_name|aux)|chema(?:\W*\(|_name)|qlite(_temp)?_master)|d(?:atabas|b_nam)e\W*\(|information_schema|pg_(catalog|toast)|northwind|tempdb))" \
@@ -195,40 +99,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}"
 
-
-
-#
-# -=[ SQL Function Names ]=-
-#
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmf sql-function-names.data" \
-	"chain,\
-	phase:request,\
-	rev:'2',\
-	ver:'OWASP_CRS/2.2.6',\
-	maturity:'9',\
-	accuracy:'8',\
-	capture,\
-	t:none,t:urlDecodeUni,\
-	ctl:auditLogParts=+E,\
-	block,\
-	msg:'SQL Injection Attack',\
-	id:'942150',\
-	tag:'application-multi',\
-	tag:'language-mutli',\
-	tag:'platform-multi',\
-	tag:'attack-sqli',\
-	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-	tag:'WASCTC/WASC-19',\
-	tag:'OWASP_TOP_10/A1',\
-	tag:'OWASP_AppSensor/CIE1',\
-	tag:'PCI/6.5.2',\
-	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	severity:'CRITICAL'"
-	SecRule MATCHED_VARS "@rx (?i)\b(?:c(?:o(?:n(?:v(?:ert(?:_tz)?)?|cat(?:_ws)?|nection_id)|(?:mpres)?s|ercibility|(?:un)?t|llation|alesce)|ur(?:rent_(?:time(?:stamp)?|date|user)|(?:dat|tim)e)|h(?:ar(?:(?:acter)?_length|set)?|r)|iel(?:ing)?|ast|r32)|s(?:u(?:b(?:str(?:ing(?:_index)?)?|(?:dat|tim)e)|m)|t(?:d(?:dev_(?:sam|po)p)?|r(?:_to_date|cmp))|e(?:c(?:_to_time|ond)|ssion_user)|ys(?:tem_user|date)|ha[12]?|oundex|chema|ig?n|leep|pace|qrt)|i(?:s(?:_(?:ipv(?:4(?:_(?:compat|mapped))?|6)|n(?:ot(?:_null)?|ull)|(?:free|used)_lock)|null)|n(?:et(?:6_(?:aton|ntoa)|_(?:aton|ntoa))|s(?:ert|tr)|terval)?|f(?:null)?)|d(?:a(?:t(?:e(?:_(?:format|add|sub)|diff)?|abase)|y(?:of(?:month|week|year)|name)?)|e(?:(?:s_(?:de|en)cryp|faul)t|grees|code)|count|ump)|l(?:o(?:ca(?:l(?:timestamp)?|te)|g(?:10|2)?|ad_file|wer)|ast(?:_(?:inser_id|day))?|e(?:(?:as|f)t|ngth)|case|trim|pad|n)|u(?:n(?:compress(?:ed_length)?|ix_timestamp|hex)|tc_(?:time(?:stamp)?|date)|p(?:datexml|per)|uid(?:_short)?|case|ser)|t(?:ime(?:_(?:format|to_sec)|stamp(?:diff|add)?|diff)?|o(?:(?:second|day)s|_base64|n?char)|r(?:uncate|im)|an)|m(?:a(?:ke(?:_set|date)|ster_pos_wait|x)|i(?:(?:crosecon)?d|n(?:ute)?)|o(?:nth(?:name)?|d)|d5)|r(?:e(?:p(?:lace|eat)|lease_lock|verse)|a(?:wtohex|dians|nd)|o(?:w_count|und)|ight|trim|pad)|f(?:i(?:eld(?:_in_set)?|nd_in_set)|rom_(?:unixtime|base64|days)|o(?:und_rows|rmat)|loor)|p(?:o(?:w(?:er)?|sition)|eriod_(?:diff|add)|rocedure_analyse|assword|g_sleep|i)|a(?:s(?:cii(?:str)?|in)|es_(?:de|en)crypt|dd(?:dat|tim)e|(?:co|b)s|tan2?|vg)|b(?:i(?:t_(?:length|count|x?or|and)|n(?:_to_num)?)|enchmark)|e(?:x(?:tract(?:value)?|p(?:ort_set)?)|nc(?:rypt|ode)|lt)|g(?:r(?:oup_conca|eates)t|et_(?:format|lock))|v(?:a(?:r(?:_(?:sam|po)p|iance)|lues)|ersion)|o(?:(?:ld_passwo)?rd|ct(?:et_length)?)|we(?:ek(?:ofyear|day)?|ight_string)|n(?:o(?:t_in|w)|ame_const|ullif)|h(?:ex(?:toraw)?|our)|qu(?:arter|ote)|year(?:week)?|xmltype)\W*\("\
-		"setvar:'tx.msg=%{rule.msg}',\
-		setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
-		setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-		setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}"
 
 #
 # -=[ PHPIDS - Converted SQLI Filters ]=-
@@ -279,29 +149,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?i:\d[\"'`]\s+[\"'`]\s+\d)|(?:^admin\s*?[\"'`]|(\/\*)+[\"'`]+\s?(?:--|#|\/\*|{)?)|(?:[\"'`]\s*?(x?or|div|like|between|and)[\w\s-]+\s*?[+<>=(),-]\s*?[\d\"'`])|(?:[\"'`]\s*?[^\w\s]?=\s*?[\"'`])|(?:[\"'`]\W*?[+=]+\W*?[\"'`])|(?:[\"'`]\s*?[!=|][\d\s!=+-]+.*?[\"'`(].*?$)|(?:[\"'`]\s*?[!=|][\d\s!=]+.*?\d+$)|(?:[\"'`]\s*?like\W+[\w\"'`(])|(?:\sis\s*?0\W)|(?:where\s[\s\w\.,-]+\s=)|(?:[\"'`][<>~]+[\"'`]))" \
-	"phase:request,\
-        rev:'2',\
-        ver:'OWASP_CRS/3.0.0',\
-        maturity:'9',\
-        accuracy:'8',\
-	capture,\
-	t:none,t:urlDecodeUni,\
-	block,\
-	msg:'Detects basic SQL authentication bypass attempts 1/3',\
-	id:'942180',\
-	tag:'application-multi',\
-	tag:'language-mutli',\
-	tag:'platform-multi',\
-	tag:'attack-sqli',\
-	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	severity:'CRITICAL',\
-	setvar:'tx.msg=%{rule.msg}',\
-	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
-	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
-
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:\sexec\s+xp_cmdshell)|(?:[\"'`]\s*?!\s*?[\"'`\w])|(?:from\W+information_schema\W)|(?:(?:(?:current_)?user|database|schema|connection_id)\s*?\([^\)]*?)|(?:[\"'`];?\s*?(?:select|union|having)\s*?[^\s])|(?:\wiif\s*?\()|(?:exec\s+master\.)|(?:union select @)|(?:union[\w(\s]*?select)|(?:select.*?\w?user\()|(?:into[\s+]+(?:dump|out)file\s*?[\"'`]))" \
 	"phase:request,\
         rev:'2',\
@@ -313,52 +160,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	block,\
 	msg:'Detects MSSQL code execution and information gathering attempts',\
 	id:'942190',\
-	tag:'application-multi',\
-	tag:'language-mutli',\
-	tag:'platform-multi',\
-	tag:'attack-sqli',\
-	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	severity:'CRITICAL',\
-	setvar:'tx.msg=%{rule.msg}',\
-	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
-	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
-
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:,.*?[)\da-f\"'`][\"'`](?:[\"'`].*?[\"'`]|\Z|[^\"'`]+))|(?:\Wselect.+\W*?from)|((?:select|create|rename|truncate|load|alter|delete|update|insert|desc)\s*?\(\s*?space\s*?\())" \
-	"phase:request,\
-        rev:'2',\
-        ver:'OWASP_CRS/3.0.0',\
-        maturity:'9',\
-        accuracy:'8',\
-	capture,\
-	t:none,t:urlDecodeUni,\
-	block,\
-	msg:'Detects MySQL comment-/space-obfuscated injections and backtick termination',\
-	id:'942200',\
-	tag:'application-multi',\
-	tag:'language-mutli',\
-	tag:'platform-multi',\
-	tag:'attack-sqli',\
-	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	severity:'CRITICAL',\
-	setvar:'tx.msg=%{rule.msg}',\
-	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
-	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
-
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:@.+=\s*?\(\s*?select)|(?:\d+\s*?(x?or|div|like|between|and)\s*?\d+\s*?[\-+])|(?:\/\w+;?\s+(?:having|and|x?or|div|like|between|and|select)\W)|(?:\d\s+group\s+by.+\()|(?:(?:;|#|--)\s*?(?:drop|alter))|(?:(?:;|#|--)\s*?(?:update|insert)\s*?\w{2,})|(?:[^\w]SET\s*?@\w+)|(?:(?:n?and|x?x?or|div|like|between|and|not |\|\||\&\&)[\s(]+\w+[\s)]*?[!=+]+[\s\d]*?[\"'`=()]))" \
-	"phase:request,\
-        rev:'2',\
-        ver:'OWASP_CRS/3.0.0',\
-        maturity:'9',\
-        accuracy:'8',\
-	capture,\
-	t:none,t:urlDecodeUni,\
-	block,\
-	msg:'Detects chained SQL injection attempts 1/2',\
-	id:'942210',\
 	tag:'application-multi',\
 	tag:'language-mutli',\
 	tag:'platform-multi',\
@@ -463,29 +264,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:union\s*?(?:all|distinct|[(!@]*?)?\s*?[([]*?\s*?select\s+)|(?:\w+\s+like\s+[\"'`])|(?:like\s*?[\"'`]\%)|(?:[\"'`]\s*?like\W*?[\"'`\d])|(?:[\"'`]\s*?(?:n?and|x?x?or|div|like|between|and|not |\|\||\&\&)\s+[\s\w]+=\s*?\w+\s*?having\s+)|(?:[\"'`]\s*?\*\s*?\w+\W+[\"'`])|(?:[\"'`]\s*?[^?\w\s=.,;)(]+\s*?[(@\"'`]*?\s*?\w+\W+\w)|(?:select\s+?[\[\]()\s\w\.,\"'`-]+from\s+)|(?:find_in_set\s*?\())" \
-	"phase:request,\
-        rev:'2',\
-        ver:'OWASP_CRS/3.0.0',\
-        maturity:'9',\
-        accuracy:'8',\
-	capture,\
-	t:none,t:urlDecodeUni,\
-	block,\
-	msg:'Detects basic SQL authentication bypass attempts 2/3',\
-	id:'942260',\
-        tag:'application-multi',\
-        tag:'language-mutli',\
-        tag:'platform-multi',\
-        tag:'attack-sqli',\
-	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	severity:'CRITICAL',\
-	setvar:'tx.msg=%{rule.msg}',\
-	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
-	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
-
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:(union(.*?)select(.*?)from)))" \
 	"phase:request,\
         rev:'2',\
@@ -555,52 +333,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:\)\s*?when\s*?\d+\s*?then)|(?:[\"'`]\s*?(?:#|--|{))|(?:\/\*!\s?\d+)|(?:ch(?:a)?r\s*?\(\s*?\d)|(?:(?:(n?and|x?x?or|div|like|between|and|not)\s+|\|\||\&\&)\s*?\w+\())" \
-	"phase:request,\
-        rev:'2',\
-        ver:'OWASP_CRS/3.0.0',\
-        maturity:'9',\
-        accuracy:'8',\
-	capture,\
-	t:none,t:urlDecodeUni,\
-	block,\
-	msg:'Detects MySQL comments, conditions and ch(a)r injections',\
-	id:'942300',\
-        tag:'application-multi',\
-        tag:'language-mutli',\
-        tag:'platform-multi',\
-        tag:'attack-sqli',\
-	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	severity:'CRITICAL',\
-	setvar:'tx.msg=%{rule.msg}',\
-	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
-	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
-
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s+and\s*?=\W)|(?:\(\s*?select\s*?\w+\s*?\()|(?:\*\/from)|(?:\+\s*?\d+\s*?\+\s*?@)|(?:\w[\"'`]\s*?(?:[-+=|@]+\s*?)+[\d(])|(?:coalesce\s*?\(|@@\w+\s*?[^\w\s])|(?:\W!+[\"'`]\w)|(?:[\"'`];\s*?(?:if|while|begin))|(?:[\"'`][\s\d]+=\s*?\d)|(?:order\s+by\s+if\w*?\s*?\()|(?:[\s(]+case\d*?\W.+[tw]hen[\s(]))" \
-	"phase:request,\
-        rev:'2',\
-        ver:'OWASP_CRS/3.0.0',\
-        maturity:'9',\
-        accuracy:'8',\
-	capture,\
-	t:none,t:urlDecodeUni,\
-	block,\
-	msg:'Detects chained SQL injection attempts 2/2',\
-	id:'942310',\
-        tag:'application-multi',\
-        tag:'language-mutli',\
-        tag:'platform-multi',\
-        tag:'attack-sqli',\
-	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	severity:'CRITICAL',\
-	setvar:'tx.msg=%{rule.msg}',\
-	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
-	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
-
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:procedure\s+analyse\s*?\()|(?:;\s*?(declare|open)\s+[\w-]+)|(?:create\s+(procedure|function)\s*?\w+\s*?\(\s*?\)\s*?-)|(?:declare[^\w]+[@#]\s*?\w+)|(exec\s*?\(\s*?@))" \
 	"phase:request,\
         rev:'2',\
@@ -612,52 +344,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	block,\
 	msg:'Detects MySQL and PostgreSQL stored procedure/function injections',\
 	id:'942320',\
-        tag:'application-multi',\
-        tag:'language-mutli',\
-        tag:'platform-multi',\
-        tag:'attack-sqli',\
-	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	severity:'CRITICAL',\
-	setvar:'tx.msg=%{rule.msg}',\
-	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
-	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
-
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s*?(x?or|div|like|between|and)\s*?[\"'`]?\d)|(?:\\\\x(?:23|27|3d))|(?:^.?[\"'`]$)|(?:(?:^[\"'`\\\\]*?(?:[\d\"'`]+|[^\"'`]+[\"'`]))+\s*?(?:n?and|x?x?or|div|like|between|and|not|\|\||\&\&)\s*?[\w\"'`][+&!@(),.-])|(?:[^\w\s]\w+\s*?[|-]\s*?[\"'`]\s*?\w)|(?:@\w+\s+(and|x?or|div|like|between|and)\s*?[\"'`\d]+)|(?:@[\w-]+\s(and|x?or|div|like|between|and)\s*?[^\w\s])|(?:[^\w\s:]\s*?\d\W+[^\w\s]\s*?[\"'`].)|(?:\Winformation_schema|table_name\W))" \
-	"phase:request,\
-        rev:'2',\
-        ver:'OWASP_CRS/3.0.0',\
-        maturity:'9',\
-        accuracy:'8',\
-	capture,\
-	t:none,t:urlDecodeUni,\
-	block,\
-	msg:'Detects classic SQL injection probings 1/2',\
-	id:'942330',\
-        tag:'application-multi',\
-        tag:'language-mutli',\
-        tag:'platform-multi',\
-        tag:'attack-sqli',\
-	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	severity:'CRITICAL',\
-	setvar:'tx.msg=%{rule.msg}',\
-	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
-	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
-
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:in\s*?\(+\s*?select)|(?:(?:n?and|x?x?or|div|like|between|and|not |\|\||\&\&)\s+[\s\w+]+(?:regexp\s*?\(|sounds\s+like\s*?[\"'`]|[=\d]+x))|([\"'`]\s*?\d\s*?(?:--|#))|(?:[\"'`][\%&<>^=]+\d\s*?(=|x?or|div|like|between|and))|(?:[\"'`]\W+[\w+-]+\s*?=\s*?\d\W+[\"'`])|(?:[\"'`]\s*?is\s*?\d.+[\"'`]?\w)|(?:[\"'`]\|?[\w-]{3,}[^\w\s.,]+[\"'`])|(?:[\"'`]\s*?is\s*?[\d.]+\s*?\W.*?[\"'`]))" \
-	"phase:request,\
-        rev:'2',\
-        ver:'OWASP_CRS/3.0.0',\
-        maturity:'9',\
-        accuracy:'8',\
-	capture,\
-	t:none,t:urlDecodeUni,\
-	block,\
-	msg:'Detects basic SQL authentication bypass attempts 3/3',\
-	id:'942340',\
         tag:'application-multi',\
         tag:'language-mutli',\
         tag:'platform-multi',\
@@ -716,6 +402,340 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
+
+
+SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:1,id:942013,nolog,pass,skipAfter:END-REQUEST-42-APPLICATION-ATTACK-SQLI"
+SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:942014,nolog,pass,skipAfter:END-REQUEST-42-APPLICATION-ATTACK-SQLI"
+#
+# -= Paranoia Level 2 =- (apply only when tx.paranoia_level is sufficiently high: 2 or higher)
+#
+
+
+#
+# -=[ String Termination/Statement Ending Injection Testing ]=-
+#
+# Identifies common initial SQLi probing requests where attackers insert/append
+# quote characters to the existing normal payload to see how the app/db responds.
+#
+SecRule ARGS_NAMES|ARGS|XML:/* "(^[\"'`;]+|[\"'`]+$)" \
+	"phase:request,\
+	rev:'4',\
+	ver:'OWASP_CRS/3.0.0',\
+	maturity:'9',\
+	accuracy:'8',\
+	capture,\
+	t:none,t:utf8toUnicode,t:urlDecodeUni,\
+	block,\
+	msg:'SQL Injection Attack: Common Injection Testing Detected',\
+	id:'942110',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	tag:'application-multi',\
+	tag:'language-mutli',\
+	tag:'platform-multi',\
+	tag:'attack-sqli',\
+	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+	tag:'WASCTC/WASC-19',\
+	tag:'OWASP_TOP_10/A1',\
+	tag:'OWASP_AppSensor/CIE1',\
+	tag:'PCI/6.5.2',\
+	tag:'paranoia-level/2',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.sql_injection_score=+%{tx.warning_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
+	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}"
+
+
+#
+# -=[ SQL Operators ]=-
+#
+SecRule ARGS_NAMES|ARGS|XML:/* "(?i:(\!\=|\&\&|\|\||>>|<<|>=|<=|<>|<=>|\bxor\b|\brlike\b|\bregexp\b|\bisnull\b)|(?:not\s+between\s+0\s+and)|(?:is\s+null)|(like\s+null)|(?:(?:^|\W)in[+\s]*\([\s\d\"]+[^()]*\))|(?:\bxor\b|<>|rlike(?:\s+binary)?)|(?:regexp\s+binary))" \
+	"phase:request,\
+	rev:'3',\
+	ver:'OWASP_CRS/3.0.0',\
+	maturity:'9',\
+	accuracy:'8',\
+	capture,\
+	t:none,t:utf8toUnicode,t:urlDecodeUni,\
+	block,\
+	msg:'SQL Injection Attack: SQL Operator Detected',\
+	id:'942120',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	tag:'application-multi',\
+	tag:'language-mutli',\
+	tag:'platform-multi',\
+ 	tag:'attack-sqli',\
+	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+	tag:'WASCTC/WASC-19',\
+	tag:'OWASP_TOP_10/A1',\
+	tag:'OWASP_AppSensor/CIE1',\
+	tag:'PCI/6.5.2',\
+	tag:'paranoia-level/2',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.sql_injection_score=+%{tx.notice_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}"
+
+
+#
+# -=[ SQL Tautologies ]=-
+#
+SecRule ARGS_NAMES|ARGS|XML:/* "(?i:([\s'\"`\(\)]*?)([\d\w]++)([\s'\"`\(\)]*?)(?:(?:=|<=>|r?like|sounds\s+like|regexp)([\s'\"`\(\)]*?)\2|(?:!=|<=|>=|<>|<|>|\^|is\s+not|not\s+like|not\s+regexp)([\s'\"`\(\)]*?)(?!\2)([\d\w]+)))" \
+	"phase:request,\
+	rev:'2',\
+	ver:'OWASP_CRS/3.0.0',\
+	maturity:'9',\
+	accuracy:'8',\
+	capture,\
+	multiMatch,t:none,t:urlDecodeUni,t:replaceComments,\
+	block,\
+	msg:'SQL Injection Attack: SQL Tautology Detected.',\
+	id:'942130',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	tag:'application-multi',\
+	tag:'language-mutli',\
+	tag:'platform-multi',\
+	tag:'attack-sqli',\
+	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+	tag:'WASCTC/WASC-19',\
+	tag:'OWASP_TOP_10/A1',\
+	tag:'OWASP_AppSensor/CIE1',\
+	tag:'PCI/6.5.2',\
+	tag:'paranoia-level/2',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}"
+
+
+#
+# -=[ SQL Function Names ]=-
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmf sql-function-names.data" \
+	"chain,\
+	phase:request,\
+	rev:'2',\
+	ver:'OWASP_CRS/2.2.6',\
+	maturity:'9',\
+	accuracy:'8',\
+	capture,\
+	t:none,t:urlDecodeUni,\
+	ctl:auditLogParts=+E,\
+	block,\
+	msg:'SQL Injection Attack',\
+	id:'942150',\
+	tag:'application-multi',\
+	tag:'language-mutli',\
+	tag:'platform-multi',\
+	tag:'attack-sqli',\
+	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+	tag:'WASCTC/WASC-19',\
+	tag:'OWASP_TOP_10/A1',\
+	tag:'OWASP_AppSensor/CIE1',\
+	tag:'PCI/6.5.2',\
+	tag:'paranoia-level/2',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL'"
+	SecRule MATCHED_VARS "@rx (?i)\b(?:c(?:o(?:n(?:v(?:ert(?:_tz)?)?|cat(?:_ws)?|nection_id)|(?:mpres)?s|ercibility|(?:un)?t|llation|alesce)|ur(?:rent_(?:time(?:stamp)?|date|user)|(?:dat|tim)e)|h(?:ar(?:(?:acter)?_length|set)?|r)|iel(?:ing)?|ast|r32)|s(?:u(?:b(?:str(?:ing(?:_index)?)?|(?:dat|tim)e)|m)|t(?:d(?:dev_(?:sam|po)p)?|r(?:_to_date|cmp))|e(?:c(?:_to_time|ond)|ssion_user)|ys(?:tem_user|date)|ha[12]?|oundex|chema|ig?n|leep|pace|qrt)|i(?:s(?:_(?:ipv(?:4(?:_(?:compat|mapped))?|6)|n(?:ot(?:_null)?|ull)|(?:free|used)_lock)|null)|n(?:et(?:6_(?:aton|ntoa)|_(?:aton|ntoa))|s(?:ert|tr)|terval)?|f(?:null)?)|d(?:a(?:t(?:e(?:_(?:format|add|sub)|diff)?|abase)|y(?:of(?:month|week|year)|name)?)|e(?:(?:s_(?:de|en)cryp|faul)t|grees|code)|count|ump)|l(?:o(?:ca(?:l(?:timestamp)?|te)|g(?:10|2)?|ad_file|wer)|ast(?:_(?:inser_id|day))?|e(?:(?:as|f)t|ngth)|case|trim|pad|n)|u(?:n(?:compress(?:ed_length)?|ix_timestamp|hex)|tc_(?:time(?:stamp)?|date)|p(?:datexml|per)|uid(?:_short)?|case|ser)|t(?:ime(?:_(?:format|to_sec)|stamp(?:diff|add)?|diff)?|o(?:(?:second|day)s|_base64|n?char)|r(?:uncate|im)|an)|m(?:a(?:ke(?:_set|date)|ster_pos_wait|x)|i(?:(?:crosecon)?d|n(?:ute)?)|o(?:nth(?:name)?|d)|d5)|r(?:e(?:p(?:lace|eat)|lease_lock|verse)|a(?:wtohex|dians|nd)|o(?:w_count|und)|ight|trim|pad)|f(?:i(?:eld(?:_in_set)?|nd_in_set)|rom_(?:unixtime|base64|days)|o(?:und_rows|rmat)|loor)|p(?:o(?:w(?:er)?|sition)|eriod_(?:diff|add)|rocedure_analyse|assword|g_sleep|i)|a(?:s(?:cii(?:str)?|in)|es_(?:de|en)crypt|dd(?:dat|tim)e|(?:co|b)s|tan2?|vg)|b(?:i(?:t_(?:length|count|x?or|and)|n(?:_to_num)?)|enchmark)|e(?:x(?:tract(?:value)?|p(?:ort_set)?)|nc(?:rypt|ode)|lt)|g(?:r(?:oup_conca|eates)t|et_(?:format|lock))|v(?:a(?:r(?:_(?:sam|po)p|iance)|lues)|ersion)|o(?:(?:ld_passwo)?rd|ct(?:et_length)?)|we(?:ek(?:ofyear|day)?|ight_string)|n(?:o(?:t_in|w)|ame_const|ullif)|h(?:ex(?:toraw)?|our)|qu(?:arter|ote)|year(?:week)?|xmltype)\W*\("\
+		"setvar:'tx.msg=%{rule.msg}',\
+		setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
+		setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+		setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}"
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?i:\d[\"'`]\s+[\"'`]\s+\d)|(?:^admin\s*?[\"'`]|(\/\*)+[\"'`]+\s?(?:--|#|\/\*|{)?)|(?:[\"'`]\s*?(x?or|div|like|between|and)[\w\s-]+\s*?[+<>=(),-]\s*?[\d\"'`])|(?:[\"'`]\s*?[^\w\s]?=\s*?[\"'`])|(?:[\"'`]\W*?[+=]+\W*?[\"'`])|(?:[\"'`]\s*?[!=|][\d\s!=+-]+.*?[\"'`(].*?$)|(?:[\"'`]\s*?[!=|][\d\s!=]+.*?\d+$)|(?:[\"'`]\s*?like\W+[\w\"'`(])|(?:\sis\s*?0\W)|(?:where\s[\s\w\.,-]+\s=)|(?:[\"'`][<>~]+[\"'`]))" \
+	"phase:request,\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'8',\
+	capture,\
+	t:none,t:urlDecodeUni,\
+	block,\
+	msg:'Detects basic SQL authentication bypass attempts 1/3',\
+	id:'942180',\
+	tag:'application-multi',\
+	tag:'language-mutli',\
+	tag:'platform-multi',\
+	tag:'attack-sqli',\
+	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+	tag:'paranoia-level/2',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:,.*?[)\da-f\"'`][\"'`](?:[\"'`].*?[\"'`]|\Z|[^\"'`]+))|(?:\Wselect.+\W*?from)|((?:select|create|rename|truncate|load|alter|delete|update|insert|desc)\s*?\(\s*?space\s*?\())" \
+	"phase:request,\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'8',\
+	capture,\
+	t:none,t:urlDecodeUni,\
+	block,\
+	msg:'Detects MySQL comment-/space-obfuscated injections and backtick termination',\
+	id:'942200',\
+	tag:'application-multi',\
+	tag:'language-mutli',\
+	tag:'platform-multi',\
+	tag:'attack-sqli',\
+	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+	tag:'paranoia-level/2',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:@.+=\s*?\(\s*?select)|(?:\d+\s*?(x?or|div|like|between|and)\s*?\d+\s*?[\-+])|(?:\/\w+;?\s+(?:having|and|x?or|div|like|between|and|select)\W)|(?:\d\s+group\s+by.+\()|(?:(?:;|#|--)\s*?(?:drop|alter))|(?:(?:;|#|--)\s*?(?:update|insert)\s*?\w{2,})|(?:[^\w]SET\s*?@\w+)|(?:(?:n?and|x?x?or|div|like|between|and|not |\|\||\&\&)[\s(]+\w+[\s)]*?[!=+]+[\s\d]*?[\"'`=()]))" \
+	"phase:request,\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'8',\
+	capture,\
+	t:none,t:urlDecodeUni,\
+	block,\
+	msg:'Detects chained SQL injection attempts 1/2',\
+	id:'942210',\
+	tag:'application-multi',\
+	tag:'language-mutli',\
+	tag:'platform-multi',\
+	tag:'attack-sqli',\
+	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+	tag:'paranoia-level/2',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:union\s*?(?:all|distinct|[(!@]*?)?\s*?[([]*?\s*?select\s+)|(?:\w+\s+like\s+[\"'`])|(?:like\s*?[\"'`]\%)|(?:[\"'`]\s*?like\W*?[\"'`\d])|(?:[\"'`]\s*?(?:n?and|x?x?or|div|like|between|and|not |\|\||\&\&)\s+[\s\w]+=\s*?\w+\s*?having\s+)|(?:[\"'`]\s*?\*\s*?\w+\W+[\"'`])|(?:[\"'`]\s*?[^?\w\s=.,;)(]+\s*?[(@\"'`]*?\s*?\w+\W+\w)|(?:select\s+?[\[\]()\s\w\.,\"'`-]+from\s+)|(?:find_in_set\s*?\())" \
+	"phase:request,\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'8',\
+	capture,\
+	t:none,t:urlDecodeUni,\
+	block,\
+	msg:'Detects basic SQL authentication bypass attempts 2/3',\
+	id:'942260',\
+        tag:'application-multi',\
+        tag:'language-mutli',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
+	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+	tag:'paranoia-level/2',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:\)\s*?when\s*?\d+\s*?then)|(?:[\"'`]\s*?(?:#|--|{))|(?:\/\*!\s?\d+)|(?:ch(?:a)?r\s*?\(\s*?\d)|(?:(?:(n?and|x?x?or|div|like|between|and|not)\s+|\|\||\&\&)\s*?\w+\())" \
+	"phase:request,\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'8',\
+	capture,\
+	t:none,t:urlDecodeUni,\
+	block,\
+	msg:'Detects MySQL comments, conditions and ch(a)r injections',\
+	id:'942300',\
+        tag:'application-multi',\
+        tag:'language-mutli',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
+	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+	tag:'paranoia-level/2',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s+and\s*?=\W)|(?:\(\s*?select\s*?\w+\s*?\()|(?:\*\/from)|(?:\+\s*?\d+\s*?\+\s*?@)|(?:\w[\"'`]\s*?(?:[-+=|@]+\s*?)+[\d(])|(?:coalesce\s*?\(|@@\w+\s*?[^\w\s])|(?:\W!+[\"'`]\w)|(?:[\"'`];\s*?(?:if|while|begin))|(?:[\"'`][\s\d]+=\s*?\d)|(?:order\s+by\s+if\w*?\s*?\()|(?:[\s(]+case\d*?\W.+[tw]hen[\s(]))" \
+	"phase:request,\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'8',\
+	capture,\
+	t:none,t:urlDecodeUni,\
+	block,\
+	msg:'Detects chained SQL injection attempts 2/2',\
+	id:'942310',\
+        tag:'application-multi',\
+        tag:'language-mutli',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
+	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+	tag:'paranoia-level/2',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s*?(x?or|div|like|between|and)\s*?[\"'`]?\d)|(?:\\\\x(?:23|27|3d))|(?:^.?[\"'`]$)|(?:(?:^[\"'`\\\\]*?(?:[\d\"'`]+|[^\"'`]+[\"'`]))+\s*?(?:n?and|x?x?or|div|like|between|and|not|\|\||\&\&)\s*?[\w\"'`][+&!@(),.-])|(?:[^\w\s]\w+\s*?[|-]\s*?[\"'`]\s*?\w)|(?:@\w+\s+(and|x?or|div|like|between|and)\s*?[\"'`\d]+)|(?:@[\w-]+\s(and|x?or|div|like|between|and)\s*?[^\w\s])|(?:[^\w\s:]\s*?\d\W+[^\w\s]\s*?[\"'`].)|(?:\Winformation_schema|table_name\W))" \
+	"phase:request,\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'8',\
+	capture,\
+	t:none,t:urlDecodeUni,\
+	block,\
+	msg:'Detects classic SQL injection probings 1/2',\
+	id:'942330',\
+        tag:'application-multi',\
+        tag:'language-mutli',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
+	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+        tag:'paranoia-level/2',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:in\s*?\(+\s*?select)|(?:(?:n?and|x?x?or|div|like|between|and|not |\|\||\&\&)\s+[\s\w+]+(?:regexp\s*?\(|sounds\s+like\s*?[\"'`]|[=\d]+x))|([\"'`]\s*?\d\s*?(?:--|#))|(?:[\"'`][\%&<>^=]+\d\s*?(=|x?or|div|like|between|and))|(?:[\"'`]\W+[\w+-]+\s*?=\s*?\d\W+[\"'`])|(?:[\"'`]\s*?is\s*?\d.+[\"'`]?\w)|(?:[\"'`]\|?[\w-]{3,}[^\w\s.,]+[\"'`])|(?:[\"'`]\s*?is\s*?[\d.]+\s*?\W.*?[\"'`]))" \
+	"phase:request,\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'8',\
+	capture,\
+	t:none,t:urlDecodeUni,\
+	block,\
+	msg:'Detects basic SQL authentication bypass attempts 3/3',\
+	id:'942340',\
+        tag:'application-multi',\
+        tag:'language-mutli',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
+	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+        tag:'paranoia-level/2',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s*?\*.+(?:x?or|div|like|between|and|id)\W*?[\"'`]\d)|(?:\^[\"'`])|(?:^[\w\s\"'`-]+(?<=and\s)(?<=or|xor|div|like|between|and\s)(?<=xor\s)(?<=nand\s)(?<=not\s)(?<=\|\|)(?<=\&\&)\w+\()|(?:[\"'`][\s\d]*?[^\w\s]+\W*?\d\W*?.*?[\"'`\d])|(?:[\"'`]\s*?[^\w\s?]+\s*?[^\w\s]+\s*?[\"'`])|(?:[\"'`]\s*?[^\w\s]+\s*?[\W\d].*?(?:#|--))|(?:[\"'`].*?\*\s*?\d)|(?:[\"'`]\s*?(x?or|div|like|between|and)\s[^\d]+[\w-]+.*?\d)|(?:[()\*<>%+-][\w-]+[^\w\s]+[\"'`][^,]))" \
 	"phase:request,\
         rev:'2',\
@@ -732,20 +752,13 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         tag:'platform-multi',\
         tag:'attack-sqli',\
 	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+        tag:'paranoia-level/2',\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	severity:'CRITICAL',\
 	setvar:'tx.msg=%{rule.msg}',\
 	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
-
-
-
-SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:1,id:942013,nolog,pass,skipAfter:END-REQUEST-42-APPLICATION-ATTACK-SQLI"
-SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:942014,nolog,pass,skipAfter:END-REQUEST-42-APPLICATION-ATTACK-SQLI"
-#
-# -= Paranoia Level 2 =- (apply only when tx.paranoia_level is sufficiently high: 2 or higher)
-#
 
 
 

--- a/rules/RESPONSE-50-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-50-DATA-LEAKAGES.conf
@@ -20,35 +20,6 @@ SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:4,id:950012,nolog,pass,skipAfter:END-RE
 #
 
 # 
-# -=[ The application is not available - 5xx level status code ]=-
-#
-SecRule RESPONSE_STATUS "^5\d{2}$" \
-	"phase:response,\
-	rev:'3',\
-	ver:'OWASP_CRS/3.0.0',\
-	maturity:'9',\
-	accuracy:'9',\
-	t:none,\
-	capture,\
-	ctl:auditLogParts=+E,\
-	block,\
-	msg:'The Application Returned a 500-Level Status Code',\
-	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	id:'950100',\
-	tag:'application-multi',\
-	tag:'language-multi',\
-	tag:'platform-multi',\
-	tag:'attack-information disclosure',\
-	tag:'WASCTC/WASC-13',\
-	tag:'OWASP_TOP_10/A6',\
-	tag:'PCI/6.5.6',\
-	severity:'ERROR',\
-	setvar:'tx.msg=%{rule.msg}',\
-	setvar:tx.outbound_anomaly_score=+%{tx.error_anomaly_score},\
-	setvar:tx.anomaly_score=+%{tx.error_anomaly_score},\
-	setvar:tx.%{rule.id}-AVAILABILITY/APP_NOT_AVAIL-%{matched_var_name}=%{tx.0}"
-
-# 
 # -=[ Directory Listing ]=-
 #
 SecRule RESPONSE_BODY "(?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Index of|>\[To Parent Directory\]<\/[Aa]><br>)" \
@@ -85,6 +56,36 @@ SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:4,id:950014,nolog,pass,skipAfter:END-RE
 #
 # -= Paranoia Level 2 =- (apply only when tx.paranoia_level is sufficiently high: 2 or higher)
 #
+
+# 
+# -=[ The application is not available - 5xx level status code ]=-
+#
+SecRule RESPONSE_STATUS "^5\d{2}$" \
+	"phase:response,\
+	rev:'3',\
+	ver:'OWASP_CRS/3.0.0',\
+	maturity:'9',\
+	accuracy:'9',\
+	t:none,\
+	capture,\
+	ctl:auditLogParts=+E,\
+	block,\
+	msg:'The Application Returned a 500-Level Status Code',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	id:'950100',\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-information disclosure',\
+	tag:'WASCTC/WASC-13',\
+	tag:'OWASP_TOP_10/A6',\
+	tag:'PCI/6.5.6',\
+        tag:'paranoia-level/2',\
+	severity:'ERROR',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.outbound_anomaly_score=+%{tx.error_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.error_anomaly_score},\
+	setvar:tx.%{rule.id}-AVAILABILITY/APP_NOT_AVAIL-%{matched_var_name}=%{tx.0}"
 
 
 


### PR DESCRIPTION
This is the second pull request in a series of four pull requests bringing support for a grouping of rules in multiple paranoia levels. See https://www.owasp.org/index.php/OWASP_ModSec_CRS_Paranoia_Mode for details.

3.0.0-rc1 rules that are confirmed for paranoia mode have been moved to level 2. This has not been tested thoroughly.