### PR TITLE
Rules skipped when no Accept header sent

### DIFF
--- a/rules/REQUEST-20-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-20-PROTOCOL-ENFORCEMENT.conf
@@ -1086,6 +1086,14 @@ SecRule ARGS "\%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
    setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
 
+
+#
+# Missing/Empty Accept Header
+#
+# -=[ Rule Logic ]=-
+# These rules will first check to see if an Accept header is present.
+# The second check is to see if an Accept header exists but is empty.
+#
 SecRule &REQUEST_HEADERS:Accept "@eq 0" \
   "msg:'Request Missing an Accept Header',\
    chain,\
@@ -1115,14 +1123,6 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
             setvar:'tx.msg=%{rule.msg}',\
             setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
             setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
-
-#
-# Missing/Empty Accept Header
-#
-# -=[ Rule Logic ]=-
-# These rules will first check to see if an Accept header is present.
-# The second check is to see if an Accept header exists but is empty.
-#
 
 SecRule REQUEST_HEADERS:Accept "^$" \
   "msg:'Request Has an Empty Accept Header',\

--- a/rules/REQUEST-20-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-20-PROTOCOL-ENFORCEMENT.conf
@@ -684,40 +684,6 @@ SecRule REQUEST_HEADERS:Host "^$" \
 SecMarker END_HOST_CHECK
     
 
-#
-# Missing/Empty Accept Header
-#
-# -=[ Rule Logic ]=-
-# These rules will first check to see if an Accept header is present.
-# The second check is to see if an Accept header exists but is empty.
-#
-
-SecRule REQUEST_HEADERS:Accept "^$" \
-  "msg:'Request Has an Empty Accept Header',\
-   chain,\
-   phase:request,\
-   rev:'2',\
-   ver:'OWASP_CRS/3.0.0',\
-   maturity:'9',\
-   accuracy:'8',\
-   t:none,\
-   pass,\
-   severity:'NOTICE',\
-   id:'920310',\
-   tag:'application-multi',\
-   tag:'language-multi',\
-   tag:'platform-multi',\
-   tag:'attack-protocol',\
-   tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_ACCEPT'"
-     SecRule REQUEST_METHOD "!^OPTIONS$" \
-       "chain"
-          SecRule REQUEST_HEADERS:User-Agent "!@pm AppleWebKit Android" \
-            "t:none,\
-            setvar:'tx.msg=%{rule.msg}',\
-            setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
-            setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
-
-SecMarker END_ACCEPT_CHECK
 
 #
 # Missing/Empty User-Agent Header
@@ -1149,6 +1115,41 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
             setvar:'tx.msg=%{rule.msg}',\
             setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
             setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
+
+#
+# Missing/Empty Accept Header
+#
+# -=[ Rule Logic ]=-
+# These rules will first check to see if an Accept header is present.
+# The second check is to see if an Accept header exists but is empty.
+#
+
+SecRule REQUEST_HEADERS:Accept "^$" \
+  "msg:'Request Has an Empty Accept Header',\
+   chain,\
+   phase:request,\
+   rev:'2',\
+   ver:'OWASP_CRS/3.0.0',\
+   maturity:'9',\
+   accuracy:'8',\
+   t:none,\
+   pass,\
+   severity:'NOTICE',\
+   id:'920310',\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_ACCEPT'"
+     SecRule REQUEST_METHOD "!^OPTIONS$" \
+       "chain"
+          SecRule REQUEST_HEADERS:User-Agent "!@pm AppleWebKit Android" \
+            "t:none,\
+            setvar:'tx.msg=%{rule.msg}',\
+            setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+            setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
+
+SecMarker END_ACCEPT_CHECK
 
 #
 # Maximum number of arguments in request limited


### PR DESCRIPTION
In PR #300, rule 920300 (Request Missing an Accept Header) was moved to paranoia level 2, lower in the file `REQUEST-20-PROTOCOL-ENFORCEMENT.conf`.

Rule 920300 performs a `skipAfter:END_ACCEPT_CHECK`. However, the `END_ACCEPT_CHECK` marker has remained at the old location, above it. So, if this rule fires, we have a `skipAfter` loop.

This causes the bug that if paranoia level is 2 or higher, and the client sends no Accept header, the rules and files after rule 920300 are no longer processed. (I'm not exactly sure how ModSecurity would cause this effect in case of a `skipAfter` loop, I would prefer an error 500 in this case, but I'll check and report that separately)

The marker is used because there is also rule 920310 (Request Has an Empty Accept Header) which is skipped if no Accept header is sent.

This issue is resolved by moving rule 920310 and the `END_ACCEPT_CHECK` marker below rule 920300, so they appear in tandem again.