### PR TITLE
fix invalid skipAfter when client sends no Accept header

### DIFF
--- a/rules/REQUEST-20-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-20-PROTOCOL-ENFORCEMENT.conf
@@ -685,11 +685,10 @@ SecMarker END_HOST_CHECK
     
 
 #
-# Missing/Empty Accept Header
+# Empty Accept Header
 #
 # -=[ Rule Logic ]=-
-# These rules will first check to see if an Accept header is present.
-# The second check is to see if an Accept header exists but is empty.
+# This rule checks if an Accept header exists, but has an empty value.
 #
 
 SecRule REQUEST_HEADERS:Accept "^$" \
@@ -716,8 +715,6 @@ SecRule REQUEST_HEADERS:Accept "^$" \
             setvar:'tx.msg=%{rule.msg}',\
             setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
             setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
-
-SecMarker END_ACCEPT_CHECK
 
 #
 # Missing/Empty User-Agent Header
@@ -1120,6 +1117,12 @@ SecRule ARGS "\%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
    setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
 
+#
+# Missing Accept Header
+#
+# -=[ Rule Logic ]=-
+# This rule generates a notice if the Accept header is missing.
+#
 SecRule &REQUEST_HEADERS:Accept "@eq 0" \
   "msg:'Request Missing an Accept Header',\
    chain,\
@@ -1140,8 +1143,7 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
    tag:'WASCTC/WASC-21',\
    tag:'OWASP_TOP_10/A7',\
    tag:'PCI/6.5.10',\
-   tag:'paranoia-level/2',\
-   skipAfter:END_ACCEPT_CHECK"
+   tag:'paranoia-level/2'"
      SecRule REQUEST_METHOD "!^OPTIONS$" \
        "chain"
 	  SecRule REQUEST_HEADERS:User-Agent "!@pm AppleWebKit Android" \


### PR DESCRIPTION
Rule 920300 (now in PL2) performs a `skipAfter:END_ACCEPT_CHECK`. However, the `END_ACCEPT_CHECK` marker has remained at the old location, above it. So, if this rule fires, we have a skipAfter loop.

This causes the bug that if paranoia level is 2 or higher, and the client sends no Accept header, the rules and files after rule 920300 are no longer processed.

This is fixed by removing skipAfter and the marker, while keeping the "empty Accept header" check at the old paranoia level.