### PR TITLE
detect PHP I/O stream injection attempts

### DIFF
--- a/rules/REQUEST-33-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-33-APPLICATION-ATTACK-PHP.conf
@@ -153,6 +153,46 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
                         setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}"
 
 
+#
+# [ PHP I/O Streams ]
+#
+# The "php://" syntax can be used to refer to various objects, such as local files (for LFI),
+# remote urls (for RFI), or standard input/request body. Its occurrence indicates a possible attempt
+# to either inject PHP code or exploit a file inclusion vulnerability in a PHP web app.
+#
+# Examples:
+# php://filter/resource=./../../../wp-config.php
+# php://filter/resource=http://www.example.com
+# php://stdin
+# php://input
+#
+# http://php.net/manual/en/wrappers.php.php
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* \
+                "@rx (?i)php://(std(in|out|err)|(in|out)put|fd|memory|temp|filter)" \
+        "msg:'PHP Injection Attack: I/O Stream Found',\
+        phase:request,\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'9',\
+        t:none,\
+        ctl:auditLogParts=+E,\
+        block,\
+        capture,\
+        logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        id:'933140',\
+        severity:'CRITICAL',\
+        tag:'application-multi',\
+        tag:'language-PHP',\
+        tag:'platform-multi',\
+        tag:'attack-PHP injection',\
+        tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
+        tag:'OWASP_TOP_10/A1',\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:tx.php_injection_score=+%{tx.critical_anomaly_score},\
+        setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+        setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}"
+
 
 SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:1,id:933013,nolog,pass,skipAfter:END-REQUEST-33-APPLICATION-ATTACK-PHP"
 SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:933014,nolog,pass,skipAfter:END-REQUEST-33-APPLICATION-ATTACK-PHP"

--- a/util/regression-tests/manifest.yaml
+++ b/util/regression-tests/manifest.yaml
@@ -245,6 +245,16 @@
   - test: [{url: '/?id=1%25%27%20UNION%20ALL%20SELECT%20NULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%23', code: 403}]
   - test: [{url: '/?id=1%25%27%20UNION%20ALL%20SELECT%20NULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%23', code: 403}]
   - test: [{url: '/?id=1%25%27%20UNION%20ALL%20SELECT%20NULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%23', code: 403}]
+  # PHP I/O Stream injection using php:// syntax (issue #301)
+  - test: [{url: '/?php%3A%2F%2Fstdin', code: 403}]
+  - test: [{url: '/?PHP%3A%2F%2Fstdout', code: 403}]
+  - test: [{url: '/?PHP%3A%2F%2Fstderr=1', code: 403}]
+  - test: [{url: '/?foo=someprefix%20php%3A%2F%2Finput', code: 403}]
+  - test: [{url: '/?foo=%20php%3A%2F%2Foutput%20bar', code: 403}]
+  - test: [{url: '/?bar=php%3A%2F%2Ffilter%2Fresource%3Dfile.php', code: 403}]
+  - test: [{url: '/?bar=php%3A%2F%2Ffilter%2Fresource%3Dhttp%3A%2F%2Fwww.example.com', code: 403}]
+  - test: [{url: '/', method: 'POST', data: 'php://memory', code: 403}]
+  - test: [{url: '/', method: 'POST', data: 'foo=PHp%3A%2F%2Ftemp', code: 403}]
   # PHP pre-check removal
   # This should trigger rule 933100, but the rule is skipped as URL does not end with .php
   - test: [{url: '/?foo=%3C%3Fphp', code: 403}]


### PR DESCRIPTION
The `php://` syntax can be used to refer to various objects, such as local files (for LFI), remote urls (for RFI), or standard input/request body. Its occurrence indicates a possible attempt to either inject PHP code or exploit a file inclusion vulnerability in a PHP web app.