### PR TITLE
PHP additions to lfi-os-files.data

### DIFF
--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -1039,6 +1039,8 @@ config.inc.php
 LocalSettings.php
 # MyBB
 inc/config.php
+# TYPO3
+typo3conf/localconf.php
 # Laravel
 # Note: these entries might be benign in REQUEST_FILENAME
 config/app.php

--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -1009,3 +1009,44 @@
 /etc/vmware-tools/vmware-tools-libraries.conf
 /var/log/vmware/hostd.log
 /var/log/vmware/hostd-1.log
+# Wordpress
+wp-config.php
+# Symfony
+/config.yml
+/config_dev.yml
+/config_prod.yml
+/config_test.yml
+/parameters.yml
+/routing.yml
+/security.yml
+/services.yml
+# Drupal
+sites/default/default.settings.php
+sites/default/settings.php
+# Magento
+app/etc/local.xml
+# Sublime Text
+sftp-config.json
+# ASP.NET
+Web.config
+# vBulletin
+includes/config.php
+# OSCommerce
+includes/configure.php
+# phpMyAdmin
+config.inc.php
+# MediaWiki
+LocalSettings.php
+# MyBB
+inc/config.php
+# Laravel
+# Note: these entries might be benign in REQUEST_FILENAME
+config/app.php
+config/custom.php
+config/database.php
+# Joomla
+# Note: this string might be benign in REQUEST_FILENAME
+/configuration.php
+# phpBB
+# Note: this string might be benign in REQUEST_FILENAME
+/config.php

--- a/util/regression-tests/manifest.yaml
+++ b/util/regression-tests/manifest.yaml
@@ -23,6 +23,7 @@
   # LFI tests (issue #295)
   #
   - test: [{url: '/?page=ok', code: 200}]
+  - test: [{url: '/?page=%23%20Wordpress', code: 200}] #ensure that @pmf ignores comment line
   - test: [{url: '/?page=/etc/php.ini', code: 403}]
   - test: [{url: '/admin.php?page=miwoftp&option=com_miwoftp&action=download&item=wp-config.php', code: 403}]
   - test: [{url: '/?lfi=app/config.yml', code: 403}]

--- a/util/regression-tests/manifest.yaml
+++ b/util/regression-tests/manifest.yaml
@@ -20,7 +20,17 @@
   - test: [{url: '/', code: 200}]
   - test: [{url: '/?id=', code: 200}]
   - test: [{url: '/?id=1', code: 200}]
+  # LFI tests (issue #295)
   #
+  - test: [{url: '/?page=ok', code: 200}]
+  - test: [{url: '/?page=/etc/php.ini', code: 403}]
+  - test: [{url: '/admin.php?page=miwoftp&option=com_miwoftp&action=download&item=wp-config.php', code: 403}]
+  - test: [{url: '/?lfi=app/config.yml', code: 403}]
+  - test: [{url: '/?lfi=sftp-config.json', code: 403}]
+  - test: [{url: '/?lfi=Web.config', code: 403}]
+  - test: [{url: '/?lfi=includes/configure.php', code: 403}]
+  - test: [{url: '/?config.inc.php', code: 403}]
+  - test: [{url: '/', method: 'POST', data: 'lfi=wp-config.php', code: 403}]
   # SQL injection tests
   # Generated with: sqlmap --random-agent --batch --flush-session -u 'http://example.com/?id=1'
   #

--- a/util/regression-tests/manifest.yaml
+++ b/util/regression-tests/manifest.yaml
@@ -30,6 +30,7 @@
   - test: [{url: '/?lfi=Web.config', code: 403}]
   - test: [{url: '/?lfi=includes/configure.php', code: 403}]
   - test: [{url: '/?config.inc.php', code: 403}]
+  - test: [{url: '/?foo=./typo3conf/localconf.php', code: 403}]
   - test: [{url: '/', method: 'POST', data: 'lfi=wp-config.php', code: 403}]
   # SQL injection tests
   # Generated with: sqlmap --random-agent --batch --flush-session -u 'http://example.com/?id=1'


### PR DESCRIPTION
Add entries for common PHP web applications and frameworks to `lfi-os-files.data`.

Currently, the LFI data file contains mostly pretty long paths, which protects against false positives. I have only used bare filenames (e.g. not prefixed with slashes or path names) if the files are likely to be in the current working directory, such as `wp-config.php` (Wordpress).