### PR TITLE
skip HttpBL checks if user has not defined one of the TX:block_* variables

### DIFF
--- a/rules/REQUEST-10-IP-REPUTATION.conf
+++ b/rules/REQUEST-10-IP-REPUTATION.conf
@@ -142,7 +142,7 @@ SecRule IP:PREVIOUS_RBL_CHECK "@eq 1" \
 
 # Skip HttpBL checks if user has not defined one of the TX:block_* variables.
 # This prevents error "Operator error: RBL httpBl called but no key defined: set SecHttpBlKey"
-SecRule &TX:block_suspicious_ip 0 \
+SecRule &TX:block_suspicious_ip "@eq 0" \
   "id:910128,\
   phase:request,\
   t:none,\
@@ -150,9 +150,9 @@ SecRule &TX:block_suspicious_ip 0 \
   pass,\
   chain,\
   skipAfter:END_RBL_CHECK"
-  SecRule &TX:block_harvester_ip 0 "chain"
-  SecRule &TX:block_spammer_ip 0 "chain"
-  SecRule &TX:block_search_ip 0
+  SecRule &TX:block_harvester_ip "@eq 0" "chain"
+  SecRule &TX:block_spammer_ip "@eq 0" "chain"
+  SecRule &TX:block_search_ip "@eq 0"
 
 SecRule TX:REAL_IP "@rbl dnsbl.httpbl.org" \
   "id:'910130',\

--- a/rules/REQUEST-10-IP-REPUTATION.conf
+++ b/rules/REQUEST-10-IP-REPUTATION.conf
@@ -12,7 +12,6 @@
 #
 
 
-
 SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:1,id:910011,nolog,pass,skipAfter:END-REQUEST-10-IP-REPUTATION"
 SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:2,id:910012,nolog,pass,skipAfter:END-REQUEST-10-IP-REPUTATION"
 #
@@ -132,10 +131,29 @@ SecRule IP:PREVIOUS_RBL_CHECK "@eq 1" \
 # Check Client IP against ProjectHoneypot's HTTP Blacklist
 # Ref: http://www.projecthoneypot.org/httpbl_api.php
 #
-# Must register for an HttpBL API Key and configure SecHttpBlKey directive
-# in the modsecurity_crs_10_setup.conf file.
+# To use the blacklist, you must register for an HttpBL API Key, and configure the following in
+# modsecurity_crs_10_setup.conf file:
+# 1) Uncomment and set SecHttpBlKey directive
+# 2) Uncomment rule 900025, and enable the clients you want to block:
+#    tx.block_search_ip, tx.block_suspicious_ip, tx.block_harvester_ip, tx.block_spammer_ip.
+#
 # Ref: https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#wiki-SecHttpBlKey
 # 
+
+# Skip HttpBL checks if user has not defined one of the TX:block_* variables.
+# This prevents error "Operator error: RBL httpBl called but no key defined: set SecHttpBlKey"
+SecRule &TX:block_suspicious_ip 0 \
+  "id:910128,\
+  phase:request,\
+  t:none,\
+  nolog,\
+  pass,\
+  chain,\
+  skipAfter:END_RBL_CHECK"
+  SecRule &TX:block_harvester_ip 0 "chain"
+  SecRule &TX:block_spammer_ip 0 "chain"
+  SecRule &TX:block_search_ip 0
+
 SecRule TX:REAL_IP "@rbl dnsbl.httpbl.org" \
   "id:'910130',\
   phase:request,\


### PR DESCRIPTION
The HttpBL rules cause "Rule processing failed." warning message if SecHttpBlKey not set.
In debug log: "Operator error: RBL httpBl called but no key defined: set SecHttpBlKey"

Skip over the HttpBL rules when the user does not use the HttpBL feature.

We can't detect whether SecHttpBlKey is set, but we can check if the user has defined HttpBL categories to block in rule 900025 (which is commented out by default).

To keep this rule simple and fast, I only check for existence of the TX:block_* variables, and don't add more conditions to check if the variables are actually set to 1 with `"!@eq 1"`.

This resolves #313 .