### PR TITLE
Moving 942420 to pl3, adding stricter siblings for 942420/942430

### DIFF
--- a/rules/REQUEST-42-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-42-APPLICATION-ATTACK-SQLI.conf
@@ -864,34 +864,20 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 #
 # [ SQL Injection Character Anomaly Usage ]
 #
-# These rules attempted to gauge when there is an exccesive use of
+# This rules attempts to gauge when there is an exccesive use of
 # meta-characters within a single parameter payload.
 #
+# Expect a lot of false positives with this rule.
 # The most likely false positive instances will be free-form text fields.
-# Adjust the the @ge operator value appropriately for your site.  Increasing
-# the score will reduce false positives but may also decrease detection of
-# obfuscated attack payloads.
+# This will make it necessary to disable the rule for certain known parameters.
+# The following directive is an example to switch off the rule globally for
+# the parameter foo. Place this instruction in your configuration after
+# the include directive for the Core Rules Set.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){8,}" \
-        "phase:request,\
-        t:none,t:urlDecodeUni,\
-        block,\
-        id:'942420',\
-        rev:'2',\
-        ver:'OWASP_CRS/3.0.0',\
-        maturity:'9',\
-        accuracy:'8',\
-        msg:'Restricted SQL Character Anomaly Detection Alert - Total # of special characters exceeded',\
-        capture,\
-        logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-        tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-        tag:'paranoia-level/2',\
-        setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
-        setvar:tx.sql_injection_score=+1,\
-        setvar:'tx.msg=%{rule.msg}',\
-        setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}"
+# SecRuleUpdateTargetById 942430 "!ARGS:foo"
+#
 
-SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){5,}" \
+SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){12,}" \
         "phase:request,\
         t:none,t:urlDecodeUni,\
         block,\
@@ -900,7 +886,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'
         ver:'OWASP_CRS/3.0.0',\
         maturity:'9',\
         accuracy:'8',\
-        msg:'Restricted SQL Character Anomaly Detection Alert - Total # of special characters exceeded',\
+        msg:'Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (12)',\
         capture,\
         logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
@@ -1017,6 +1003,68 @@ SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:2,id:942016,nolog,pass,skipAfter:END-RE
 # -= Paranoia Level 3 =- (apply only when tx.paranoia_level is sufficiently high: 3 or higher)
 #
 
+#
+# [ SQL Injection Character Anomaly Usage ]
+#
+# This rule attempts to gauge when there is an exccesive use of
+# meta-characters within a single parameter payload.
+#
+# It is similar to 942430, but focues on Cookies instead of
+# GET/POST parameters.
+#
+# Expect a lot of false positives with this rule.
+# The most likely false positive instances will be complex session ids.
+# This will make it necessary to disable the rule for certain known cookies.
+# The following directive is an example to switch off the rule globally for
+# the cookie foo_id. Place this instruction in your configuration after
+# the include directive for the Core Rules Set.
+#
+# SecRuleUpdateTargetById 942420 "!REQUEST_COOKIES:foo_id"
+#
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){8,}" \
+        "phase:request,\
+        t:none,t:urlDecodeUni,\
+        block,\
+        id:'942420',\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'8',\
+        msg:'Restricted SQL Character Anomaly Detection (cookies): # of special characters exceeded (8)',\
+        capture,\
+        logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+        tag:'paranoia-level/3',\
+        setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
+        setvar:tx.sql_injection_score=+1,\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}"
+
+
+#
+# This is a stricter sibling of rule 942430.
+#
+
+SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){6,}" \
+        "phase:request,\
+        t:none,t:urlDecodeUni,\
+        block,\
+        id:'942431',\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'8',\
+        msg:'Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (6)',\
+        capture,\
+        logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+        tag:'paranoia-level/3',\
+        setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
+        setvar:tx.sql_injection_score=+1,\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}"
+
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:1,id:942017,nolog,pass,skipAfter:END-REQUEST-42-APPLICATION-ATTACK-SQLI"
@@ -1025,6 +1073,54 @@ SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:2,id:942018,nolog,pass,skipAfter:END-RE
 # -= Paranoia Level 4 =- (apply only when tx.paranoia_level is sufficiently high: 4 or higher)
 #
 
+#
+# [ SQL Injection Character Anomaly Usage ]
+#
+# This is a stricter sibling of rule 942420.
+#
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){3,}" \
+        "phase:request,\
+        t:none,t:urlDecodeUni,\
+        block,\
+        id:'942421',\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'8',\
+        msg:'Restricted SQL Character Anomaly Detection (cookies): # of special characters exceeded (3)',\
+        capture,\
+        logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+        tag:'paranoia-level/4',\
+        setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
+        setvar:tx.sql_injection_score=+1,\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}"
+
+
+#
+# This is a stricter sibling of rule 942430.
+#
+
+SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){2,}" \
+        "phase:request,\
+        t:none,t:urlDecodeUni,\
+        block,\
+        id:'942432',\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'8',\
+        msg:'Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (2)',\
+        capture,\
+        logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+        tag:'paranoia-level/4',\
+        setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
+        setvar:tx.sql_injection_score=+1,\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}"
 
 
 #


### PR DESCRIPTION
This implements the resolutions found in #317:

942420:
 * Move rule to paranoia level 3, limit 8.
 * Add stricter sibling to level 4 (942421), limit 3.

942430:
 * Changed limit to 8.
 * Add stricter sibling to level 3 (942431), limit 6.
 * Add stricter sibling to level 4 (942432), limit 2.

Also changed msg for all rules, indicating limit and cookie target vs. args target.