### PR TITLE
Adding stricter sibling for 912100, cleanup

### DIFF
--- a/modsecurity_crs_10_setup.conf.example
+++ b/modsecurity_crs_10_setup.conf.example
@@ -505,13 +505,10 @@ SecAction \
 
 
 #
-# -- [[ DoS Protection ]] ----------------------------------------------------------------
+# -- [[ Anti-Automation / DoS Protection ]] ----------------------------------------------
 #
-# If you are using the DoS Protection rule set, then uncomment the following
-# lines and set the following variables:
-# - Burst Time Slice Interval: time interval window to monitor for bursts
-# - Request Threshold: request # threshold to trigger a burst
-# - Block Period: temporary block timeout
+# See rule file REQUEST-12-DOS-PROTECTION.conf for a detailed description.
+# Uncomment to activate optional protection rules.
 #
 #SecAction \
  "id:'900015',\

--- a/rules/REQUEST-12-DOS-PROTECTION.conf
+++ b/rules/REQUEST-12-DOS-PROTECTION.conf
@@ -8,13 +8,82 @@
 # ---------------------------------------------------------------
 
 #
-# Anti-Automation rule set for detecting Denial of Service Attacks. 
+# Anti-Automation rules to detect Denial of Service attacks.
+#
+# Description of mechanics:
+# When a request hits a non-static resource (TX:STATIC_RESOURCES), then a counter for the IP
+# address is being raised (IP:DOS_COUNTER). If the counter (IP:DOS_COUNTER) hits a limit
+# (TX:DOS_COUNTER_THRESHOLD), then a burst is identified (IP:DOS_BURST_COUNTER) and the
+# counter (IP:DOS_COUNTER) is reset. The burst counter expires within a timeout period
+# (TX:DOS_BURST_TIME_SLICE).
+# If the burst counter (IP:DOS_BURST_COUNTER) is greater equal 2, then the blocking flag
+# is being set (IP:DOS_BLOCK). The blocking flag (IP:DOS_BLOCK) expires within a timeout
+# period (TX:DOS_BLOCK_TIMEOUT). All this counting happens in phase 5.
+# There is a stricter sibling to this rule (912100) in paranoia level 2, where the
+# burst counter check (IP:DOS_BURST_COUNTER) hits at greater equal 1.
+#
+# The blocking is done in phase 1: When the blocking flag is encountered (IP:DOS_BLOCK),
+# then the request is dropped without sending a response. If this happens,, then a
+# counter is # raised (IP:DOS_BLOCK_COUNTER).
+# When an IP address is blocked for the first time, then the blocking is reported in a
+# message and a flag (IP:DOS_BLOCK_FLAG) is set. This flag expires in 60 seconds.
+# When an IP address is blocked and the flag (IP:DOS_BLOCK_FLAG) is set, then the
+# blocking is not being reported (to prevent a flood of alerts). When the flag
+# (IP:DOS_BLOCK_FLAG) has expired and a new request is being blocked, then the
+# counter (IP:DOS_BLOCK_COUNTER) is being reset to 0 and the block is being treated
+# as the first block (-> alert).
+# In order to be able to display the counter (IP:DOS_BLOCK_COUNTER) and resetting
+# it at the same time, we copy the counter (IP:DOS_BLOCK_COUNTER) into a different
+# variable (TX:DOS_BLOCK_COUNTER), which is then displayed in turn.
+#
+# Variables:
+# IP:DOS_BLOCK              Flag if an IP address should be blocked
+# IP:DOS_BLOCK_COUNTER      Counter of blocked requests
+# IP:DOS_BLOCK_FLAG         Flag keeping track of alert. Flag expires after 60 seconds.
+# IP:DOS_BURST_COUNTER      Burst counter
+# IP:DOS_COUNTER            Request counter (static resources are ignored)
+# TX:DOS_BLOCK_COUNTER      Copy of IP:DOS_BLOCK_COUNTER (needed for display reasons)
+# TX:DOS_BLOCK_TIMEOUT      Period in seconds a blocked IP will be blocked
+# TX:DOS_COUNTER_THRESHOLD  Limit of requests, where a burst is identified
+# TX:DOS_BURST_TIME_SLICE   Period in seconds when we will forget a burst
+# TX:STATIC_RESOURCES       Paths which can be ignored with regards to DoS
+#
+# As a precondition for these rules, please set the following three variables:
+#  - TX:DOS_BLOCK_TIMEOUT
+#  - TX:DOS_COUNTER_THRESHOLD
+#  - TX:DOS_BURST_TIME_SLICE
+# 
+# And make sure, that TX:STATIC_RESOURCES as also set.
 #
 
 #
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
 #
 
+#
+# Skip if variables defining DoS protection are not set
+#
+SecRule &TX:dos_burst_time_slice "@eq 0" \
+	"id:912021,\
+	phase:1,\
+	t:none,\
+	nolog,\
+	pass,\
+	chain,\
+	skipAfter:END_DOS_PROTECTION_CHECKS"
+	SecRule &TX:dos_counter_threshold "@eq 0" "chain"
+	SecRule &TX:dos_block_timeout "@eq 0"
+
+SecRule &TX:dos_burst_time_slice "@eq 0" \
+	"id:912022,\
+	phase:5,\
+	t:none,\
+	nolog,\
+	pass,\
+	chain,\
+	skipAfter:END_DOS_PROTECTION_CHECKS"
+	SecRule &TX:dos_counter_threshold "@eq 0" "chain"
+	SecRule &TX:dos_block_timeout "@eq 0"
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:1,id:912011,nolog,pass,skipAfter:END-REQUEST-12-DOS-PROTECTION"
@@ -24,54 +93,152 @@ SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:2,id:912012,nolog,pass,skipAfter:END-RE
 #
 
 #
-# Enforce an existing IP address block and log only 1-time/minute
-# We don't want to get flooded by alerts during an attack or scan so
-# we are only triggering an alert once/minute.  You can adjust how often
-# you want to receive status alerts by changing the expirevar setting below.
+# -=[ Anti-Automation / DoS Protection : Block ]=-
 #
-SecRule IP:DOS_BLOCK "@eq 1" "chain,phase:1,id:'912000',drop,tag:'application-multi',tag:'language-multi',tag:'platform-multi',tag:'attack-dos',msg:'Denial of Service (DoS) Attack Identified from %{tx.real_ip} (%{tx.dos_block_counter} hits since last alert)',setvar:ip.dos_block_counter=+1"
-	SecRule &IP:DOS_BLOCK_FLAG "@eq 0" "setvar:ip.dos_block_flag=1,expirevar:ip.dos_block_flag=60,setvar:tx.dos_block_counter=%{ip.dos_block_counter},setvar:ip.dos_block_counter=0"
+
+#
+# Block and track # of requests and log
+#
+SecRule IP:DOS_BLOCK "@eq 1" \
+	"chain,\
+	phase:1,\
+	id:'912000',\
+	drop,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-dos',\
+	msg:'Denial of Service (DoS) attack identified from %{tx.real_ip} (%{tx.dos_block_counter} hits since last alert)'"
+	SecRule &IP:DOS_BLOCK_FLAG "@eq 0" \
+		"setvar:ip.dos_block_counter=+1\
+		setvar:ip.dos_block_flag=1,\
+		expirevar:ip.dos_block_flag=60,\
+		setvar:tx.dos_block_counter=%{ip.dos_block_counter},\
+		setvar:ip.dos_block_counter=0"
+
 
 #
 # Block and track # of requests but don't log
-SecRule IP:DOS_BLOCK "@eq 1" "phase:1,id:'912010',t:none,drop,nolog,tag:'application-multi',tag:'language-multi',tag:'platform-multi',tag:'attack-dos',setvar:ip.dos_block_counter=+1"
+#
+SecRule IP:DOS_BLOCK "@eq 1" \
+	"phase:1,\
+	id:'912010',\
+	t:none,\
+	drop,\
+	nolog,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-dos',\
+	setvar:ip.dos_block_counter=+1"
+
 
 #
-# skipAfter Check
-# There are different scenarios where we don't want to do checks -
-# 1. If the current IP address has already been blocked due to high requests
-# In this case, we skip doing the request counts.
+# -=[ Anti-Automation / DoS Protection: Count requests ]=-
 #
-SecRule IP:DOS_BLOCK "@eq 1" "phase:5,id:'912020',t:none,nolog,tag:'application-multi',tag:'language-multi',tag:'platform-multi',tag:'attack-dos',pass,skipAfter:END_DOS_PROTECTION_CHECKS"
 
 #
-# DOS Counter
-# Count the number of requests to non-static resoures
-# 
-SecRule REQUEST_BASENAME "!\.(%{tx.static_resources})$" "phase:5,id:'912030',t:none,t:lowercase,nolog,pass,tag:'application-multi',tag:'language-multi',tag:'platform-multi',tag:'attack-dos',setvar:ip.dos_counter=+1"
+# Skip if we have blocked the request
+#
+SecRule IP:DOS_BLOCK "@eq 1" \
+	"phase:5,\
+	id:'912020',\
+	t:none,\
+	nolog,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-dos',\
+	pass,\
+	skipAfter:END_DOS_PROTECTION_CHECKS"
+
 
 #
-# Check DOS Counter
+# DOS Counter: Count the number of requests to non-static resoures
+#
+SecRule REQUEST_BASENAME "!\.(%{tx.static_resources})$" \
+	"phase:5,\
+	id:'912030',\
+	t:none,\
+	t:lowercase,\
+	nolog,\
+	pass,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-dos',\
+	setvar:ip.dos_counter=+1"
+
+
+#
+# Check DOS Counter:
 # If the request count is greater than or equal to user settings,
-# we then set the burst counter
-# 
-SecRule IP:DOS_COUNTER "@gt %{tx.dos_counter_threshold}" "phase:5,id:'912040',t:none,nolog,pass,tag:'application-multi',tag:'language-multi',tag:'platform-multi',tag:'attack-dos',setvar:ip.dos_burst_counter=+1,expirevar:ip.dos_burst_counter=%{tx.dos_burst_time_slice},setvar:!ip.dos_counter"
+# we set the burst counter.
+#
+SecRule IP:DOS_COUNTER "@gt %{tx.dos_counter_threshold}" \
+	"phase:5,\
+	id:'912040',\
+	t:none,\
+	nolog,\
+	pass,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-dos',\
+	setvar:ip.dos_burst_counter=+1,\
+	expirevar:ip.dos_burst_counter=%{tx.dos_burst_time_slice},\
+	setvar:!ip.dos_counter"
+
 
 #
 # Check DOS Burst Counter and set Block
 # Check the burst counter - if greater than or equal to 2, then we set the IP
-# block variable for 5 mins and issue an alert.
+# block variable for a given expiry and issue an alert.
 #
-SecRule IP:DOS_BURST_COUNTER "@ge 2" "phase:5,id:'912100',t:none,log,pass,tag:'application-multi',tag:'language-multi',tag:'platform-multi',tag:'attack-dos',msg:'Potential Denial of Service (DoS) Attack from %{tx.real_ip} - # of Request Bursts: %{ip.dos_burst_counter}',setvar:ip.dos_block=1,expirevar:ip.dos_block=%{tx.dos_block_timeout}"
+SecRule IP:DOS_BURST_COUNTER "@ge 2" \
+	"phase:5,\
+	id:'912100',\
+	t:none,\
+	log,\
+	pass,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-dos',\
+	msg:'Potential Denial of Service (DoS) Attack from %{tx.real_ip} - # of Request Bursts: %{ip.dos_burst_counter}',\
+	setvar:ip.dos_block=1,\
+	expirevar:ip.dos_block=%{tx.dos_block_timeout}"
 
-SecMarker END_DOS_PROTECTION_CHECKS
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:1,id:912013,nolog,pass,skipAfter:END-REQUEST-12-DOS-PROTECTION"
 SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:912014,nolog,pass,skipAfter:END-REQUEST-12-DOS-PROTECTION"
+SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:5,id:912019,nolog,pass,skipAfter:END-REQUEST-12-DOS-PROTECTION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.paranoia_level is sufficiently high: 2 or higher)
 #
+
+#
+# Check DOS Burst Counter and set Block
+# Check the burst counter - if greater than or equal to 1, then we set the IP
+# block variable for a given expiry and issue an alert.
+#
+# This is a stricter sibling of rule 912100.
+#
+SecRule IP:DOS_BURST_COUNTER "@ge 1" \
+	"phase:5,\
+	id:'912101',\
+	t:none,\
+	log,\
+	pass,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-dos',\
+	tag:'paranoia-level/2',\
+	msg:'Potential Denial of Service (DoS) Attack from %{tx.real_ip} - # of Request Bursts: %{ip.dos_burst_counter}',\
+	setvar:ip.dos_block=1,\
+	expirevar:ip.dos_block=%{tx.dos_block_timeout}"
 
 
 
@@ -96,3 +263,4 @@ SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:2,id:912018,nolog,pass,skipAfter:END-RE
 #
 SecMarker "END-REQUEST-12-DOS-PROTECTION"
 
+SecMarker END_DOS_PROTECTION_CHECKS

--- a/rules/REQUEST-12-DOS-PROTECTION.conf
+++ b/rules/REQUEST-12-DOS-PROTECTION.conf
@@ -171,7 +171,7 @@ SecRule REQUEST_BASENAME "!\.(%{tx.static_resources})$" \
 
 
 #
-# Check DOS Counter:
+# Check DOS Counter
 # If the request count is greater than or equal to user settings,
 # we set the burst counter.
 #


### PR DESCRIPTION
I've looked at the anti-automation / dos protection rules in detail to come up with a stricter sibling.

Details of this pull request:
 - Re-formatted all rules for 3.0
 - Added a detailed description of the mechanics
 - Added a summary for every variable in use
 - Added a base check for the setting of the
   necessary parameters. Skip everything if unset.
 - Fix a bug with ip.dos_block_counter
   (used to count every blocked request twice)
 - Added a stricter sibling for paranoia level 2
   which triggers a block on the first detected
   burst of requests per IP (The standard rule 
   triggers only on the 2nd occurrence of a 
   burst).

I do not really know why the original rule waits for the 2nd burst to happen before a blocking is issued.
Whatever the intention was, it allows for a stricter sibling in PL 2 without changing the default behaviour.

If you want to this, then it may be useful to use the following
rule to monitor the behaviour:

```
SecRule REQUEST_URI "@beginsWith /index.html" "id:912001,phase:1,pass,log,msg:'\
I:DB %{ip.dos_block} \
I:DBLC %{ip.dos_block_counter} \
I:DBF %{ip.dos_block_flag} \
I:DBUC %{ip.dos_burst_counter} \
I:DC %{ip.dos_counter} \
T:DBLC %{tx.dos_block_counter} | \
T:DBT %{tx.dos_block_timeout} \
T:DCT %{tx.dos_counter_threshold} \
T:DBTS %{tx.dos_burst_time_slice} \
T:SR %{tx.static_resources}'
```
