### PR TITLE
Remove FP prone entries from php-config-directives.data

### DIFF
--- a/rules/php-config-directives.data
+++ b/rules/php-config-directives.data
@@ -46,7 +46,6 @@ doc_root
 docref_ext
 docref_root
 enable_dl
-engine
 error_append_string
 error_log
 error_prepend_string
@@ -64,7 +63,6 @@ fastcgi.logging
 file_uploads
 filter.default
 filter.default_flags
-from
 gd.jpeg_ignore_warning
 highlight.bg
 highlight.comment
@@ -198,7 +196,6 @@ phar.cache_list
 phar.readonly
 phar.require_hash
 post_max_size
-precision
 realpath_cache_size
 realpath_cache_ttl
 register_argc_argv

--- a/util/regression-tests/manifest.yaml
+++ b/util/regression-tests/manifest.yaml
@@ -270,6 +270,10 @@
   # PHP pre-check removal
   # This should trigger rule 933100, but the rule is skipped as URL does not end with .php
   - test: [{url: '/?foo=%3C%3Fphp', code: 403}]
+  # PHP config directives (rule 933120)
+  # /phppath/php?-d+allow_url_include=on
+  - test: [{url: '/%70%68%70%70%61%74%68/%70%68%70?%2D%64+%61%6C%6C%6F%77%5F%75%72%6C%5F%69%6E%63%6C%75%64%65%3D%6F%6E', code: 403}]
+  - test: [{url: '/', method: 'POST', data: 'foo=allow_url_include%3Don', code: 403}]
   # PHP variables should be caught without ending bracket (issue #293)
   - test: [{url: '/?foo=%24argv', code: 403}]
   - test: [{url: '/?foo=%24HTTP_COOKIE_VARS%20%5B', code: 403}]

--- a/util/regression-tests/manifest.yaml
+++ b/util/regression-tests/manifest.yaml
@@ -274,6 +274,9 @@
   # /phppath/php?-d+allow_url_include=on
   - test: [{url: '/%70%68%70%70%61%74%68/%70%68%70?%2D%64+%61%6C%6C%6F%77%5F%75%72%6C%5F%69%6E%63%6C%75%64%65%3D%6F%6E', code: 403}]
   - test: [{url: '/', method: 'POST', data: 'foo=allow_url_include%3Don', code: 403}]
+  - test: [{url: '/', method: 'POST', data: 'foo=engine%3D1', code: 200}]
+  - test: [{url: '/', method: 'POST', data: 'foo=from%3D1', code: 200}]
+  - test: [{url: '/', method: 'POST', data: 'foo=precision%3D1', code: 200}]
   # PHP variables should be caught without ending bracket (issue #293)
   - test: [{url: '/?foo=%24argv', code: 403}]
   - test: [{url: '/?foo=%24HTTP_COOKIE_VARS%20%5B', code: 403}]


### PR DESCRIPTION
File `php-config-directives.data` contains a list of PHP configuration option names. Some of these names are commonly used on PHP cgi handlers to disable PHP security features.

Some entries from the data file are relatively uninteresting from an attacker's perspective, but are prone to cause false positives. 

Rule 933120 fires when a list entry is found together with the character `=`. For example, a variable that contains `=` as well as one of the words `engine`, `from`, `precision`, would be blocked now. That's too heavy and adds little security.

Remove these FP prone entries and add some tests for the rule.