### PR TITLE
Add new scores to regression test headers

### DIFF
--- a/util/regression-tests/modsecurity_crs_59_header_tagging.conf
+++ b/util/regression-tests/modsecurity_crs_59_header_tagging.conf
@@ -11,7 +11,7 @@
 #
 SecRule &TX:REGRESSION_TESTING|TX:REGRESSION_TESTING "@eq 0" "phase:4,t:none,nolog,id:'981228',pass,skipAfter:END_RESPONSE_HEADER_TAGGING"
 SecRule TX:ANOMALY_SCORE "@eq 0" "phase:4,id:'981229',t:none,nolog,pass,skipAfter:END_RESPONSE_HEADER_TAGGING"
-SecRule TX:/^\d*\-/ "." "phase:4,id:'981230',t:none,nolog,pass,setvar:tx.counter=+1,setenv:matched_rule-%{tx.counter}=%{matched_var_name},setenv:anomaly_score=%{tx.anomaly_score},setenv:sql_injection_score=%{tx.sql_injection_score},setenv:xss_score=%{tx.xss_score}"
+SecRule TX:/^\d*\-/ "." "phase:4,id:'981230',t:none,nolog,pass,setvar:tx.counter=+1,setenv:matched_rule-%{tx.counter}=%{matched_var_name},setenv:anomaly_score=%{tx.anomaly_score},setenv:sql_injection_score=%{tx.sql_injection_score},setenv:xss_score=%{tx.xss_score},setenv:rfi_score=%{tx.rfi_score},setenv:lfi_score=%{tx.lfi_score},setenv:rce_score=%{tx.rce_score},setenv:php_injection_score=%{tx.php_injection_score},setenv:http_violation_score=%{tx.http_violation_score},setenv:session_fixation_score=%{tx.session_fixation_score}"
 
 Header append X-WAF-Events "%{matched_rule-1}e" env=matched_rule-1
 Header append X-WAF-Events "%{matched_rule-2}e" env=matched_rule-2
@@ -33,6 +33,6 @@ Header append X-WAF-Events "%{matched_rule-17}e" env=matched_rule-17
 Header append X-WAF-Events "%{matched_rule-18}e" env=matched_rule-18
 Header append X-WAF-Events "%{matched_rule-19}e" env=matched_rule-19
 Header append X-WAF-Events "%{matched_rule-20}e" env=matched_rule-20
-Header set X-WAF-Score "Total=%{anomaly_score}e; sqli=%{sql_injection_score}e; xss=%{xss_score}e" env=anomaly_score
+Header set X-WAF-Score "Total=%{anomaly_score}e; sqli=%{sql_injection_score}e; xss=%{xss_score}e; rfi=%{rfi_score}e; lfi=%{lfi_score}e; rce=%{rce_score}e; php=%{php_injection_score}e; http=%{http_violation_score}e; ses=%{session_fixation_score}e" env=anomaly_score
 
 SecMarker END_RESPONSE_HEADER_TAGGING

--- a/util/regression-tests/modsecurity_crs_59_header_tagging.conf
+++ b/util/regression-tests/modsecurity_crs_59_header_tagging.conf
@@ -9,9 +9,39 @@
 # Must enable/configure the TX:REGRESSION_TESTING variable in the
 # modsecurity_crs_10_setup.conf file.
 #
-SecRule &TX:REGRESSION_TESTING|TX:REGRESSION_TESTING "@eq 0" "phase:4,t:none,nolog,id:'981228',pass,skipAfter:END_RESPONSE_HEADER_TAGGING"
-SecRule TX:ANOMALY_SCORE "@eq 0" "phase:4,id:'981229',t:none,nolog,pass,skipAfter:END_RESPONSE_HEADER_TAGGING"
-SecRule TX:/^\d*\-/ "." "phase:4,id:'981230',t:none,nolog,pass,setvar:tx.counter=+1,setenv:matched_rule-%{tx.counter}=%{matched_var_name},setenv:anomaly_score=%{tx.anomaly_score},setenv:sql_injection_score=%{tx.sql_injection_score},setenv:xss_score=%{tx.xss_score},setenv:rfi_score=%{tx.rfi_score},setenv:lfi_score=%{tx.lfi_score},setenv:rce_score=%{tx.rce_score},setenv:php_injection_score=%{tx.php_injection_score},setenv:http_violation_score=%{tx.http_violation_score},setenv:session_fixation_score=%{tx.session_fixation_score}"
+SecRule &TX:REGRESSION_TESTING|TX:REGRESSION_TESTING "@eq 0" \
+	"phase:4,\
+	t:none,\
+	nolog,\
+	id:'981228',\
+	pass,\
+	skipAfter:END_RESPONSE_HEADER_TAGGING"
+
+SecRule TX:ANOMALY_SCORE "@eq 0" \
+	"phase:4,\
+	id:'981229',\
+	t:none,\
+	nolog,\
+	pass,\
+	skipAfter:END_RESPONSE_HEADER_TAGGING"
+
+SecRule TX:/^\d*\-/ "." \
+	"phase:4,\
+	id:'981230',\
+	t:none,\
+	nolog,\
+	pass,\
+	setvar:tx.counter=+1,\
+	setenv:matched_rule-%{tx.counter}=%{matched_var_name},\
+	setenv:anomaly_score=%{tx.anomaly_score},\
+	setenv:sql_injection_score=%{tx.sql_injection_score},\
+	setenv:xss_score=%{tx.xss_score},\
+	setenv:rfi_score=%{tx.rfi_score},\
+	setenv:lfi_score=%{tx.lfi_score},\
+	setenv:rce_score=%{tx.rce_score},\
+	setenv:php_injection_score=%{tx.php_injection_score},\
+	setenv:http_violation_score=%{tx.http_violation_score},\
+	setenv:session_fixation_score=%{tx.session_fixation_score}"
 
 Header append X-WAF-Events "%{matched_rule-1}e" env=matched_rule-1
 Header append X-WAF-Events "%{matched_rule-2}e" env=matched_rule-2
@@ -33,6 +63,7 @@ Header append X-WAF-Events "%{matched_rule-17}e" env=matched_rule-17
 Header append X-WAF-Events "%{matched_rule-18}e" env=matched_rule-18
 Header append X-WAF-Events "%{matched_rule-19}e" env=matched_rule-19
 Header append X-WAF-Events "%{matched_rule-20}e" env=matched_rule-20
+
 Header set X-WAF-Score "Total=%{anomaly_score}e; sqli=%{sql_injection_score}e; xss=%{xss_score}e; rfi=%{rfi_score}e; lfi=%{lfi_score}e; rce=%{rce_score}e; php=%{php_injection_score}e; http=%{http_violation_score}e; ses=%{session_fixation_score}e" env=anomaly_score
 
 SecMarker END_RESPONSE_HEADER_TAGGING


### PR DESCRIPTION
Adds the following scores to the `X-WAF-Score` header emitted by the regression test rules. This makes it possible to analyze the partial scores when testing the CRS.

- tx.rfi_score
- tx.lfi_score
- tx.rce_score
- tx.php_injection_score
- tx.http_violation_score
- tx.session_fixation_score

Old output: `X-WAF-Score: Total=35; sqli=0; xss=5`
New output: `X-WAF-Score: Total=35; sqli=0; xss=5; rfi=0; lfi=5; rce=5; php=15; http=5; ses=0`