### PR TITLE
Detect PHP object injection

### DIFF
--- a/rules/REQUEST-33-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-33-APPLICATION-ATTACK-PHP.conf
@@ -284,6 +284,56 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
         setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}"
 
 
+#
+# [ PHP Object Injection ]
+#
+# PHP Object Injection is an application level vulnerability that could allow
+# an attacker to perform different kinds of malicious attacks, such as
+# Code Injection, SQL Injection, Path Traversal and Application Denial of Service,
+# depending on the context.
+#
+# The vulnerability occurs when user-supplied input is not properly sanitized
+# before being passed to the unserialize() PHP function. Since PHP allows object
+# serialization, attackers could pass ad-hoc serialized strings to a vulnerable
+# unserialize() call, resulting in an arbitrary PHP object(s) injection into the
+# application scope.
+#
+# https://www.owasp.org/index.php/PHP_Object_Injection
+#
+# In serialized form, PHP objects have the following format:
+#
+#    O:8:"stdClass":1:{s:1:"a";i:2;}
+#    O:3:"Foo":0:{}
+#
+# The User-Agent header is inspected, since its content is used by PHP applications
+# such as Joomla: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8562
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* \
+                "@rx [oO]:\d+:\".+?\":\d+:{.*}" \
+        "msg:'PHP Injection Attack: Serialized Object Injection',\
+        phase:request,\
+        rev:'1',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'1',\
+        accuracy:'9',\
+        t:none,\
+        ctl:auditLogParts=+E,\
+        block,\
+        capture,\
+        logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        id:'933170',\
+        severity:'CRITICAL',\
+        tag:'application-multi',\
+        tag:'language-PHP',\
+        tag:'platform-multi',\
+        tag:'attack-PHP injection',\
+        tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
+        tag:'OWASP_TOP_10/A1',\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:tx.php_injection_score=+%{tx.critical_anomaly_score},\
+        setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+        setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}"
+
 
 SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:1,id:933013,nolog,pass,skipAfter:END-REQUEST-33-APPLICATION-ATTACK-PHP"
 SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:933014,nolog,pass,skipAfter:END-REQUEST-33-APPLICATION-ATTACK-PHP"

--- a/util/regression-tests/modsecurity_crs_59_header_tagging.conf
+++ b/util/regression-tests/modsecurity_crs_59_header_tagging.conf
@@ -11,7 +11,7 @@
 #
 SecRule &TX:REGRESSION_TESTING|TX:REGRESSION_TESTING "@eq 0" "phase:4,t:none,nolog,id:'981228',pass,skipAfter:END_RESPONSE_HEADER_TAGGING"
 SecRule TX:ANOMALY_SCORE "@eq 0" "phase:4,id:'981229',t:none,nolog,pass,skipAfter:END_RESPONSE_HEADER_TAGGING"
-SecRule TX:/^\d*\-/ "." "phase:4,id:'981230',t:none,nolog,pass,setvar:tx.counter=+1,setenv:matched_rule-%{tx.counter}=%{matched_var_name},setenv:anomaly_score=%{tx.anomaly_score},setenv:sql_injection_score=%{tx.sql_injection_score},setenv:xss_score=%{tx.xss_score}"
+SecRule TX:/^\d*\-/ "." "phase:4,id:'981230',t:none,nolog,pass,setvar:tx.counter=+1,setenv:matched_rule-%{tx.counter}=%{matched_var_name},setenv:anomaly_score=%{tx.anomaly_score},setenv:sql_injection_score=%{tx.sql_injection_score},setenv:xss_score=%{tx.xss_score},setenv:rfi_score=%{tx.rfi_score},setenv:lfi_score=%{tx.lfi_score},setenv:rce_score=%{tx.rce_score},setenv:php_injection_score=%{tx.php_injection_score},setenv:http_violation_score=%{tx.http_violation_score},setenv:session_fixation_score=%{tx.session_fixation_score}"
 
 Header append X-WAF-Events "%{matched_rule-1}e" env=matched_rule-1
 Header append X-WAF-Events "%{matched_rule-2}e" env=matched_rule-2
@@ -33,6 +33,6 @@ Header append X-WAF-Events "%{matched_rule-17}e" env=matched_rule-17
 Header append X-WAF-Events "%{matched_rule-18}e" env=matched_rule-18
 Header append X-WAF-Events "%{matched_rule-19}e" env=matched_rule-19
 Header append X-WAF-Events "%{matched_rule-20}e" env=matched_rule-20
-Header set X-WAF-Score "Total=%{anomaly_score}e; sqli=%{sql_injection_score}e; xss=%{xss_score}e" env=anomaly_score
+Header set X-WAF-Score "Total=%{anomaly_score}e; sqli=%{sql_injection_score}e; xss=%{xss_score}e; rfi=%{rfi_score}e; lfi=%{lfi_score}e; rce=%{rce_score}e; php=%{php_injection_score}e; http=%{http_violation_score}e; ses=%{session_fixation_score}e" env=anomaly_score
 
 SecMarker END_RESPONSE_HEADER_TAGGING

--- a/util/regression-tests/modsecurity_crs_59_header_tagging.conf
+++ b/util/regression-tests/modsecurity_crs_59_header_tagging.conf
@@ -9,9 +9,39 @@
 # Must enable/configure the TX:REGRESSION_TESTING variable in the
 # modsecurity_crs_10_setup.conf file.
 #
-SecRule &TX:REGRESSION_TESTING|TX:REGRESSION_TESTING "@eq 0" "phase:4,t:none,nolog,id:'981228',pass,skipAfter:END_RESPONSE_HEADER_TAGGING"
-SecRule TX:ANOMALY_SCORE "@eq 0" "phase:4,id:'981229',t:none,nolog,pass,skipAfter:END_RESPONSE_HEADER_TAGGING"
-SecRule TX:/^\d*\-/ "." "phase:4,id:'981230',t:none,nolog,pass,setvar:tx.counter=+1,setenv:matched_rule-%{tx.counter}=%{matched_var_name},setenv:anomaly_score=%{tx.anomaly_score},setenv:sql_injection_score=%{tx.sql_injection_score},setenv:xss_score=%{tx.xss_score},setenv:rfi_score=%{tx.rfi_score},setenv:lfi_score=%{tx.lfi_score},setenv:rce_score=%{tx.rce_score},setenv:php_injection_score=%{tx.php_injection_score},setenv:http_violation_score=%{tx.http_violation_score},setenv:session_fixation_score=%{tx.session_fixation_score}"
+SecRule &TX:REGRESSION_TESTING|TX:REGRESSION_TESTING "@eq 0" \
+	"phase:4,\
+	t:none,\
+	nolog,\
+	id:'981228',\
+	pass,\
+	skipAfter:END_RESPONSE_HEADER_TAGGING"
+
+SecRule TX:ANOMALY_SCORE "@eq 0" \
+	"phase:4,\
+	id:'981229',\
+	t:none,\
+	nolog,\
+	pass,\
+	skipAfter:END_RESPONSE_HEADER_TAGGING"
+
+SecRule TX:/^\d*\-/ "." \
+	"phase:4,\
+	id:'981230',\
+	t:none,\
+	nolog,\
+	pass,\
+	setvar:tx.counter=+1,\
+	setenv:matched_rule-%{tx.counter}=%{matched_var_name},\
+	setenv:anomaly_score=%{tx.anomaly_score},\
+	setenv:sql_injection_score=%{tx.sql_injection_score},\
+	setenv:xss_score=%{tx.xss_score},\
+	setenv:rfi_score=%{tx.rfi_score},\
+	setenv:lfi_score=%{tx.lfi_score},\
+	setenv:rce_score=%{tx.rce_score},\
+	setenv:php_injection_score=%{tx.php_injection_score},\
+	setenv:http_violation_score=%{tx.http_violation_score},\
+	setenv:session_fixation_score=%{tx.session_fixation_score}"
 
 Header append X-WAF-Events "%{matched_rule-1}e" env=matched_rule-1
 Header append X-WAF-Events "%{matched_rule-2}e" env=matched_rule-2
@@ -33,6 +63,7 @@ Header append X-WAF-Events "%{matched_rule-17}e" env=matched_rule-17
 Header append X-WAF-Events "%{matched_rule-18}e" env=matched_rule-18
 Header append X-WAF-Events "%{matched_rule-19}e" env=matched_rule-19
 Header append X-WAF-Events "%{matched_rule-20}e" env=matched_rule-20
+
 Header set X-WAF-Score "Total=%{anomaly_score}e; sqli=%{sql_injection_score}e; xss=%{xss_score}e; rfi=%{rfi_score}e; lfi=%{lfi_score}e; rce=%{rce_score}e; php=%{php_injection_score}e; http=%{http_violation_score}e; ses=%{session_fixation_score}e" env=anomaly_score
 
 SecMarker END_RESPONSE_HEADER_TAGGING

--- a/util/regression-tests/php-object-injection.yaml
+++ b/util/regression-tests/php-object-injection.yaml
@@ -1,0 +1,11 @@
+- server: crsv3
+  scenarios:
+  - test: [{url: '/', code: 200}]
+  # PHP object injection (rule 933150)
+  # TODO: add a rule covering User-Agent
+  - test: [{url: '/serialize0?foo=O%3A8%3A%22stdClass%22%3A0%3A%7B%7D', code: 403}]
+  - test: [{url: '/serialize1?foo=O%3A8%3A%22stdClass%22%3A1%3A%7Bs%3A1%3A%22a%22%3Bi%3A2%3B%7D', code: 403}]
+  - test: [{url: '/serialize2', method: 'POST', data: 'foo=O%3A8%3A%22stdClass%22%3A1%3A%7Bs%3A1%3A%22a%22%3Bi%3A2%3B%7D', code: 403}]
+  - test: [{url: '/serialize3?foo=O%3A21%3A%22JDatabaseDriverMysqli%22%3A3%3A%7Bs%3A2%3A%22fc%22%3BO%3A17%3A%22JSimplepieFactory%22%3A0%3A%7B%7Ds%3A21%3A%22%5C0%5C0%5C0disconnectHandlers%22%3Ba%3A1%3A%7Bi%3A0%3Ba%3A2%3A%7Bi%3A0%3BO%3A9%3A%22SimplePie%22%3A5%3A%7Bs%3A8%3A%22sanitize%22%3BO%3A20%3A%22JDatabaseDriverMysql%22%3A0%3A%7B%7Ds%3A8%3A%22feed_url%22%3Bs%3A119%3A%22eval%28chr%28112%29.chr%28104%29.chr%28112%29.chr%28105%29.chr%28110%29.chr%28102%29.chr%28111%29.chr%2840%29.chr%2841%29.chr%2859%29%29%3BJFactory%3A%3AgetConfig%28%29%3Bexit%22%3Bs%3A19%3A%22cache_name_function%22%3Bs%3A6%3A%22assert%22%3Bs%3A5%3A%22cache%22%3Bb%3A1%3Bs%3A11%3A%22cache_class%22%3BO%3A20%3A%22JDatabaseDriverMysql%22%3A0%3A%7B%7D%7Di%3A1%3Bs%3A4%3A%22init%22%3B%7D%7Ds%3A13%3A%22%5C0%5C0%5C0connection%22%3Bb%3A1%3B%7D', code: 403}]
+  - test: [{url: '/serialize4/ajax/api/hook/decodeArguments?arguments=O%3A12%3A%22vB_dB_Result%22%3A2%3A%7Bs%3A5%3A%22%00%2a%00db%22%3BO%3A11%3A%22vB_Database%22%3A1%3A%7Bs%3A9%3A%22functions%22%3Ba%3A1%3A%7Bs%3A11%3A%22free_result%22%3Bs%3A7%3A%22phpinfo%22%3B%7D%7Ds%3A12%3A%22%00%2a%00recordset%22%3Bi%3A1%3B%7D', code: 403}]
+  - test: [{url: '/serialize5?O%3A8%3A%22stdClass%22%3A4%3A%7Bs%3A3%3A%22aaa%22%3Ba%3A5%3A%7Bi%3A0%3Bi%3A1%3Bi%3A1%3Bi%3A2%3Bi%3A2%3Ba%3A1%3A%7Bi%3A0%3Bi%3A1%3B%7Di%3A3%3Bi%3A4%3Bi%3A4%3Bi%3A5%3B%7Ds%3A3%3A%22aaa%22%3Bi%3A1%3Bs%3A3%3A%22ccc%22%3BR%3A5%3Bs%3A3%3A%22ddd%22%3Bs%3A4%3A%22AAAA%22%3B%7D', code: 403}]


### PR DESCRIPTION
Add detection for [PHP Object Injection](https://www.owasp.org/index.php/PHP_Object_Injection), described in #273.

In serialized form, PHP objects have the following format:

```
O:8:"stdClass":1:{s:1:"a";i:2;}
O:3:"Foo":0:{}
```

The User-Agent header is inspected, since its content is used by PHP applications such as Joomla (see [CVE-2015-8562](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8562)).

I improved the regexp based on suggestions by @csanders-git:

* Match more of the serialized string to log the full object string as matched data
* Made the initial `O` case-insensitive (good idea, you might never know)
* I didn't copy the `[aAsSoObBiI]` substring for the following reasons: (1) I want to also match empty objects, e.g. `O:3:"Foo":0:{}`, even sending this will call wakeup/destructor functions so might be a RCE vector. (2) By listing the types exhaustively, we may get a bypass if the PHP runtime introduces new types in the future. (3) I prefer the most simple regexp that still is FP proof.