### PR TITLE
scanners-user-agents: add WPScan

### DIFF
--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -91,3 +91,4 @@ PiplBot
 GrapeshotCrawler/2.0
 grapeFX
 SearchmetricsBot
+WPScan


### PR DESCRIPTION
The venerable [WPScan](http://wpscan.org) was missing from the list of scanners (rule 913100).

Its full User-Agent is `WPScan v2.9.1 (http://wpscan.org)`.

I didn't find the substring `WPScan` in [this database of User-Agents](http://www.useragentstring.com/pages/All/), so I expect few false positives.