### PR TITLE
Update Tags to be more unified as specified in #383

### DIFF
--- a/rules/REQUEST-10-IP-REPUTATION.conf
+++ b/rules/REQUEST-10-IP-REPUTATION.conf
@@ -39,7 +39,7 @@ SecRule IP:BLOCK "@eq 1" \
   tag:'language-multi',\
   tag:'platform-multi',\
   tag:'attack-reputation',\
-  tag:'reputation-Malware URL',\
+  tag:'attack-reputation-url-malware',\
   tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
   setvar:'tx.msg=%{rule.msg}',\
   setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
@@ -67,7 +67,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!^$" \
   tag:'language-multi',\
   tag:'platform-multi',\
   tag:'attack-reputation',\
-  tag:'reputation-Malicious IP',\
+  tag:'attack-reputation-ip',\
   tag:'IP_REPUTATION/GEO_LOCATION',\
   chain"
   SecRule TX:REAL_IP "@geoLookup" \
@@ -100,7 +100,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!^$" \
   tag:'language-multi',\
   tag:'platform-multi',\
   tag:'attack-reputation',\
-  tag:'reputation-Malicious IP',\
+  tag:'attack-reputation-ip',\
   tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
   setvar:'tx.msg=%{rule.msg}',\
   setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
@@ -122,7 +122,7 @@ SecRule IP:PREVIOUS_RBL_CHECK "@eq 1" \
   tag:'language-multi',\
   tag:'platform-multi',\
   tag:'attack-reputation',\
-  tag:'reputation-Malicious IP',\
+  tag:'attack-reputation-ip',\
   pass,\
   t:none,\
   skipAfter:END_RBL_LOOKUP"
@@ -163,7 +163,7 @@ SecRule TX:REAL_IP "@rbl dnsbl.httpbl.org" \
   tag:'language-multi',\
   tag:'platform-multi',\
   tag:'attack-reputation',\
-  tag:'reputation-Malicious IP',\
+  tag:'attack-reputation-ip',\
   tag:'IP_REPUTATON/MALICIOUS_CLIENT',\
   chain,\
   setvar:tx.httpbl_msg=%{tx.0}"
@@ -184,7 +184,7 @@ SecRule TX:block_search_ip "@eq 1" \
    tag:'language-multi',\
    tag:'platform-multi',\
    tag:'attack-reputation',\
-   tag:'reputation-Malicious IP',\
+   tag:'attack-reputation-ip',\
    tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
    chain,\
    skipAfter:END_RBL_CHECK"
@@ -209,7 +209,7 @@ SecRule TX:block_spammer_ip "@eq 1" \
    tag:'language-multi',\
    tag:'platform-multi',\
    tag:'attack-reputation',\
-   tag:'reputation-Malicious IP',\
+   tag:'attack-reputation-ip',\
    tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
    chain,\
    skipAfter:END_RBL_CHECK"
@@ -234,7 +234,7 @@ SecRule TX:block_suspicious_ip "@eq 1" \
    tag:'language-multi',\
    tag:'platform-multi',\
    tag:'attack-reputation',\
-   tag:'reputation-Malicious IP',\
+   tag:'attack-reputation-ip',\
    tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
    chain,\
    skipAfter:END_RBL_CHECK"
@@ -259,7 +259,7 @@ SecRule TX:block_harvester_ip "@eq 1" \
    tag:'language-multi',\
    tag:'platform-multi',\
    tag:'attack-reputation',\
-   tag:'reputation-Malicious IP',\
+   tag:'attack-reputation-ip',\
    tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
    chain,\
    skipAfter:END_RBL_CHECK"
@@ -283,7 +283,7 @@ SecAction \
   tag:'language-multi',\
   tag:'platform-multi',\
   tag:'attack-reputation',\
-  tag:'reputation-Malicious IP',\
+  tag:'attack-reputation-ip',\
   setvar:ip.previous_rbl_check=1,\
   expirevar:ip.previous_rbl_check=86400"
 

--- a/rules/REQUEST-10-IP-REPUTATION.conf
+++ b/rules/REQUEST-10-IP-REPUTATION.conf
@@ -38,7 +38,6 @@ SecRule IP:BLOCK "@eq 1" \
   tag:'application-multi',\
   tag:'language-multi',\
   tag:'platform-multi',\
-  tag:'attack-reputation',\
   tag:'attack-reputation-url-malware',\
   tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
   setvar:'tx.msg=%{rule.msg}',\
@@ -66,9 +65,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!^$" \
   tag:'application-multi',\
   tag:'language-multi',\
   tag:'platform-multi',\
-  tag:'attack-reputation',\
   tag:'attack-reputation-ip',\
-  tag:'IP_REPUTATION/GEO_LOCATION',\
   chain"
   SecRule TX:REAL_IP "@geoLookup" \
    "chain"
@@ -99,9 +96,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!^$" \
   tag:'application-multi',\
   tag:'language-multi',\
   tag:'platform-multi',\
-  tag:'attack-reputation',\
   tag:'attack-reputation-ip',\
-  tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
   setvar:'tx.msg=%{rule.msg}',\
   setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
   setvar:tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var},\
@@ -121,7 +116,6 @@ SecRule IP:PREVIOUS_RBL_CHECK "@eq 1" \
   tag:'application-multi',\
   tag:'language-multi',\
   tag:'platform-multi',\
-  tag:'attack-reputation',\
   tag:'attack-reputation-ip',\
   pass,\
   t:none,\
@@ -162,9 +156,7 @@ SecRule TX:REAL_IP "@rbl dnsbl.httpbl.org" \
   tag:'application-multi',\
   tag:'language-multi',\
   tag:'platform-multi',\
-  tag:'attack-reputation',\
   tag:'attack-reputation-ip',\
-  tag:'IP_REPUTATON/MALICIOUS_CLIENT',\
   chain,\
   setvar:tx.httpbl_msg=%{tx.0}"
         SecRule TX:httpbl_msg "RBL lookup of .*?.dnsbl.httpbl.org succeeded at TX:checkip. (.*?): .*" \
@@ -183,9 +175,7 @@ SecRule TX:block_search_ip "@eq 1" \
    tag:'application-multi',\
    tag:'language-multi',\
    tag:'platform-multi',\
-   tag:'attack-reputation',\
    tag:'attack-reputation-ip',\
-   tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
    chain,\
    skipAfter:END_RBL_CHECK"
         SecRule TX:httpbl_msg "Search Engine" \
@@ -208,9 +198,7 @@ SecRule TX:block_spammer_ip "@eq 1" \
    tag:'application-multi',\
    tag:'language-multi',\
    tag:'platform-multi',\
-   tag:'attack-reputation',\
    tag:'attack-reputation-ip',\
-   tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
    chain,\
    skipAfter:END_RBL_CHECK"
         SecRule TX:httpbl_msg "(?i)^.*? spammer .*?$" \
@@ -233,9 +221,7 @@ SecRule TX:block_suspicious_ip "@eq 1" \
    tag:'application-multi',\
    tag:'language-multi',\
    tag:'platform-multi',\
-   tag:'attack-reputation',\
    tag:'attack-reputation-ip',\
-   tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
    chain,\
    skipAfter:END_RBL_CHECK"
         SecRule TX:httpbl_msg "(?i)^.*? suspicious .*?$" \
@@ -258,9 +244,7 @@ SecRule TX:block_harvester_ip "@eq 1" \
    tag:'application-multi',\
    tag:'language-multi',\
    tag:'platform-multi',\
-   tag:'attack-reputation',\
    tag:'attack-reputation-ip',\
-   tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
    chain,\
    skipAfter:END_RBL_CHECK"
         SecRule TX:httpbl_msg "(?i)^.*? harvester .*?$" \
@@ -282,7 +266,6 @@ SecAction \
   tag:'application-multi',\
   tag:'language-multi',\
   tag:'platform-multi',\
-  tag:'attack-reputation',\
   tag:'attack-reputation-ip',\
   setvar:ip.previous_rbl_check=1,\
   expirevar:ip.previous_rbl_check=86400"

--- a/rules/REQUEST-13-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-13-SCANNER-DETECTION.conf
@@ -41,7 +41,6 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
   tag:'application-multi',\
   tag:'language-multi',\
   tag:'platform-multi',\
-  tag:'attack-reputation',\
   tag:'attack-reputation-scanner',\
   tag:'OWASP_CRS/AUTOMATION/SECURITY_SCANNER',\
   tag:'WASCTC/WASC-21',\
@@ -69,7 +68,6 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmf scanners-headers.data" \
   tag:'application-multi',\
   tag:'language-multi',\
   tag:'platform-multi',\
-  tag:'attack-reputation',\
   tag:'attack-reputation-scanner',\
   tag:'OWASP_CRS/AUTOMATION/SECURITY_SCANNER',\
   tag:'WASCTC/WASC-21',\
@@ -97,7 +95,6 @@ SecRule REQUEST_FILENAME|ARGS "@pmf scanners-urls.data" \
   tag:'application-multi',\
   tag:'language-multi',\
   tag:'platform-multi',\
-  tag:'attack-reputation',\
   tag:'attack-reputation-scanner',\
   tag:'OWASP_CRS/AUTOMATION/SECURITY_SCANNER',\
   tag:'WASCTC/WASC-21',\

--- a/rules/REQUEST-13-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-13-SCANNER-DETECTION.conf
@@ -42,7 +42,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
   tag:'language-multi',\
   tag:'platform-multi',\
   tag:'attack-reputation',\
-  tag:'reputation-scanner',\
+  tag:'attack-reputation-scanner',\
   tag:'OWASP_CRS/AUTOMATION/SECURITY_SCANNER',\
   tag:'WASCTC/WASC-21',\
   tag:'OWASP_TOP_10/A7',\
@@ -70,7 +70,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmf scanners-headers.data" \
   tag:'language-multi',\
   tag:'platform-multi',\
   tag:'attack-reputation',\
-  tag:'reputation-scanner',\
+  tag:'attack-reputation-scanner',\
   tag:'OWASP_CRS/AUTOMATION/SECURITY_SCANNER',\
   tag:'WASCTC/WASC-21',\
   tag:'OWASP_TOP_10/A7',\
@@ -98,7 +98,7 @@ SecRule REQUEST_FILENAME|ARGS "@pmf scanners-urls.data" \
   tag:'language-multi',\
   tag:'platform-multi',\
   tag:'attack-reputation',\
-  tag:'reputation-scanner',\
+  tag:'attack-reputation-scanner',\
   tag:'OWASP_CRS/AUTOMATION/SECURITY_SCANNER',\
   tag:'WASCTC/WASC-21',\
   tag:'OWASP_TOP_10/A7',\

--- a/rules/REQUEST-30-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-30-APPLICATION-ATTACK-LFI.conf
@@ -42,7 +42,7 @@ SecRule REQUEST_URI_RAW|REQUEST_BODY|REQUEST_HEADERS|XML:/*|!REQUEST_HEADERS:Ref
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-multi',\
-	tag:'attack-local file inclusion',\
+	tag:'attack-lfi',\
 	tag:'OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL',\
 	setvar:'tx.msg=%{rule.msg}',\
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
@@ -69,7 +69,7 @@ SecRule REQUEST_URI|REQUEST_BODY|REQUEST_HEADERS|XML:/*|!REQUEST_HEADERS:Referer
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-local file inclusion',\
+        tag:'attack-lfi',\
         tag:'OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL',\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
@@ -95,7 +95,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-local file inclusion',\
+        tag:'attack-lfi',\
 	tag:'OWASP_CRS/WEB_ATTACK/FILE_INJECTION',\
 	tag:'WASCTC/WASC-33',\
 	tag:'OWASP_TOP_10/A4',\

--- a/rules/REQUEST-31-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-31-APPLICATION-ATTACK-RFI.conf
@@ -50,7 +50,7 @@ SecRule ARGS "^(?i)(?:ht|f)tps?:\/\/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})" \
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-multi',\
-	tag:'attack-remote file inclusion',\
+	tag:'attack-rfi',\
 	tag:'OWASP_CRS/WEB_ATTACK/RFI',\
 	setvar:'tx.msg=%{rule.msg}',\
 	setvar:tx.rfi_score=+%{tx.critical_anomaly_score},\
@@ -74,7 +74,7 @@ SecRule QUERY_STRING|REQUEST_BODY "(?i:(\binclude\s*\([^)]*|mosConfig_absolute_p
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-remote file inclusion',\
+        tag:'attack-rfi',\
 	tag:'OWASP_CRS/WEB_ATTACK/RFI',\
 	setvar:'tx.msg=%{rule.msg}',\
 	setvar:tx.rfi_score=+%{tx.critical_anomaly_score},\
@@ -98,7 +98,7 @@ SecRule ARGS "^(?i)(?:ft|htt)ps?(.*?)\?+$" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-remote file inclusion',\
+        tag:'attack-rfi',\
 	tag:'OWASP_CRS/WEB_ATTACK/RFI',\
 	setvar:'tx.msg=%{rule.msg}',\
 	setvar:tx.rfi_score=+%{tx.critical_anomaly_score},\
@@ -131,7 +131,7 @@ SecRule ARGS "^(?:ht|f)tps?://(.*)$" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-remote file inclusion',\
+        tag:'attack-rfi',\
 	tag:'OWASP_CRS/WEB_ATTACK/RFI',\
 	tag:'paranoia-level/2'"
         	SecRule TX:1 "!@beginsWith %{request_headers.host}" \

--- a/rules/REQUEST-32-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-32-APPLICATION-ATTACK-RCE.conf
@@ -47,7 +47,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-multi',\
-	tag:'attack-remote code execution',\
+	tag:'attack-rce',\
 	tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
 	tag:'WASCTC/WASC-31',\
 	tag:'OWASP_TOP_10/A1',\

--- a/rules/REQUEST-33-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-33-APPLICATION-ATTACK-PHP.conf
@@ -46,9 +46,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	id:933100,\
 	severity:'CRITICAL',\
         tag:'application-multi',\
-        tag:'language-PHP',\
+        tag:'language-php',\
         tag:'platform-multi',\
-        tag:'attack-PHP injection',\
+        tag:'attack-injection-php',\
 	tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
 	tag:'OWASP_TOP_10/A1',\
 	setvar:'tx.msg=%{rule.msg}',\
@@ -92,9 +92,9 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
         id:933110,\
         severity:'CRITICAL',\
         tag:'application-multi',\
-        tag:'language-PHP',\
+        tag:'language-php',\
         tag:'platform-multi',\
-        tag:'attack-PHP injection',\
+        tag:'attack-injection-php',\
         tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
         tag:'OWASP_TOP_10/A1',\
         setvar:'tx.msg=%{rule.msg}',\
@@ -119,9 +119,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         block,\
         id:933120,\
         tag:'application-multi',\
-        tag:'language-PHP',\
+        tag:'language-php',\
         tag:'platform-multi',\
-        tag:'attack-PHP injection',\
+        tag:'attack-injection-php',\
         tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
         tag:'OWASP_TOP_10/A1',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -151,9 +151,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         block,\
         id:933130,\
  	tag:'application-multi',\
- 	tag:'language-PHP',\
+ 	tag:'language-php',\
  	tag:'platform-multi',\
- 	tag:'attack-PHP injection',\
+ 	tag:'attack-injection-php',\
         tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
         tag:'OWASP_TOP_10/A1',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -194,9 +194,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         id:933140,\
         severity:'CRITICAL',\
         tag:'application-multi',\
-        tag:'language-PHP',\
+        tag:'language-php',\
         tag:'platform-multi',\
-        tag:'attack-PHP injection',\
+        tag:'attack-injection-php',\
         tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
         tag:'OWASP_TOP_10/A1',\
         setvar:'tx.msg=%{rule.msg}',\
@@ -264,9 +264,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
         block,\
         id:933150,\
         tag:'application-multi',\
-        tag:'language-PHP',\
+        tag:'language-php',\
         tag:'platform-multi',\
-        tag:'attack-PHP injection',\
+        tag:'attack-injection-php',\
         tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
         tag:'OWASP_TOP_10/A1',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -316,9 +316,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
         block,\
         id:933160,\
         tag:'application-multi',\
-        tag:'language-PHP',\
+        tag:'language-php',\
         tag:'platform-multi',\
-        tag:'attack-PHP injection',\
+        tag:'attack-injection-php',\
         tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
         tag:'OWASP_TOP_10/A1',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -366,9 +366,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
         block,\
         id:933151,\
         tag:'application-multi',\
-        tag:'language-PHP',\
+        tag:'language-php',\
         tag:'platform-multi',\
-        tag:'attack-PHP injection',\
+        tag:'attack-injection-php',\
         tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
         tag:'OWASP_TOP_10/A1',\
         tag:'paranoia-level/2',\
@@ -423,9 +423,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
         block,\
         id:933161,\
         tag:'application-multi',\
-        tag:'language-PHP',\
+        tag:'language-php',\
         tag:'platform-multi',\
-        tag:'attack-PHP injection',\
+        tag:'attack-injection-php',\
         tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
         tag:'OWASP_TOP_10/A1',\
         tag:'paranoia-level/3',\
@@ -472,9 +472,9 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
         id:933111,\
         severity:'CRITICAL',\
         tag:'application-multi',\
-        tag:'language-PHP',\
+        tag:'language-php',\
         tag:'platform-multi',\
-        tag:'attack-PHP injection',\
+        tag:'attack-injection-php',\
         tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
         tag:'OWASP_TOP_10/A1',\
         tag:'paranoia-level/3',\

--- a/rules/REQUEST-43-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-43-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -43,7 +43,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-multi',\
-	tag:'attack-session fixation',\
+	tag:'attack-fixation',\
 	tag:'OWASP_CRS/WEB_ATTACK/SESSION_FIXATION',\
 	tag:'WASCTC/WASC-37',\
 	tag:'CAPEC-61',\
@@ -70,7 +70,7 @@ SecRule ARGS_NAMES "@rx ^(jsessionid|aspsessionid|asp.net_sessionid|phpsession|p
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-session fixation',\
+        tag:'attack-fixation',\
 	tag:'OWASP_CRS/WEB_ATTACK/SESSION_FIXATION',\
 	tag:'WASCTC/WASC-37',\
 	tag:'CAPEC-61',\
@@ -102,7 +102,7 @@ SecRule ARGS_NAMES "@rx ^(jsessionid|aspsessionid|asp.net_sessionid|phpsession|p
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-session fixation',\
+        tag:'attack-fixation',\
 	tag:'OWASP_CRS/WEB_ATTACK/SESSION_FIXATION',\
 	tag:'WASCTC/WASC-37',\
 	tag:'CAPEC-61',\

--- a/rules/REQUEST-49-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-49-BLOCKING-EVALUATION.conf
@@ -94,7 +94,7 @@ SecRule TX:RFI_SCORE "@ge %{tx.rfi_score_threshold}" \
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-multi',\
-	tag:'attack-remote file inclusion',\
+	tag:'attack-rfi',\
 	setvar:tx.inbound_tx_msg=%{tx.msg},\
 	setvar:tx.inbound_anomaly_score=%{tx.anomaly_score},\
 	chain"
@@ -116,7 +116,7 @@ SecRule TX:LFI_SCORE "@ge %{tx.lfi_score_threshold}" \
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-multi',\
-	tag:'attack-local file inclusion',\
+	tag:'attack-lfi',\
 	setvar:tx.inbound_tx_msg=%{tx.msg},\
 	setvar:tx.inbound_anomaly_score=%{tx.anomaly_score},\
 	chain"
@@ -139,7 +139,7 @@ SecRule TX:RCE_SCORE "@ge %{tx.rce_score_threshold}" \
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-multi',\
-	tag:'attack-remote code execution',\
+	tag:'attack-rce',\
 	setvar:tx.inbound_tx_msg=%{tx.msg},\
 	setvar:tx.inbound_anomaly_score=%{tx.anomaly_score},\
 	chain"
@@ -160,9 +160,9 @@ SecRule TX:PHP_INJECTION_SCORE "@ge %{tx.php_injection_score_threshold}" \
 	deny,\
 	log,\
 	tag:'application-multi',\
-	tag:'language-PHP',\
+	tag:'language-php',\
 	tag:'platform-multi',\
-	tag:'attack-PHP injection',\
+	tag:'attack-injection-php',\
 	setvar:tx.inbound_tx_msg=%{tx.msg},\
 	setvar:tx.inbound_anomaly_score=%{tx.anomaly_score},\
 	chain"
@@ -208,7 +208,7 @@ SecRule TX:SESSION_FIXATION_SCORE "@ge %{tx.session_fixation_score_threshold}" \
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-multi',\
-	tag:'attack-session fixation',\
+	tag:'attack-fixation',\
 	setvar:tx.inbound_tx_msg=%{tx.msg},\
 	setvar:tx.inbound_anomaly_score=%{tx.anomaly_score},\
 	chain"

--- a/rules/REQUEST-49-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-49-BLOCKING-EVALUATION.conf
@@ -29,7 +29,7 @@ SecRule IP:BLOCK "@eq 1" \
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-multi',\
-	tag:'attack-reputation',\
+	tag:'attack-reputation-ip',\
 	setvar:tx.inbound_tx_msg=%{tx.msg},\
 	setvar:tx.inbound_anomaly_score=%{tx.anomaly_score}"
 

--- a/rules/RESPONSE-50-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-50-DATA-LEAKAGES-IIS.conf
@@ -33,8 +33,8 @@ SecRule RESPONSE_BODY "[a-z]:\\\\inetpub\b" \
 	block,\
 	tag:'application-multi',\
 	tag:'language-multi',\
-	tag:'platform-IIS',\
-	tag:'attack-information disclosure',\
+	tag:'platform-iis',\
+	tag:'attack-disclosure',\
 	msg:'Disclosure of IIS install location',\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	id:950120,\
@@ -62,8 +62,8 @@ SecRule RESPONSE_BODY "(?:Microsoft OLE DB Provider for SQL Server(?:<\/font>.{1
 	id:950130,\
         tag:'application-multi',\
         tag:'language-multi',\
-        tag:'platform-IIS',\
-        tag:'attack-information disclosure',\
+        tag:'platform-iis',\
+        tag:'attack-disclosure',\
 	tag:'WASCTC/WASC-13',\
 	tag:'OWASP_TOP_10/A6',\
 	tag:'PCI/6.5.6',\
@@ -91,8 +91,8 @@ SecRule RESPONSE_BODY "(?:\b(?:A(?:DODB\.Command\b.{0,100}?\b(?:Application uses
 	id:950140,\
         tag:'application-multi',\
         tag:'language-multi',\
-        tag:'platform-IIS',\
-        tag:'attack-information disclosure',\
+        tag:'platform-iis',\
+        tag:'attack-disclosure',\
 	tag:'OWASP_CRS/LEAKAGE/ERRORS_IIS',\
 	tag:'WASCTC/WASC-13',\
 	tag:'OWASP_TOP_10/A6',\
@@ -119,8 +119,8 @@ SecRule RESPONSE_STATUS "!^404$" \
 	id:950150,\
         tag:'application-multi',\
         tag:'language-multi',\
-        tag:'platform-IIS',\
-        tag:'attack-information disclosure',\
+        tag:'platform-iis',\
+        tag:'attack-disclosure',\
 	tag:'OWASP_CRS/LEAKAGE/ERRORS_IIS',\
 	tag:'WASCTC/WASC-13',\
 	tag:'OWASP_TOP_10/A6',\

--- a/rules/RESPONSE-50-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-50-DATA-LEAKAGES-JAVA.conf
@@ -38,7 +38,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-code-leakages.data" \
         tag:'application-multi',\
         tag:'language-java',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
 	tag:'OWASP_CRS/LEAKAGE/SOURCE_CODE_JAVA',\
 	tag:'WASCTC/WASC-13',\
 	tag:'OWASP_TOP_10/A6',\
@@ -70,7 +70,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
         tag:'application-multi',\
         tag:'language-java',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
         tag:'OWASP_CRS/LEAKAGE/ERRORS_JAVA',\
         tag:'WASCTC/WASC-13',\
         tag:'OWASP_TOP_10/A6',\

--- a/rules/RESPONSE-50-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-50-DATA-LEAKAGES-PHP.conf
@@ -39,7 +39,7 @@ SecRule RESPONSE_BODY "@pmf php-errors.data" \
         tag:'application-multi',\
         tag:'language-php',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
 	tag:'OWASP_CRS/LEAKAGE/ERRORS_PHP',\
 	tag:'WASCTC/WASC-13',\
 	tag:'OWASP_TOP_10/A6',\
@@ -67,7 +67,7 @@ SecRule RESPONSE_BODY "(?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scanf|wr
         tag:'application-multi',\
         tag:'language-php',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
 	tag:'OWASP_CRS/LEAKAGE/SOURCE_CODE_PHP',\
 	tag:'WASCTC/WASC-13',\
 	tag:'OWASP_TOP_10/A6',\
@@ -96,7 +96,7 @@ SecRule RESPONSE_BODY "<\?(?!xml)" \
         tag:'application-multi',\
         tag:'language-php',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
 	tag:'OWASP_CRS/LEAKAGE/SOURCE_CODE_PHP',\
 	tag:'WASCTC/WASC-13',\
 	tag:'OWASP_TOP_10/A6',\

--- a/rules/RESPONSE-50-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-50-DATA-LEAKAGES.conf
@@ -38,7 +38,7 @@ SecRule RESPONSE_BODY "(?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Index of
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-multi',\
-	tag:'attack-information disclosure',\
+	tag:'attack-disclosure',\
 	tag:'OWASP_CRS/LEAKAGE/INFO_DIRECTORY_LISTING',\
 	tag:'WASCTC/WASC-13',\
 	tag:'OWASP_TOP_10/A6',\
@@ -76,7 +76,7 @@ SecRule RESPONSE_STATUS "^5\d{2}$" \
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-multi',\
-	tag:'attack-information disclosure',\
+	tag:'attack-disclosure',\
 	tag:'WASCTC/WASC-13',\
 	tag:'OWASP_TOP_10/A6',\
 	tag:'PCI/6.5.6',\

--- a/rules/RESPONSE-51-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-51-DATA-LEAKAGES-SQL.conf
@@ -35,7 +35,7 @@ SecRule RESPONSE_BODY "@pmFromFile sql-errors.data" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
         setvar:tx.sql_error_match=1,\
         t:none"
 
@@ -54,7 +54,7 @@ SecRule TX:sql_error_match "@eq 1" \
    	tag:'application-multi',\
    	tag:'language-multi',\
    	tag:'platform-multi',\
-   	tag:'attack-information disclosure',\
+   	tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -84,7 +84,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -114,7 +114,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -144,7 +144,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -174,7 +174,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -204,7 +204,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
 	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
 	tag:'CWE-209',\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -234,7 +234,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
  	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -264,7 +264,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -295,7 +295,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -326,7 +326,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -356,7 +356,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -386,7 +386,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -416,7 +416,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -446,7 +446,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -476,7 +476,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -506,7 +506,7 @@ SecRule TX:sql_error_match "@eq 1" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-multi',\
-        tag:'attack-information disclosure',\
+        tag:'attack-disclosure',\
    	tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
    	tag:'CWE-209',\
    	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\


### PR DESCRIPTION
Specified in #383
Some small changes were made to the overall suggestion in or to maintain ease of use for automated scripts. That is retaining the prefix 'attack' in front of reputational data. Additionally I removed IP_REPUTATION/MALICIOUS_CLIENT type tagging as it was redundant and didn't really add anything in most cases.