### PR TITLE
Remove web addresses from tags

### DIFF
--- a/rules/REQUEST-20-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-20-PROTOCOL-ENFORCEMENT.conf
@@ -834,7 +834,6 @@ SecRule REQUEST_HEADERS:Host "^[\d.:]+$" \
    tag:'WASCTC/WASC-21',\
    tag:'OWASP_TOP_10/A7',\
    tag:'PCI/6.5.10',\
-   tag:'http://technet.microsoft.com/en-us/magazine/2005.01.hackerbasher.aspx',\
    setvar:'tx.msg=%{rule.msg}',\
    setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
    setvar:tx.%{rule.id}-OWASP_CRS/POLICY/IP_HOST-%{matched_var_name}=%{matched_var}"

--- a/rules/REQUEST-41-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-41-APPLICATION-ATTACK-XSS.conf
@@ -67,7 +67,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         tag:'OWASP_TOP_10/A3',\
         tag:'OWASP_AppSensor/IE1',\
         tag:'CAPEC-242',\
-	tag:'https://libinjection.client9.com/',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.xss_score=+%{tx.critical_anomaly_score},\

--- a/rules/REQUEST-42-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-42-APPLICATION-ATTACK-SQLI.conf
@@ -62,7 +62,6 @@ SecRule ARGS|REQUEST_COOKIES|QUERY_STRING|REQUEST_FILENAME "@detectSQLi" \
    tag:'OWASP_TOP_10/A1',\
    tag:'OWASP_AppSensor/CIE1',\
    tag:'PCI/6.5.2',\
-   tag:'https://libinjection.client9.com/',\
    setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
    setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
    setvar:'tx.msg=%{rule.msg}',setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{matched_var}"


### PR DESCRIPTION
Remove tags containing URLs, as discussed in #383.

The URLs were already present in the comments, so the tags can just be deleted.