### PR TITLE
Remove rule 920110 using WEBSERVER_ERROR_LOG

### DIFF
--- a/rules/REQUEST-20-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-20-PROTOCOL-ENFORCEMENT.conf
@@ -69,39 +69,6 @@ SecRule REQUEST_LINE "!^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+)?)?
 
 
 #
-# Identify Invalid URIs Blocked by Apache 
-#
-# -=[ Rule Logic ]=-
-#
-# There are some request violations that Apache will handle internally, prior to the
-# ModSecurity phase:request POST-READ-REQUEST hook.  For these requests, we can still get
-# visibility by running a check in phase:logging logging to look for the Apache error msg.
-#
-# -=[ References ]=-
-#
-SecRule WEBSERVER_ERROR_LOG "@contains Invalid URI in request" \
-  "msg:'Apache Error: Invalid URI in Request.',\
-  severity:'WARNING',\
-  id:920110,\
-  ver:'OWASP_CRS/3.0.0',\
-  rev:'1',\
-  maturity:'9',\
-  accuracy:'9',\
-  logdata:'%{request_line}',\
-  phase:logging,\
-  pass,\
-  t:none,\
-  tag:'application-multi',\
-  tag:'language-multi',\
-  tag:'platform-multi',\
-  tag:'attack-protocol',\
-  tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ',\
-  tag:'CAPEC-272',\
-  setvar:'tx.msg=%{rule.msg}',\
-  setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
-  setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ-%{matched_var_name}=%{matched_var}'"
-
-#
 # Identify multipart/form-data name evasion attempts 
 #
 # There are possible impedance mismatches between how


### PR DESCRIPTION
Removed rule 920110 which is incompatible in ModSec 2.x with all platforms except Apache. This change is proposed regaurdless of the outcome of https://github.com/SpiderLabs/ModSecurity/issues/1028 as ModSecurity 2.x doesn't really support this and this rule adds very little to the ruleset as Apache will throwout the URL as part of normal operation.
Suggested in #394