### PR TITLE
scanners-user-agents: add commix

### DIFF
--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -12,6 +12,7 @@ brutus/aet
 bsqlbf
 cgichk
 cisco-torch
+commix
 core-project/1.0
 crimscanner/
 datacha0s


### PR DESCRIPTION
Noticed that the cool [commix](https://github.com/stasinopoulos/commix) command injection tool was missing from the list of scanners. (For those currently testing with it, no fear, it has `--user-agent` and `--random-agent` options)