### PR TITLE
Use detectSQLi operator on all standard variables

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -40,7 +40,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:2,id:942012,nolog,pass,skipAfter:END-RE
 #
 # Ref: https://libinjection.client9.com/
 #
-SecRule ARGS|REQUEST_COOKIES|QUERY_STRING|REQUEST_FILENAME "@detectSQLi" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@detectSQLi" \
   "msg:'SQL Injection Attack Detected via LibInjection',\
    id:942100,\
    rev:'1',\

--- a/util/regression-tests/manifest.yaml
+++ b/util/regression-tests/manifest.yaml
@@ -42,6 +42,8 @@
   - test: [{url: '/?id=1%29%20AND%201421%3D3553%20AND%20%289926%3D9926', code: 403}]
   - test: [{url: '/?id=1%29%20AND%202912%3D2912%20AND%20%287303%3D7303', code: 403}]
   - test: [{url: '/?id=1%20AND%204598%3D4189', code: 403}]
+  - test: [{url: '/?1%20AND%204598%3D4189', code: 403}]
+  - test: [{url: '/', method: 'POST', data: '1%20AND%204598%3D4189', code: 403}]
   - test: [{url: '/?id=1%20AND%202912%3D2912', code: 403}]
   - test: [{url: '/?id=1%20AND%206112%3D7517--%20aUOj', code: 403}]
   - test: [{url: '/?id=1%20AND%202912%3D2912--%20IPSi', code: 403}]


### PR DESCRIPTION
I noticed that in rule 942100, the detectSQLi operator is only used on a limited number of variables:

```
SecRule ARGS|REQUEST_COOKIES|QUERY_STRING|REQUEST_FILENAME "@detectSQLi" \
```

This is different from almost all other rules. Most rules are using the standard:

```
SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*`
```

The problem of omitting `ARGS_NAMES` is that bare POST data goes unchecked. For example, the following payload is not passed to detectSQLi by rule 942100:

```
curl --data '1%20AND%204598%3D4189' http://foo/
```

The request only gets score 5 in paranoia level 2 because of rule 942400. It is missed in paranoia level 1.

By changing the variables for detectSQLi, the above payload is checked correctly and gets score 5 in PL1, 10 in PL2.

I don't know if there's a specific reason why the variables were different for this rule, or if it was an oversight.