### PR TITLE
Removing the chained evaluation of TX.\d from the anomaly score thres…

### DIFF
--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -37,7 +37,7 @@ SecRule IP:BLOCK "@eq 1" \
 #
 # -=[ Overall Transaction Anomaly Score ]=-
 #
-SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
+SecRule TX:ANOMALY_SCORE_BLOCKING "@streq on" \
     "msg:'Inbound Anomaly Score Exceeded (Total Score: %{TX.ANOMALY_SCORE})',\
     severity:CRITICAL,\
     phase:request,\
@@ -52,7 +52,7 @@ SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     setvar:tx.inbound_tx_msg=%{tx.msg},\
     setvar:tx.inbound_anomaly_score=%{tx.anomaly_score},\
     chain"
-        SecRule TX:ANOMALY_SCORE_BLOCKING "@streq on"
+        SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}"
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:1,id:949011,nolog,pass,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -23,7 +23,7 @@
 
 # Alert and Block on High Anomaly Scores - this would block outbound data leakages
 #
-SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
+SecRule TX:ANOMALY_SCORE_BLOCKING "@streq on" \
   "chain,\
   phase:4,\
   id:959100,\
@@ -31,7 +31,7 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
   t:none,\
   deny,\
   msg:'Outbound Anomaly Score Exceeded (Total Score: %{TX.OUTBOUND_ANOMALY_SCORE})'"
-    SecRule TX:ANOMALY_SCORE_BLOCKING "@streq on"
+    SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}"
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:3,id:959011,nolog,pass,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"


### PR DESCRIPTION
Removing the chained evaluation of TX.\d from the anomaly score threshold evaluation rule.

I streamlined the msg in the two files as well and removed a logdata entry which did not make sense anymore.

See issue #418 