### PR TITLE
Fix SQLI scores not being incremented correctly

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -428,7 +428,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "(^[\"'`;]+|[\"'`]+$)" \
 	msg:'SQL Injection Attack: Common Injection Testing Detected',\
 	id:942110,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	severity:'CRITICAL',\
+	severity:'WARNING',\
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-multi',\
@@ -778,7 +778,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         tag:'PCI/6.5.2',\
         tag:'paranoia-level/2',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-        severity:'2',\
+        severity:'CRITICAL',\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
         setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
@@ -803,7 +803,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         tag:'PCI/6.5.2',\
         tag:'paranoia-level/2',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-        severity:'2',\
+        severity:'CRITICAL',\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
         setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
@@ -828,7 +828,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         tag:'PCI/6.5.2',\
         tag:'paranoia-level/2',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-        severity:'2',\
+        severity:'CRITICAL',\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
         setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
@@ -853,7 +853,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         tag:'PCI/6.5.2',\
         tag:'paranoia-level/2',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-        severity:'2',\
+        severity:'CRITICAL',\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
         setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
@@ -928,7 +928,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         t:none,t:urlDecodeUni,\
         block,\
         msg:'SQL Comment Sequence Detected.',\
-        severity:'2',\
+        severity:'CRITICAL',\
         capture,\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
@@ -958,7 +958,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         block,\
         msg:'SQL Hex Encoding Identified',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-        severity:'2',\
+        severity:'CRITICAL',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'WASCTC/WASC-19',\
         tag:'OWASP_TOP_10/A1',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -891,7 +891,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'paranoia-level/2',\
         setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
-        setvar:tx.sql_injection_score=+1,\
+        setvar:tx.sql_injection_score=+%{tx.warning_anomaly_score},\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}"
 
@@ -938,7 +938,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         tag:'PCI/6.5.2',\
         tag:'paranoia-level/2',\
         setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-        setvar:tx.sql_injection_score=+1,\
+        setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}"
 
@@ -1036,7 +1036,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQ
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'paranoia-level/3',\
         setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
-        setvar:tx.sql_injection_score=+1,\
+        setvar:tx.sql_injection_score=+%{tx.warning_anomaly_score},\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}"
 
@@ -1060,7 +1060,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'paranoia-level/3',\
         setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
-        setvar:tx.sql_injection_score=+1,\
+        setvar:tx.sql_injection_score=+%{tx.warning_anomaly_score},\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}"
 
@@ -1093,7 +1093,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQ
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'paranoia-level/4',\
         setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
-        setvar:tx.sql_injection_score=+1,\
+        setvar:tx.sql_injection_score=+%{tx.warning_anomaly_score},\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}"
 
@@ -1117,7 +1117,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'paranoia-level/4',\
         setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
-        setvar:tx.sql_injection_score=+1,\
+        setvar:tx.sql_injection_score=+%{tx.warning_anomaly_score},\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}"
 


### PR DESCRIPTION
I noticed that some SQLI scores were not matching the total scores. Seems that some rules were only incrementing the `tx.sql_injection_score` by one instead of the actual score macro. That doesn't seem correct to me.

Also, some severity tags in SQLI file were either not matching the score, or they were numeric instead of using the standard keyword.