### PR TITLE
Restricting 920270 and adding stricter siblings

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -600,7 +600,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
    block,\
    msg:'Invalid character in request (null character)',\
    id:'920270',\
-   severity:'ERROR',\
+   severity:'CRITICAL',\
    t:none,t:urlDecodeUni,\
    tag:'application-multi',\
    tag:'language-multi',\
@@ -1253,7 +1253,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 32-126,1
    block,\
    msg:'Invalid character in request (non printable characters)',\
    id:920271,\
-   severity:'ERROR',\
+   severity:'CRITICAL',\
    t:none,t:urlDecodeUni,\
    tag:'application-multi',\
    tag:'language-multi',\
@@ -1262,7 +1262,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 32-126,1
    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
    tag:'paranoia-level/2',\
    setvar:'tx.msg=%{rule.msg}',\
-   setvar:tx.anomaly_score=+%{tx.error_anomaly_score},\
+   setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
 
 
@@ -1284,7 +1284,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
    block,\
    msg:'Invalid character in request (outside of printable chars below ascii 127)',\
    id:920272,\
-   severity:'ERROR',\
+   severity:'CRITICAL',\
    t:none,t:urlDecodeUni,\
    tag:'application-multi',\
    tag:'language-multi',\
@@ -1293,7 +1293,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
    tag:'paranoia-level/3',\
    setvar:'tx.msg=%{rule.msg}',\
-   setvar:tx.anomaly_score=+%{tx.error_anomaly_score},\
+   setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
 
 
@@ -1316,7 +1316,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
    block,\
    msg:'Invalid character in request (outside of very strict set)',\
    id:920273,\
-   severity:'ERROR',\
+   severity:'CRITICAL',\
    t:none,t:urlDecodeUni,\
    tag:'application-multi',\
    tag:'language-multi',\
@@ -1325,7 +1325,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
    tag:'paranoia-level/4',\
    setvar:'tx.msg=%{rule.msg}',\
-   setvar:tx.anomaly_score=+%{tx.error_anomaly_score},\
+   setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
 
 #
@@ -1340,7 +1340,7 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
    block,\
    msg:'Invalid character in request headers (outside of very strict set)',\
    id:920274,\
-   severity:'ERROR',\
+   severity:'CRITICAL',\
    t:none,t:urlDecodeUni,\
    tag:'application-multi',\
    tag:'language-multi',\
@@ -1349,7 +1349,7 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
    tag:'paranoia-level/4',\
    setvar:'tx.msg=%{rule.msg}',\
-   setvar:tx.anomaly_score=+%{tx.error_anomaly_score},\
+   setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
 
 

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -558,28 +558,48 @@ SecRule REQUEST_URI|REQUEST_BODY "\%u[fF]{2}[0-9a-fA-F]{2}" \
 
 #
 # Restrict type of characters sent
-# NOTE In order to be broad and support localized applications this rule
-#      only validates that NULL Is not used.
 #
-#	   The strict policy version also validates that protocol and application 
-#	   generated fields are limited to printable ASCII. 
+# This is a rule with multiple stricter siblings that grows more
+# restrictive in higher paranoia levels.
 #
 # -=[ Rule Logic ]=-
-# This rule uses the @validateByteRange operator to look for Nul Bytes (%00).
+# This rule uses the @validateByteRange operator to restrict the request
+# payloads.
 #
-# -=[ References ]=-
-# http://i-technica.com/whitestuff/asciichart.html
+# -=[ Targets and ASCII Ranges ]=-
 #
+# 920270: PL1 : REQUEST_URI, REQUEST_HEADERS, ARGS and ARGS_NAMES
+# 	  ASCII 1-255 : Full ASCII range without null character
+#
+# 920271: PL2 : REQUEST_URI, REQUEST_HEADERS, ARGS and ARGS_NAMES
+#         ASCII 32-126,128-255 : Full visible ASCII range
+#
+# 920272: PL3 : REQUEST_URI, REQUEST_HEADERS, ARGS, ARGS_NAMES and REQUEST_BODY
+#         ASCII 32-36,38-126 : Visible lower ASCII range without percent symbol
+#
+# 920273: PL4 : ARGS, ARGS_NAMES and REQUEST_BODY
+#         ASCII 38,44-46,48-58,61,65-90,95,97-122
+#               A-Z a-z 0-9 = - _ . , : &
+#
+# 920274: PL4 : REQUEST_HEADERS without User-Agent, Referer and Cookie
+#         ASCII 32,34,38,42-59,61,65-90,95,97-122
+#               A-Z a-z 0-9 = - _ . , : & " * + / SPACE
+#
+# REQUEST_URI and REQUEST_HEADERS User-Agent, Referer and Cookie are very hard
+# to restrict beyond the limits in 920272.
+#
+# 920274 generally has few positives. However, it would detect rare attacks
+# on Accept request headers and friends.
 
-SecRule ARGS|ARGS_NAMES|REQUEST_HEADERS|!REQUEST_HEADERS:Referer "@validateByteRange 1-255" \
+SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
   "phase:request,\
    rev:'2',\
    ver:'OWASP_CRS/3.0.0',\
    maturity:'9',\
    accuracy:'9',\
    block,\
-   msg:'Invalid character in request',\
-   id:920270,\
+   msg:'Invalid character in request (null character)',\
+   id:'920270',\
    severity:'ERROR',\
    t:none,t:urlDecodeUni,\
    tag:'application-multi',\
@@ -1124,6 +1144,7 @@ SecRule ARGS "\%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
    setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
 
+
 #
 # Missing Accept Header
 #
@@ -1220,12 +1241,60 @@ SecRule REQUEST_BASENAME "\.(.*)$" \
         setvar:tx.%{rule.id}-OWASP_CRS/POLICY/EXT_RESTRICTED-%{matched_var_name}=%{matched_var}"
 
 
+#
+# PL2: This is a stricter sibling of 920270.
+#
+SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 32-126,128-255" \
+  "phase:request,\
+   rev:'2',\
+   ver:'OWASP_CRS/3.0.0',\
+   maturity:'9',\
+   accuracy:'9',\
+   block,\
+   msg:'Invalid character in request (non printable characters)',\
+   id:920271,\
+   severity:'ERROR',\
+   t:none,t:urlDecodeUni,\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
+   tag:'paranoia-level/2',\
+   setvar:'tx.msg=%{rule.msg}',\
+   setvar:tx.anomaly_score=+%{tx.error_anomaly_score},\
+   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
+
 
 SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:1,id:920015,nolog,pass,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:2,id:920016,nolog,pass,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
 # -= Paranoia Level 3 =- (apply only when tx.paranoia_level is sufficiently high: 3 or higher)
 #
+
+#
+# PL 3: This is a stricter sibling of 920270. Ascii range: Printable characters in the low range
+#
+SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 32-36,38-126" \
+  "phase:request,\
+   rev:'2',\
+   ver:'OWASP_CRS/3.0.0',\
+   maturity:'9',\
+   accuracy:'9',\
+   block,\
+   msg:'Invalid character in request (outside of printable chars below ascii 127)',\
+   id:920272,\
+   severity:'ERROR',\
+   t:none,t:urlDecodeUni,\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
+   tag:'paranoia-level/3',\
+   setvar:'tx.msg=%{rule.msg}',\
+   setvar:tx.anomaly_score=+%{tx.error_anomaly_score},\
+   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
 
 
 
@@ -1235,6 +1304,53 @@ SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:2,id:920018,nolog,pass,skipAfter:END-RE
 # -= Paranoia Level 4 =- (apply only when tx.paranoia_level is sufficiently high: 4 or higher)
 #
 
+#
+# This is a stricter sibling of 920270.
+#
+SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90,95,97-122" \
+  "phase:request,\
+   rev:'2',\
+   ver:'OWASP_CRS/3.0.0',\
+   maturity:'9',\
+   accuracy:'9',\
+   block,\
+   msg:'Invalid character in request (outside of very strict set)',\
+   id:920273,\
+   severity:'ERROR',\
+   t:none,t:urlDecodeUni,\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
+   tag:'paranoia-level/4',\
+   setvar:'tx.msg=%{rule.msg}',\
+   setvar:tx.anomaly_score=+%{tx.error_anomaly_score},\
+   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
+
+#
+# This is a stricter sibling of 920270.
+#
+SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!REQUEST_HEADERS:Cookie "@validateByteRange 32,34,38,42-59,61,65-90,95,97-122" \
+  "phase:request,\
+   rev:'2',\
+   ver:'OWASP_CRS/3.0.0',\
+   maturity:'9',\
+   accuracy:'9',\
+   block,\
+   msg:'Invalid character in request headers (outside of very strict set)',\
+   id:920274,\
+   severity:'ERROR',\
+   t:none,t:urlDecodeUni,\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
+   tag:'paranoia-level/4',\
+   setvar:'tx.msg=%{rule.msg}',\
+   setvar:tx.anomaly_score=+%{tx.error_anomaly_score},\
+   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
 
 
 #


### PR DESCRIPTION
Finally, I have my PR for issue #323:

Here are the ranged employed for the rule and its siblings:

```
920270: PL1 : REQUEST_URI, REQUEST_HEADERS, ARGS and ARGS_NAMES
 	  ASCII 1-255 : Full ASCII range without null character

920271: PL2 : REQUEST_URI, REQUEST_HEADERS, ARGS and ARGS_NAMES
         ASCII 32-126,128-255 : Visible ASCII range 

920272: PL3 : REQUEST_URI, REQUEST_HEADERS, ARGS, ARGS_NAMES and REQUEST_BODY
         ASCII 32-36,38-126 : Visible lower ASCII range without percent symbol

920273: PL4 : ARGS, ARGS_NAMES and REQUEST_BODY 
         ASCII 38,44-46,48-58,61,65-90,95,97-122
               & , - . 0-9 : =  A-Z _ a-z 

920274: PL4 : REQUEST_HEADERS without User-Agent, Referer and Cookie
         ASCII 32,34,38,42-59,61,65-90,95,97-122
               SPACE " &  * + , - . / 0-9 : = A-Z  _ a-z 	
```

Stats for 8K vanilla requests and 26K attack requests:
```
Rule   PL  FP %  (FP #)   RealP % (RealP #)
920270 PL1 0%    (   0)   3.4% ( 912)
920271 PL2 0%    (   4)	  5.4% (1452)
920272 PL3 3.4%  ( 285)	 23.5% (6259)
920273 PL4 29.9% (2492)	 37.4% (9963)
920274 PL4 0.4%  (  36)	    0% (   0)
```

The results of 920274 are a bit odd. For the vanilla requests, the FPs are rare and limited to
Ajax calls with special custom request headers. Something that is simple to tune for
a PL4 installation. The fact that the attack requests are not triggering anything here is that
the attack traffic is focusing on the User-Agent and Referer headers which are not covered.
However, the rule still makes sense, as rare attacks targeting other request headers like
Accept, etc. will be detected.

You could argue that 920274 should be moved to PL3 and REQUEST_HEADERS should be 
taken out of 920272, where they are less restricted at PL3. However, 920272 applies 
to User-Agent, Referer and Cookie headers as well. So they would need to be covered 
in an updated 920272 or in a new separate rule with the same restrictions.
