### PR TITLE
Fix 920160 by making it phase 1

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -240,7 +240,7 @@ SecRule REQUEST_HEADERS:Content-Length "!^\d+$" \
   rev:'1',\
   maturity:'9',\
   accuracy:'9',\
-  phase:request,\
+  phase:1,\
   block,\
   logdata:'%{matched_var}',\
   t:none,\


### PR DESCRIPTION
920160 has an issue where if the request is invalid Apache will response before phase:2 with a 400 bad request. It is looking for a content type that is non-numeric. Generally we tested this with something like content-type: 3; which has an invalid char. Phase 2 can't reach this so we shifted to phase 1.