### PR TITLE
SQLi: move 'HAVING injections' to PL3

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1011,7 +1011,8 @@ SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:2,id:942016,nolog,pass,skipAfter:END-RE
 # injections with HAVING should be detected by libinjection
 # (rule 942100).
 #
-
+# This is a stricter sibling of rule 942250.
+#
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i)\W+\d*?\s*?having\s*?[^\s\-]" \
 	"phase:request,\
 	rev:'1',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -240,7 +240,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:merge.*?using\s*?\()|(execute\s*?immediate\s*?[\"'`])|(?:\W+\d*?\s*?having\s*?[^\s\-])|(?:match\s*?[\w(),+-]+\s*?against\s*?\())" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:merge.*?using\s*?\()|(execute\s*?immediate\s*?[\"'`])|(?:match\s*?[\w(),+-]+\s*?against\s*?\())" \
 	"phase:request,\
         rev:'2',\
         ver:'OWASP_CRS/3.0.0',\
@@ -249,7 +249,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	capture,\
 	t:none,t:urlDecodeUni,\
 	block,\
-	msg:'Detects MATCH AGAINST, MERGE, EXECUTE IMMEDIATE and HAVING injections',\
+	msg:'Detects MATCH AGAINST, MERGE and EXECUTE IMMEDIATE injections',\
 	id:942250,\
         tag:'application-multi',\
         tag:'language-multi',\
@@ -1001,6 +1001,40 @@ SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:2,id:942016,nolog,pass,skipAfter:END-RE
 #
 # -= Paranoia Level 3 =- (apply only when tx.paranoia_level is sufficiently high: 3 or higher)
 #
+
+
+#
+# [ SQL HAVING queries ]
+#
+# This pattern was split off from rule 942250 due to frequent
+# false positives in English text. Testing showed that SQL
+# injections with HAVING should be detected by libinjection
+# (rule 942100).
+#
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i)\W+\d*?\s*?having\s*?[^\s\-]" \
+	"phase:request,\
+	rev:'1',\
+	ver:'OWASP_CRS/3.0.0',\
+	maturity:'9',\
+	accuracy:'6',\
+	capture,\
+	t:none,t:urlDecodeUni,\
+	block,\
+	msg:'Detects HAVING injections',\
+	id:942251,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-sqli',\
+	tag:'paranoia-level/3',\
+	tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
 #
 # [ SQL Injection Character Anomaly Usage ]


### PR DESCRIPTION
Fixes false positives from detecting `HAVING` SQLi injections (see #409).

On the dataset of 126k Reddit comments, rule 942250 (Detects MATCH AGAINST, MERGE, EXECUTE IMMEDIATE and HAVING injections) matched 2142 times (1.7%). Rule 942250 is now the biggest source of false positives on that dataset (after rule 932100 was reworked). Even a string like `I am having trouble` matches this rule.

The `HAVING...` part of rule 942250's regexp looks to be somewhat redundant, since libinjection (rule 942100) also catches HAVING syntax. All sqlmap traffic that hit this rule had score 20. So the pattern might be safe to move to higher levels.

After splitting this part off to rule 942251 at PL3, all the false positives from this rule on the Reddit dataset are gone!