### PR TITLE
fix rule 910100 severity tag to match its score

### DIFF
--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -57,7 +57,7 @@ SecRule IP:BLOCK "@eq 1" \
 #
 SecRule TX:HIGH_RISK_COUNTRY_CODES "!^$" \
  "msg:'Client IP is from a HIGH Risk Country Location.',\
-  severity:'WARNING',\
+  severity:'CRITICAL',\
   id:910100,\
   phase:request,\
   block,\


### PR DESCRIPTION
Rule 910100 (Country block) has a WARNING severity, but it adds critical anomaly score and also adds to ip.block, so the severity should reflect this.