### PR TITLE
Updating DOS functionality to fix extension checking

### DIFF
--- a/modsecurity_crs_10_setup.conf.example
+++ b/modsecurity_crs_10_setup.conf.example
@@ -451,7 +451,7 @@ SecAction \
   pass,\
   t:none,\
   setvar:'tx.allowed_methods=GET HEAD POST OPTIONS', \
-  setvar:'tx.static_resources=.jpg/ .jpeg/ .png/ .gif/ .js/ .css/ .ico/ .svg/ .webp/', \
+  setvar:'tx.static_resources=/.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/', \
   setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|text/plain', \
   setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2', \
   setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/', \
@@ -548,7 +548,7 @@ SecAction \
 #
 # You may also want to check out the definition of tx.static_resources in rule 900012.
 #
-#SecAction \
+SecAction \
  "id:'900015',\
   phase:1,\
   nolog,\

--- a/modsecurity_crs_10_setup.conf.example
+++ b/modsecurity_crs_10_setup.conf.example
@@ -548,7 +548,7 @@ SecAction \
 #
 # You may also want to check out the definition of tx.static_resources in rule 900012.
 #
-SecAction \
+#SecAction \
  "id:'900015',\
   phase:1,\
   nolog,\

--- a/modsecurity_crs_10_setup.conf.example
+++ b/modsecurity_crs_10_setup.conf.example
@@ -451,7 +451,7 @@ SecAction \
   pass,\
   t:none,\
   setvar:'tx.allowed_methods=GET HEAD POST OPTIONS', \
-  setvar:'tx.static_resources=/.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/', \
+  setvar:'tx.static_extensions=/.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/', \
   setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|text/plain', \
   setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2', \
   setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/', \

--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -154,9 +154,9 @@ SecRule IP:DOS_BLOCK "@eq 1" \
 
 
 #
-# DOS Counter: Count the number of requests to non-static resoures
+# DOS Counter: Count the number of requests to non-static resources
 #
-SecRule REQUEST_BASENAME "(\..*)?$" \
+SecRule REQUEST_BASENAME ".*?(\.[a-z0-9]{1,4})?$" \
 	"phase:5,\
 	id:912150,\
 	t:none,\
@@ -171,7 +171,7 @@ SecRule REQUEST_BASENAME "(\..*)?$" \
    	setvar:tx.extension=/%{TX.1}/,\
 	chain"
 	SecRule TX:EXTENSION "!@within %{tx.static_resources}" \
-		setvar:ip.dos_counter=+1"
+		"setvar:ip.dos_counter=+1"
 
 
 #

--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -156,7 +156,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
 #
 # DOS Counter: Count the number of requests to non-static resoures
 #
-SecRule REQUEST_BASENAME "\.(.*)$" \
+SecRule REQUEST_BASENAME "(\..*)?$" \
 	"phase:5,\
 	id:912150,\
 	t:none,\
@@ -168,9 +168,9 @@ SecRule REQUEST_BASENAME "\.(.*)$" \
 	tag:'platform-multi',\
 	tag:'attack-dos',\
 	capture,\
-   	setvar:tx.extension=%{TX.1}/,\
+   	setvar:tx.extension=/%{TX.1}/,\
 	chain"
-	SecRule TX:EXTENSION "!@within %{tx.static_resources}/" \
+	SecRule TX:EXTENSION "!@within %{tx.static_resources}" \
 		setvar:ip.dos_counter=+1"
 
 

--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -156,7 +156,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
 #
 # DOS Counter: Count the number of requests to non-static resources
 #
-SecRule REQUEST_BASENAME ".*?(\.[a-z0-9]{1,4})?$" \
+SecRule REQUEST_BASENAME ".*?(\.[a-z0-9]{1,10})?$" \
 	"phase:5,\
 	id:912150,\
 	t:none,\
@@ -170,7 +170,7 @@ SecRule REQUEST_BASENAME ".*?(\.[a-z0-9]{1,4})?$" \
 	capture,\
    	setvar:tx.extension=/%{TX.1}/,\
 	chain"
-	SecRule TX:EXTENSION "!@within %{tx.static_resources}" \
+	SecRule TX:EXTENSION "!@within %{tx.static_extensions}" \
 		"setvar:ip.dos_counter=+1"
 
 


### PR DESCRIPTION
Fix for #462 , good find @lifeforms 
It turns out there were a few issues here. First the old check didn't add the '.' infront of the extension even though it was checking for it. Secondly, it added a slash at the end even after it was set in setvar to have a trailling slash, so it would never match.

If tx.1 isn't populated it acts as an empty string, which is fine -- in most cases. Here it was a problem because we'd append the / at the end which would match all the /'s normally at the end. 
```/ is within .ico/```
I updated this so that the extension is surrounded by slashes on both sides within setup.conf (this will conflict with the setup.conf fix (so we have to remember to update that or push it first and update this).

Now it checks if 
```// is in /.ico/``` which it isn't.
of course .favicon.ico will now do /.ico/ is in /.ico/ so we have no problem.

