### PR TITLE
Added two rules against HTTP Parameter Pollution

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -251,6 +251,61 @@ SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:2,id:921016,nolog,pass,skipAfter:END-RE
 #
 # -= Paranoia Level 3 =- (apply only when tx.paranoia_level is sufficiently high: 3 or higher)
 #
+#
+
+# -=[ HTTP Parameter Polution ]=-
+#
+# [ Rule Logic ]
+# These rules look for multiple parameters with the same name.
+# One HPP attack vector is to try evade signature filters by distributing the
+# attack payload across multiple parameters with the same name.
+# This works as many security devices only apply signatures to individual
+# parameter payloads, however the back-end web application may (in the case
+# of ASP.NET) consolidate all of the payloads into one thus making the
+# attack payload active.
+#
+# [ References ]
+# http://tacticalwebappsec.blogspot.com/2009/05/http-parameter-pollution.html
+#
+SecRule ARGS_NAMES "." \
+        "phase:request,\
+        id:921170,\
+        rev:'1',\
+        ver:'OWASP_CRS/3.0.0',\
+        pass,\
+        nolog,\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-protocol',\
+        tag:'paranoia-level/3',\
+        setvar:'TX.paramcounter_%{MATCHED_VAR_NAME}=+1'"
+ 
+SecRule TX:/paramcounter_.*/ "@gt 1" \
+        "msg:'HTTP Parameter Pollution (%{TX.1})',\
+        chain,\
+        phase:request,\
+        id:921180,\
+        rev:'1',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'7',\
+        accuracy:'8',\
+        severity:'CRITICAL',\
+        pass,\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-protocol',\
+        tag:'paranoia-level/3',\
+        logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        pass"
+                SecRule MATCHED_VARS_NAMES "TX:paramcounter_(.*)" \
+                     "capture,\
+                     setvar:tx.msg=%{rule.msg},\
+                     setvar:tx.http_violation_score=+%{tx.critical_anomaly_score},\
+                     setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+                     setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HTTP_PARAMETER_POLLUTION-%{matched_var_name}=%{tx.0}" 
+
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:1,id:921017,nolog,pass,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -257,9 +257,9 @@ SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:2,id:921016,nolog,pass,skipAfter:END-RE
 #
 # [ Rule Logic ]
 # These rules look for multiple parameters with the same name.
-# 921170 counts the occurrences of the individual parameters. 
+# 921170 counts the occurrences of the individual parameters.
 # 921180 checks if any counter is > 1.
-# 
+#
 # One HPP attack vector is to try evade signature filters by distributing the
 # attack payload across multiple parameters with the same name.
 # This works as many security devices only apply signatures to individual

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -257,6 +257,9 @@ SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:2,id:921016,nolog,pass,skipAfter:END-RE
 #
 # [ Rule Logic ]
 # These rules look for multiple parameters with the same name.
+# 921170 counts the occurrences of the individual parameters. 
+# 921180 checks if any counter is > 1.
+# 
 # One HPP attack vector is to try evade signature filters by distributing the
 # attack payload across multiple parameters with the same name.
 # This works as many security devices only apply signatures to individual
@@ -266,11 +269,12 @@ SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:2,id:921016,nolog,pass,skipAfter:END-RE
 #
 # [ References ]
 # http://tacticalwebappsec.blogspot.com/2009/05/http-parameter-pollution.html
+# https://capec.mitre.org/data/definitions/460.html
 #
 SecRule ARGS_NAMES "." \
         "phase:request,\
         id:921170,\
-        rev:'1',\
+        rev:'2',\
         ver:'OWASP_CRS/3.0.0',\
         pass,\
         nolog,\
@@ -279,14 +283,15 @@ SecRule ARGS_NAMES "." \
         tag:'platform-multi',\
         tag:'attack-protocol',\
         tag:'paranoia-level/3',\
+        tag:'CAPEC-460',\
         setvar:'TX.paramcounter_%{MATCHED_VAR_NAME}=+1'"
- 
+
 SecRule TX:/paramcounter_.*/ "@gt 1" \
         "msg:'HTTP Parameter Pollution (%{TX.1})',\
         chain,\
         phase:request,\
         id:921180,\
-        rev:'1',\
+        rev:'2',\
         ver:'OWASP_CRS/3.0.0',\
         maturity:'7',\
         accuracy:'8',\
@@ -297,13 +302,14 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
         tag:'platform-multi',\
         tag:'attack-protocol',\
         tag:'paranoia-level/3',\
+        tag:'CAPEC-460',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}'"
                 SecRule MATCHED_VARS_NAMES "TX:paramcounter_(.*)" \
                      "capture,\
                      setvar:tx.msg=%{rule.msg},\
                      setvar:tx.http_violation_score=+%{tx.critical_anomaly_score},\
                      setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-                     setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HTTP_PARAMETER_POLLUTION-%{matched_var_name}=%{tx.0}" 
+                     setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HTTP_PARAMETER_POLLUTION-%{matched_var_name}=%{tx.0}"
 
 
 

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -297,8 +297,7 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
         tag:'platform-multi',\
         tag:'attack-protocol',\
         tag:'paranoia-level/3',\
-        logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-        pass"
+        logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}'"
                 SecRule MATCHED_VARS_NAMES "TX:paramcounter_(.*)" \
                      "capture,\
                      setvar:tx.msg=%{rule.msg},\


### PR DESCRIPTION
I've added the HTTP Parameter Pollution rules to solve issue #400. 

What I've done:
- Added 2 new rules: id: 921170 and id: 921180 (id 921180 is chained)
- Put them in REQUEST-921-PROTOCOL-ATTACK.conf (another possibility was REQUEST-920-PROTOCOL-ENFORCEMENT.conf, but I think this suits best)
- Added a description which I partially took from old experimental_rules/modsecurity_crs_40_http_parameter_pollution.conf 
