### PR TITLE
new rule: abnormal character escapes in PL4 (920460)

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1349,6 +1349,58 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
 
 
+# -=[ Abnormal Character Escapes ]=-
+#
+# [ Rule Logic ]
+# Consider the following payload: arg=cat+/e\tc/pa\ssw\d
+# Here, \s and \d were only used to obfuscate the string passwd and a lot of
+# parsers will silently ignore the non-necessary escapes. The case with \t is
+# a bit different though, as \t is a natural escape for the TAB character,
+# so we will avoid this (and \n, \r, etc.).
+#
+# This rule aims to detect non-necessary, abnormal esacpes. You could say it is
+# a nice # way to forbid the backslash character where it is not needed.
+#
+# This is a new rule at paranoia level 4. We expect quite a few false positives
+# for this rule and we will later evaluate if the rule makes any sense at all.
+# The rule is redundant with 920273 and 920274 in PL4. But if the rule proofs
+# to be useful and false positives remain at a reasonable level, then it might
+# be shifted to PL3 in a future release, where it would be the only rule
+# covering the backslash escape.
+#
+# The rule construct is overly complex due to the fact that matching the
+# backslash character with \b did not work. \Q\\\E does match the backslash
+# character though. This is thus the base of the rule. We forbid the backslash
+# when followed by a list of basic ascii characters - unless the backslash
+# is preceded by another backslash character, which is being checked via a
+# negative look-behind construct. If that is the case, the backslash character
+# is allowed.
+#
+SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "(?<!\Q\\\E)\Q\\\E[cdeghijklmpqwxyz123456789]" \
+  "phase:request,\
+   id:920460,\
+   rev:'1',\
+   accuracy:'1',\
+   maturity:'1',\
+   ver:'OWASP_CRS/3.0.0',\
+   block,\
+   log,\
+   severity:'CRITICAL',\
+   capture,\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'paranoia-level/4',\
+   t:none,t:htmlEntityDecode,t:lowercase,\
+   ctl:auditLogParts=+E,\
+   logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+   setvar:'tx.msg=%{rule.msg}',\
+   setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
+   setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+   setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/ABNORMAL-ESCAPE-%{matched_var_name}=%{matched_var}"
+
+
 #
 # -= Paranoia Levels Finished =-
 #


### PR DESCRIPTION
```
# [ Rule Logic ]
# Consider the following payload: arg=cat+/e\tc/pa\ssw\d
# Here, \s and \d were only used to obfuscate the string passwd and a lot of
# parsers will silently ignore the non-necessary escapes. The case with \t is
# a bit different though, as \t is a natural escape for the TAB character,
# so we will avoid this (and \n, \r, etc.).
#
# This rule aims to detect non-necessary, abnormal esacpes. You could say it is
# a nice # way to forbid the backslash character where it is not needed.
#
# This is a new rule at paranoia level 4. We expect quite a few false positives
# for this rule and we will later evaluate if the rule makes any sense at all.
# The rule is redundant with 920273 and 920274 in PL4. But if the rule proofs
# to be useful and false positives remain at a reasonable level, then it might
# be shifted to PL3 in a future release, where it would be the only rule
# covering the backslash escape.
#
# The rule construct is overly complex due to the fact that matching the
# backslash character with \b did not work. \Q\\\E does match the backslash
# character though. This is thus the base of the rule. We forbid the backslash
# when followed by a list of basic ascii characters - unless the backslash
# is preceded by another backslash character, which is being checked via a
# negative look-behind construct. If that is the case, the backslash character
# is allowed.
```

See issue #393 for a detailed discussion.