### PR TITLE
Move 942460 (Repetitive Non-Word Characters) to PL3

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -971,30 +971,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}"
 
 
-#
-# -=[ Heuristic Checks ]=-
-#
-# [ Repeatative Non-Word Chars ]
-#
-# This rule attempts to identify when multiple (4 or more) non-word characters are repeated in sequence
-#
-SecRule ARGS "\W{4,}" \
-        "phase:request,\
-        capture,\
-        t:none,t:urlDecodeUni,\
-        block,\
-        id:942460,\
-        rev:'2',\
-        ver:'OWASP_CRS/3.0.0',\
-        maturity:'9',\
-        accuracy:'8',\
-        msg:'Meta-Character Anomaly Detection Alert - Repetative Non-Word Characters',\
-        logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-        tag:'paranoia-level/2',\
-        setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},setvar:'tx.msg=%{rule.msg}',\
-        setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION-%{matched_var_name}=%{tx.0}"
-
-
 
 SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:1,id:942015,nolog,pass,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:2,id:942016,nolog,pass,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
@@ -1099,6 +1075,31 @@ SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}"
 
+
+#
+# [ Repetitive Non-Word Characters ]
+#
+# This rule attempts to identify when multiple (4 or more) non-word characters
+# are repeated in sequence.
+#
+# The pattern may occur in some normal texts, e.g. "foo...." will match.
+#
+SecRule ARGS "\W{4,}" \
+        "phase:request,\
+        capture,\
+        t:none,t:urlDecodeUni,\
+        block,\
+        id:942460,\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'9',\
+        accuracy:'8',\
+        severity:'WARNING',\
+        tag:'paranoia-level/3',\
+        msg:'Meta-Character Anomaly Detection Alert - Repetitive Non-Word Characters',\
+        logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},setvar:'tx.msg=%{rule.msg}',\
+        setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION-%{matched_var_name}=%{tx.0}"
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:1,id:942017,nolog,pass,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"


### PR DESCRIPTION
Does exactly what it says on the tin.

Also add WARNING severity.

I didn't add attack/platform tags yet. There are many other heuristic rules in the SQLi file not having those tags, so there's not a clear template. Better to make a decision on that and fix them wholesale some time, maybe once we have some linting set up. But that's beyond this PR.

Resolves #449.