### PR TITLE
Correct session fixation detection logic

### DIFF
--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -79,7 +79,7 @@ SecRule ARGS_NAMES "@rx ^(jsessionid|aspsessionid|asp.net_sessionid|phpsession|p
 		SecRule REQUEST_HEADERS:Referer	"^(?:ht|f)tps?://(.*?)\/" \
 			"capture,\
 			chain" 
-        			SecRule TX:1 "!@beginsWith %{request_headers.host}" \
+        			SecRule TX:1 "!@endsWith %{request_headers.host}" \
 					"setvar:'tx.msg=%{rule.msg}',\
 					setvar:tx.session_fixation_score=+%{tx.critical_anomaly_score},\
 					setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\


### PR DESCRIPTION
- Session fixation detection (rule 943110) is currently structured as follows:
  1) Check to see if a common session variable is in use for POST/GET args
  2) Check and extract the hostname from the HTTP Referer header
  3) Check to see if the Referer _starts_ with the host specified in the host header

As structured, this check could be by-passed if a malicious Referer creates a sub
domain, where the start of the domain matches the domain specified in the host header.

For example, if we have a request with the following structure:

    -
      stage:
        input:
          headers:
            Host: somesite.com
            Referer: "https://somesite.com.attackersite.com/"
          method: GET
          port: 80
          uri: "/?phpsessid=asdfdasfadsads"
          version: HTTP/1.0

The request will be permitted. This change suggests that the operator is changed
to an endswith() or a @strreq (even more strict but may break Referers from sub domains).

Credits: Eric Hodel [discovered this issue]