### PR TITLE
fixed broken rule id 920450, explained the rule logic

### DIFF
--- a/modsecurity_crs_10_setup.conf.example
+++ b/modsecurity_crs_10_setup.conf.example
@@ -455,7 +455,7 @@ SecAction \
   setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|text/plain', \
   setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2', \
   setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/', \
-  setvar:'tx.restricted_headers=proxy lock-token content-range translate if'"
+  setvar:'tx.restricted_headers=/proxy/ /lock-token/ /content-range/ /translate/ /if/'"
 
 
 #

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1080,11 +1080,26 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
 # 
 # Restricted HTTP headers 
 #
-# Adding Proxy to the list as it used in a vulnerability.
-# https://access.redhat.com/security/vulnerabilities/httpoxy
+# -=[ Rule Logic ]=-
+# The use of certain headers is restricted. They are listed in the variable
+# TX.restricted_headers.
 #
-SecRule REQUEST_HEADERS_NAMES "@within %{tx.restricted_headers}" \
-  "msg:'HTTP header is restricted by policy',\
+# The headers are transformed into lowercase before the match.  In order to
+# make sure that only complete header names are matching, the names in
+# TX.restricted_headers are wrapped in slashes. This guarantees that the
+# header Range (-> /range/) is not matching the restricted header
+# /content-range/ for example.
+#
+# This is a chained rule, where the first rule fills a set of variables of the
+# form TX.header_name_<HEADER_NAME>. The second rule is then executed for all
+# variables of the form TX.header_name_<HEADER_NAME>.
+#
+# As a consequence of the construction of the rule, the alert message and the
+# alert data will not display the original header name Content-Range, but
+# /content-range/ instead.
+#
+SecRule REQUEST_HEADERS_NAMES "@rx ^(.*)$" \
+  "msg:'HTTP header is restricted by policy (%{MATCHED_VAR})',\
    severity:'CRITICAL',\
    phase:request,\
    t:none,\
@@ -1094,7 +1109,8 @@ SecRule REQUEST_HEADERS_NAMES "@within %{tx.restricted_headers}" \
    maturity:'9',\
    accuracy:'9',\
    id:920450,\
-   logdata:'%{matched_var}',\
+   capture,\
+   logdata:' Restricted header detected: %{matched_var}',\
    tag:'application-multi',\
    tag:'language-multi',\
    tag:'platform-multi',\
@@ -1107,9 +1123,12 @@ SecRule REQUEST_HEADERS_NAMES "@within %{tx.restricted_headers}" \
    tag:'OWASP_TOP_10/A7',\
    tag:'PCI/12.1',\
    t:lowercase,\
-   setvar:'tx.msg=%{rule.msg}',\
-   setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-   setvar:tx.%{rule.id}-OWASP_CRS/POLICY/HEADERS_RESTRICTED-%{matched_var_name}=%{matched_var}"
+   setvar:'tx.header_name_%{tx.0}=/%{tx.0}/',\
+   chain
+     SecRule TX:/^HEADER_NAME_/ "@within %{tx.restricted_headers}" \
+   	"setvar:'tx.msg=%{rule.msg}',\
+   	 setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+   	 setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/HEADERS_RESTRICTED-%{matched_var_name}=%{matched_var}'"
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:1,id:920013,nolog,pass,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1098,6 +1098,10 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
 # alert data will not display the original header name Content-Range, but
 # /content-range/ instead.
 #
+#
+# -=[ References ]=-
+# https://access.redhat.com/security/vulnerabilities/httpoxy (Header Proxy)
+#
 SecRule REQUEST_HEADERS_NAMES "@rx ^(.*)$" \
   "msg:'HTTP header is restricted by policy (%{MATCHED_VAR})',\
    severity:'CRITICAL',\


### PR DESCRIPTION
Bugfix for issue #490.

Please merge #463 before this one.

I do not think this rule ever worked the way it was advertised in 2.2.9. It would overload TX.header_name with all header names. I have not pull this apart with creating a set of vars `TX.header_name_%{TX.0}`. This seems to work as advertised.

@csanders-git : Please use the Range / Content-Range pair for a unit test.