### PR TITLE
Rename legacy regression_testing to debug mode

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -632,34 +632,39 @@ SecCollectionTimeout 600
 
 
 #
-# -- [[ Regression/Development Mode ]] -----------------------------------------
+# -- [[ Debug Mode ]] ----------------------------------------------------------
 #
-# To enable rule development and debugging, CRS has an optional development
-# mode that does not block requests, but instead sends detection information
+# To enable rule development and debugging, CRS has an optional debug mode
+# that does not block a request, but instead sends detection information
 # back to the HTTP client.
 #
 # This functionality is currently only supported with the Apache web server.
 # The Apache mod_headers module is required.
 #
-# In this mode, the webserver inserts "X-WAF-Events" / "X-WAF-Score"
-# response headers. Example:
+# In debug mode, the webserver inserts "X-WAF-Events" / "X-WAF-Score"
+# response headers whenever a debug client makes a request. Example:
 #
 #   X-WAF-Events: TX:930110-OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL-REQUEST_URI,
 #                TX:930120-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-ARGS:foo
 #   X-WAF-Score: Total=15; sqli=0; xss=0; rfi=0; lfi=15; rce=0; php=0; http=0; ses=0
 #
-# To enable this mode, include the RESPONSE-981-REGRESSION.conf file.
+# To enable debug mode, include the RESPONSE-981-DEBUG.conf file.
 # This file resides in a separate folder, as it is not compatible with
 # nginx and IIS.
 #
-# You must specify the source IP address/range where you will be running the
+# You must specify the source IP address/network where you will be running the
 # tests from. The source IP will BYPASS all CRS blocking, and will be sent the
 # response headers as specified above. Be careful to only list your private
 # IP addresses/networks here.
 #
-# Uncomment these rules to use this feature:
+# Tip: for regression testing of CRS or your own ModSecurity rules, you may
+# be interested in using the OWASP CRS regression testing suite instead.
+# View the file util/regression-tests/README for more information.
 #
-#Include /path/to/crs/util/regression-tests/RESPONSE-981-REGRESSION.conf
+# Uncomment these rules, filling in your CRS path and the source IP address,
+# to enable debug mode:
+#
+#Include /path/to/crs/util/debug/RESPONSE-981-DEBUG.conf
 #SecRule REMOTE_ADDR "@ipMatch 192.168.1.100" \
 # "id:'900980',\
 #  phase:1,\
@@ -667,7 +672,7 @@ SecCollectionTimeout 600
 #  pass,\
 #  t:none,\
 #  ctl:ruleEngine=DetectionOnly,\
-#  setvar:tx.regression_testing=1"
+#  setvar:tx.crs_debug_mode=1"
 
 
 #

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -644,9 +644,11 @@ SecCollectionTimeout 600
 # In debug mode, the webserver inserts "X-WAF-Events" / "X-WAF-Score"
 # response headers whenever a debug client makes a request. Example:
 #
+#   # curl -v 'http://192.168.1.100/?foo=../etc/passwd'
 #   X-WAF-Events: TX:930110-OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL-REQUEST_URI,
-#                TX:930120-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-ARGS:foo
-#   X-WAF-Score: Total=15; sqli=0; xss=0; rfi=0; lfi=15; rce=0; php=0; http=0; ses=0
+#                TX:930120-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-ARGS:foo,
+#                TX:932160-OWASP_CRS/WEB_ATTACK/RCE-ARGS:foo
+#   X-WAF-Score: Total=15; sqli=0; xss=0; rfi=0; lfi=10; rce=5; php=0; http=0; ses=0
 #
 # To enable debug mode, include the RESPONSE-981-DEBUG.conf file.
 # This file resides in a separate folder, as it is not compatible with

--- a/util/debug/RESPONSE-981-DEBUG.conf
+++ b/util/debug/RESPONSE-981-DEBUG.conf
@@ -11,9 +11,11 @@
 # In debug mode, the webserver inserts "X-WAF-Events" / "X-WAF-Score"
 # response headers whenever a debug client makes a request. Example:
 #
+#   # curl -v 'http://192.168.1.100/?foo=../etc/passwd'
 #   X-WAF-Events: TX:930110-OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL-REQUEST_URI,
-#                TX:930120-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-ARGS:foo
-#   X-WAF-Score: Total=15; sqli=0; xss=0; rfi=0; lfi=15; rce=0; php=0; http=0; ses=0
+#                TX:930120-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-ARGS:foo,
+#                TX:932160-OWASP_CRS/WEB_ATTACK/RCE-ARGS:foo
+#   X-WAF-Score: Total=15; sqli=0; xss=0; rfi=0; lfi=10; rce=5; php=0; http=0; ses=0
 #
 # To enable debug mode, see the section "Debug Mode" in crs-setup.conf.
 #

--- a/util/debug/RESPONSE-981-DEBUG.conf
+++ b/util/debug/RESPONSE-981-DEBUG.conf
@@ -1,15 +1,23 @@
 #
-# This section is only used during regression testing to externalize the matched
-# rule IDs in response headers so the testing client can verify matches from
-# remote ModSecurity installs.
+# -- [[ Debug Mode ]] ----------------------------------------------------------
 #
-# WARNING: You do not want this in normal operations as this will expose
-# the inner workings of your ModSecurity configurations.
+# To enable rule development and debugging, CRS has an optional debug mode
+# that does not block a request, but instead sends detection information
+# back to the HTTP client.
 #
-# Must enable/configure the TX:REGRESSION_TESTING variable in the
-# crs-setup.conf file.
+# This functionality is currently only supported with the Apache web server.
+# The Apache mod_headers module is required.
 #
-SecRule &TX:REGRESSION_TESTING|TX:REGRESSION_TESTING "@eq 0" \
+# In debug mode, the webserver inserts "X-WAF-Events" / "X-WAF-Score"
+# response headers whenever a debug client makes a request. Example:
+#
+#   X-WAF-Events: TX:930110-OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL-REQUEST_URI,
+#                TX:930120-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-ARGS:foo
+#   X-WAF-Score: Total=15; sqli=0; xss=0; rfi=0; lfi=15; rce=0; php=0; http=0; ses=0
+#
+# To enable debug mode, see the section "Debug Mode" in crs-setup.conf.
+#
+SecRule &TX:CRS_DEBUG_MODE|TX:CRS_DEBUG_MODE "@eq 0" \
 	"phase:4,\
 	t:none,\
 	nolog,\


### PR DESCRIPTION
As discussed in #497, renaming the old regression testing server side rules to "Debug Mode".

Added a reference in the setup to `util/regression-tests/README` for people who want to do formal regression testing. We can add more comments on FTW later if needed.