### PR TITLE
Shifted 920200 to PL2, 2 new siblings for PDFs

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -22,7 +22,6 @@
 #
 
 
-
 SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:1,id:920011,nolog,pass,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:2,id:920012,nolog,pass,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
@@ -323,8 +322,6 @@ SecRule REQUEST_METHOD "^POST$" \
 # http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
 # http://seclists.org/fulldisclosure/2011/Aug/175 
 #
-# 3. Identifies an excessive number of byte range fields within one request
-#  		
 SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "(\d+)\-(\d+)\," \
   "capture,\
    phase:request,\
@@ -348,28 +345,6 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "(\d+)\-(\d+)\," \
 		"setvar:'tx.msg=%{rule.msg}',\
 		setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
 		setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}"
-
-SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=(\d+)?\-(\d+)?\,\s?(\d+)?\-(\d+)?\,\s?(\d+)?\-(\d+)?\,\s?(\d+)?\-(\d+)?\,\s?(\d+)?\-(\d+)?\," \
-  "phase:request,\
-   capture,\
-   rev:'2',\
-   ver:'OWASP_CRS/3.0.0',\
-   maturity:'6',\
-   accuracy:'8',\
-   t:none,\
-   block,\
-   msg:'Range: Too many fields',\
-   logdata:'%{matched_var}',\
-   severity:'WARNING',\
-   id:920200,\
-   tag:'application-multi',\
-   tag:'language-multi',\
-   tag:'platform-multi',\
-   tag:'attack-protocol',\
-   tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
-   setvar:'tx.msg=%{rule.msg}',\
-   setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
-   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}"
 
 
 #
@@ -1172,6 +1147,79 @@ SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:920014,nolog,pass,skipAfter:END-RE
 # -= Paranoia Level 2 =- (apply only when tx.paranoia_level is sufficiently high: 2 or higher)
 #
 
+#
+# -=[ Rule Logic ]=-
+#
+# Check the number of range fields in the Range request header.
+#
+# An excessive number of Range request headers can be used to DoS a server.
+# The original CVE proposed an arbitrary upper limit of 5 range fields.
+#
+# Several clients are known to request PDF fields with up to 34 range
+# fields. Therefore the standard rule does not cover PDF files. This is
+# performed in two separate (stricter) siblings of this rule.
+#
+# 920200: PL2: Limit of 5 range header fields for all filenames outside of PDFs
+# 920201: PL2: Limit of 34 range header fields for PDFs
+# 920202: PL4: Limit of 5 range header fields for PDFs
+#
+# -=[ References ]=-
+# https://httpd.apache.org/security/CVE-2011-3192.txt
+
+SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?(\,\s)?){6,}" \
+  "phase:request,\
+   capture,\
+   rev:'2',\
+   ver:'OWASP_CRS/3.0.0',\
+   maturity:'6',\
+   accuracy:'8',\
+   t:none,\
+   block,\
+   msg:'Range: Too many fields (6 or more)',\
+   logdata:'%{matched_var}',\
+   severity:'WARNING',\
+   id:920200,\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
+   tag:'paranoia-level/2',\
+   chain
+   SecRule REQUEST_BASENAME "!@endsWith .pdf" \
+   	"setvar:'tx.msg=%{rule.msg}',\
+	 setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
+	 setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}"
+
+#
+# This is a sibling of rule 920200
+#
+
+SecRule REQUEST_BASENAME "@endsWith .pdf" \
+  "phase:request,\
+   capture,\
+   rev:'2',\
+   ver:'OWASP_CRS/3.0.0',\
+   maturity:'6',\
+   accuracy:'8',\
+   t:none,\
+   block,\
+   msg:'Range: Too many fields for pdf request (35 or more)',\
+   logdata:'%{matched_var}',\
+   severity:'WARNING',\
+   id:920201,\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
+   tag:'paranoia-level/2',\
+   chain
+   SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?(\,\s)?){35,}" \
+   	   "setvar:'tx.msg=%{rule.msg}',\
+	   setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
+	   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}"
+
 
 SecRule ARGS "\%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
   "phase:request,\
@@ -1292,6 +1340,36 @@ SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:2,id:920018,nolog,pass,skipAfter:END-RE
 #
 # -= Paranoia Level 4 =- (apply only when tx.paranoia_level is sufficiently high: 4 or higher)
 #
+
+# 
+# This is a stricter sibling of rule 920200
+#
+
+SecRule REQUEST_BASENAME "@endsWith .pdf" \
+  "phase:request,\
+   capture,\
+   rev:'2',\
+   ver:'OWASP_CRS/3.0.0',\
+   maturity:'6',\
+   accuracy:'8',\
+   t:none,\
+   block,\
+   msg:'Range: Too many fields for pdf request (6 or more)',\
+   logdata:'%{matched_var}',\
+   severity:'WARNING',\
+   id:920202,\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
+   tag:'paranoia-level/4',\
+   chain
+   SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?(\,\s)?){6,}" \
+   	   "setvar:'tx.msg=%{rule.msg}',\
+	   setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
+	   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}"
+
 
 #
 # This is a stricter sibling of 920270.

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1166,7 +1166,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:920014,nolog,pass,skipAfter:END-RE
 # -=[ References ]=-
 # https://httpd.apache.org/security/CVE-2011-3192.txt
 
-SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?\s*,?\s*){6,}" \
+SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?\s*,?\s*){6}" \
   "phase:request,\
    capture,\
    rev:'2',\
@@ -1215,7 +1215,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
    tag:'paranoia-level/2',\
    chain
-   SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?\s*,?\s*){35,}" \
+   SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?\s*,?\s*){35}" \
    	   "setvar:'tx.msg=%{rule.msg}',\
 	   setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
 	   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}"
@@ -1365,7 +1365,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
    tag:'paranoia-level/4',\
    chain
-   SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?\s*,?\s*){6,}" \
+   SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?\s*,?\s*){6}" \
    	   "setvar:'tx.msg=%{rule.msg}',\
 	   setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
 	   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}"

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1166,7 +1166,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:920014,nolog,pass,skipAfter:END-RE
 # -=[ References ]=-
 # https://httpd.apache.org/security/CVE-2011-3192.txt
 
-SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?(\,\s)?){6,}" \
+SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?\s*,?\s*){6,}" \
   "phase:request,\
    capture,\
    rev:'2',\
@@ -1215,7 +1215,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
    tag:'paranoia-level/2',\
    chain
-   SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?(\,\s)?){35,}" \
+   SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?\s*,?\s*){35,}" \
    	   "setvar:'tx.msg=%{rule.msg}',\
 	   setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
 	   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}"
@@ -1365,7 +1365,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
    tag:'paranoia-level/4',\
    chain
-   SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?(\,\s)?){6,}" \
+   SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d+)?\s*,?\s*){6,}" \
    	   "setvar:'tx.msg=%{rule.msg}',\
 	   setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
 	   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}"


### PR DESCRIPTION
Implements a solution for issue #499 as discussed in that thread.

I redocumented the rule, added a reference to the exact CVE in question. The regex has also been simplified. Please check.

Curl requests to check / test the rules:

```
# This should PASS (PL2):
curl -v localhost/index.html -H "range: bytes=10-11, 20-21, 30-31, 40-41, 50-51"

# This should FAIL with rule 920200 (PL2):
curl -v localhost/index.html -H "range: bytes=10-11, 20-21, 30-31, 40-41, 50-51, 60-61"

# This should PASS (PL2):
curl -v localhost/index.pdf -H "range: bytes=10-11, 20-21, 30-31, 40-41, 50-51, 60-61"

# This should PASS (PL2):
curl -v localhost/index.pdf -H "range: bytes=10-11, 20-21, 30-31, 40-41, 50-51, 60-61, 70-71, 80-81, 90-91, 100-101, 110-11, 120-21, 130-31, 140-41, 150-51, 160-61, 170-71, 180-81, 190-91, 200-101, 210-11, 220-21, 230-31, 240-41, 250-51, 260-61, 270-71, 280-81, 290-91, 300-101, 310-311, 320-321, 330-331, 340-341"

# This should FAIL with rule 920201 (PL2):
curl -v localhost/index.pdf -H "range: bytes=10-11, 20-21, 30-31, 40-41, 50-51, 60-61, 70-71, 80-81, 90-91, 100-101, 110-11, 120-21, 130-31, 140-41, 150-51, 160-61, 170-71, 180-81, 190-91, 200-101, 210-11, 220-21, 230-31, 240-41, 250-51, 260-61, 270-71, 280-81, 290-91, 300-101, 310-311, 320-321, 330-331, 340-341, 350-351"

# This should FAIL with rule 920202 (PL4):
curl -v localhost/index.pdf -H "range: bytes=10-11, 20-21, 30-31, 40-41, 50-51, 60-61"
```