### PR TITLE
Moved 920320 to PL2, new comments, removed marker END_UA_CHECK

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -692,36 +692,14 @@ SecRule REQUEST_HEADERS:Accept "^$" \
 
 
 #
-# Missing/Empty User-Agent Header
+# Empty User-Agent Header
 #
 # -=[ Rule Logic ]=-
-# These rules will first check to see if a User-Agent header is present.
-# The second check is to see if a User-Agent header exists but is empty.
+# This rules will check to see if the User-Agent header is empty.
 #
-
-SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
-  "msg:'Request Missing a User Agent Header',\
-   severity:'NOTICE',\
-   phase:request,\
-   rev:'1',\
-   ver:'OWASP_CRS/3.0.0',\
-   maturity:'9',\
-   accuracy:'9',\
-   t:none,\
-   pass,\
-   id:920320,\
-   tag:'application-multi',\
-   tag:'language-multi',\
-   tag:'platform-multi',\
-   tag:'attack-protocol',\
-   tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_UA',\
-   tag:'WASCTC/WASC-21',\
-   tag:'OWASP_TOP_10/A7',\
-   tag:'PCI/6.5.10',\
-   setvar:'tx.msg=%{rule.msg}',\
-   setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
-   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var},\
-   skipAfter:END_UA_CHECK"
+# Note that there is a second rule, 920320, which will check for
+# the existence of the User-Agent header.
+#
 
 SecRule REQUEST_HEADERS:User-Agent "^$" \
   "msg:'Empty User Agent Header',\
@@ -738,12 +716,10 @@ SecRule REQUEST_HEADERS:User-Agent "^$" \
    tag:'language-multi',\
    tag:'platform-multi',\
    tag:'attack-protocol',\
-   tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_UA',\
+   tag:'OWASP_CRS/PROTOCOL_VIOLATION/EMPTY_HEADER_UA',\
    setvar:'tx.msg=%{rule.msg}',\
    setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
-
-SecMarker END_UA_CHECK
 
 #
 # Missing Content-Type Header with Request Body 
@@ -1301,6 +1277,38 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 32-126,1
    setvar:'tx.msg=%{rule.msg}',\
    setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}"
+
+
+#
+# Missing User-Agent Header
+#
+# -=[ Rule Logic ]=-
+# This rules will check to see if there is a User-Agent header or not.
+#
+
+SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
+  "msg:'Missing User Agent Header',\
+   severity:'NOTICE',\
+   phase:request,\
+   rev:'1',\
+   ver:'OWASP_CRS/3.0.0',\
+   maturity:'9',\
+   accuracy:'9',\
+   t:none,\
+   pass,\
+   id:920320,\
+   tag:'application-multi',\
+   tag:'language-multi',\
+   tag:'platform-multi',\
+   tag:'attack-protocol',\
+   tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_UA',\
+   tag:'WASCTC/WASC-21',\
+   tag:'OWASP_TOP_10/A7',\
+   tag:'PCI/6.5.10',\
+   tag:'paranoia-level/2',\
+   setvar:'tx.msg=%{rule.msg}',\
+   setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+   setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:1,id:920015,nolog,pass,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"


### PR DESCRIPTION
See issue #516.

The rule was built as a couple with 920330. This coupling is now torn apart as 920320 moves to PL2. The skip and the skip marker END_UA_CHECK were thus no longer necessary.

Note that I also corrected the description and fixed one of the tags in 920330. Is this really correct this way? I think the previous tag was an error.

This replaces PR #529, which got a merge conflict after the range header stuff was merged.
