### PR TITLE
Added BFAC scanner, small improvements to scanner list

### DIFF
--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -21,6 +21,9 @@ autogetcontent
 # http://www.crossley-nilsen.com/Linux/Bilbo_-_Nessus_WEB/bilbo_-_nessus_web.html
 # dead? 2003
 bilbo
+# Backup File Artifacts Checker
+# https://github.com/mazen160/bfac
+BFAC
 # password cracker
 # http://sectools.org/tool/brutus/
 brutus
@@ -165,6 +168,7 @@ voideye
 # http://w3af.org/
 w3af.sf.net
 w3af.sourceforge.net
+w3af.org
 # site scanner (legacy)
 # http://www.robotstxt.org/db/webbandit.html
 webbandit


### PR DESCRIPTION
Another small addition to scanners-user-agents.data

I have added the brand new BFAC scanner https://github.com/mazen160/bfac.

Mazin was kind enough to set a custom UA on my request.

w3af.org seems to be an alternative to the two w3ar listings we had so far. I wonder if we should not strip it and simply go with w3af.