### PR TITLE
Missing quote at the end of the rule 920450

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1110,7 +1110,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^(.*)$" \
    tag:'PCI/12.1',\
    t:lowercase,\
    setvar:'tx.header_name_%{tx.0}=/%{tx.0}/',\
-   chain
+   chain"
      SecRule TX:/^HEADER_NAME_/ "@within %{tx.restricted_headers}" \
    	"setvar:'tx.msg=%{rule.msg}',\
    	 setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\


### PR DESCRIPTION
Missing quote at the end of the rule 920450