### PR TITLE
Fix rule reference in comment in sampling code

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -334,7 +334,7 @@ SecRule TX:sampling_rnd100 "@rx ^0([0-9])" \
 # following directive somewhere after the inclusion of the CRS
 # (E.g., RESPONSE-999-EXCEPTIONS.conf).
 #
-# SecRuleUpdateActionById 901150 "nolog"
+# SecRuleUpdateActionById 901450 "nolog"
 #
 
 


### PR DESCRIPTION
The id within the proposed exclusion rule in the comment was wrong.