### PR TITLE
Fix script execution error

### DIFF
--- a/lua/gather_ip_data.lua
+++ b/lua/gather_ip_data.lua
@@ -4,7 +4,7 @@ require("io");
 function main()
 local anomaly_score = m.getvar("TX.ANOMALY_SCORE", "none");
 	m.log(4, "Anomaly Score is: " .. anomaly_score .. ".");
-local remote_addr = m.getvar("ARGS.REMOTE_ADDR", "none");
+local remote_addr = m.getvar("REMOTE_ADDR", "none");
 	m.log(4, "Remote IP is: " .. remote_addr .. ".");
 local ip_hostname = m.getvar("IP.HOSTNAME", "none");
 


### PR DESCRIPTION
Previously, execution of this script would fail with the following error in the audit log:

```
Message: Lua: Script execution failed: /usr/share/modsecurity-crs/lua/gather_ip_data.lua:8: attempt to concatenate local 'remote_addr' (a nil value)
```

using REMOTE_ADDR instead of ARGS.REMOTE_ADDR in the script fixes this issue.