### PR TITLE
Add urlDecodeUni() operation to ARG/ARGS_NAMES

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1471,7 +1471,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "(?<!\Q\\\E)\Q\\\E[cdeghijkl
    tag:'platform-multi',\
    tag:'attack-protocol',\
    tag:'paranoia-level/4',\
-   t:none,t:htmlEntityDecode,t:lowercase,\
+   t:none,t:urlDecodeUni,t:htmlEntityDecode,t:lowercase,\
    ctl:auditLogParts=+E,\
    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
    setvar:'tx.msg=%{rule.msg}',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -83,7 +83,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "(?:\n|\r)+(?:get|post|head|options|connect|put|d
 	tag:'language-multi',\
 	tag:'platform-multi',\
 	tag:'attack-protocol',\
-	t:none,t:htmlEntityDecode,t:lowercase,\
+	t:none,t:urlDecodeUni,t:htmlEntityDecode,t:lowercase,\
 	ctl:auditLogParts=+E,\
 	block,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -113,7 +113,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'9',\
 	accuracy:'9',\
 	severity:'CRITICAL',\
-	t:none,t:lowercase,\
+	t:none,t:urlDecodeUni,t:lowercase,\
 	capture,\
 	tag:'application-multi',\
 	tag:'language-multi',\
@@ -142,7 +142,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         tag:'language-multi',\
         tag:'platform-multi',\
         tag:'attack-protocol',\
-	t:none,t:htmlEntityDecode,t:lowercase,\
+	t:none,t:urlDecodeUni,t:htmlEntityDecode,t:lowercase,\
 	ctl:auditLogParts=+E,\
 	block,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -203,7 +203,7 @@ SecRule ARGS_NAMES|ARGS_GET "(\n|\r)" \
 	tag:'language-multi',\
 	tag:'platform-multi',\
 	tag:'attack-protocol',\
-	t:none,t:htmlEntityDecode,t:lowercase,\
+	t:none,t:urlDecodeUni,t:htmlEntityDecode,t:lowercase,\
 	ctl:auditLogParts=+E,\
 	block,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -227,7 +227,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "(?:\n|\r)+(?:\s+|location|refresh|(?:set-)?cooki
 	tag:'language-multi',\
 	tag:'platform-multi',\
 	tag:'attack-protocol',\
-	t:none,t:htmlEntityDecode,t:lowercase,\
+	t:none,t:urlDecodeUni,t:htmlEntityDecode,t:lowercase,\
 	ctl:auditLogParts=+E,\
 	block,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -163,7 +163,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'1',\
 	accuracy:'7',\
 	capture,\
-	t:none,t:cmdLine,\
+	t:none,t:urlDecodeUni,t:cmdLine,\
 	ctl:auditLogParts=+E,\
 	block,\
 	id:932120,\
@@ -206,7 +206,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'1',\
 	accuracy:'7',\
 	capture,\
-	t:none,t:cmdLine,\
+	t:none,t:urlDecodeUni,t:cmdLine,\
 	ctl:auditLogParts=+E,\
 	block,\
 	id:932130,\
@@ -257,7 +257,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'1',\
 	accuracy:'7',\
 	capture,\
-	t:none,t:cmdLine,\
+	t:none,t:urlDecodeUni,t:cmdLine,\
 	ctl:auditLogParts=+E,\
 	block,\
 	id:932140,\
@@ -346,7 +346,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'1',\
 	accuracy:'8',\
 	capture,\
-	t:none,t:cmdLine,t:normalizePath,\
+	t:none,t:urlDecodeUni,t:cmdLine,t:normalizePath,\
 	ctl:auditLogParts=+E,\
 	block,\
 	id:932160,\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -38,7 +38,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	ver:'OWASP_CRS/3.0.0',\
 	maturity:'9',\
 	accuracy:'9',\
-	t:none,t:lowercase,\
+	t:none,t:urlDecodeUni,t:lowercase,\
 	ctl:auditLogParts=+E,\
 	block,\
 	capture,\
@@ -114,7 +114,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         maturity:'1',\
         accuracy:'8',\
         capture,\
-        t:none,t:normalisePath,\
+        t:none,t:urlDecodeUni,t:normalisePath,\
         ctl:auditLogParts=+E,\
         block,\
         id:933120,\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -700,7 +700,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	id:941310,\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	t:none,t:lowercase,t:urlDecode,t:htmlEntityDecode,t:jsDecode,\
+	t:none,t:urlDecodeUni,t:lowercase,t:urlDecode,t:htmlEntityDecode,t:jsDecode,\
 	block,\
 	ctl:auditLogParts=+E,\
 	msg:'US-ASCII Malformed Encoding XSS Filter - Attack Detected.',\
@@ -734,7 +734,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         id:941350,\
         capture,\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-        t:none,t:lowercase,t:urlDecode,t:htmlEntityDecode,t:jsDecode,\
+        t:none,t:urlDecodeUni,t:lowercase,t:urlDecode,t:htmlEntityDecode,t:jsDecode,\
         block,\
         ctl:auditLogParts=+E,\
         msg:'UTF-7 Encoding IE XSS - Attack Detected.',\
@@ -829,7 +829,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 	accuracy:'8',\
 	id:941320,\
 	capture,\
-	t:none,t:jsDecode,t:lowercase,\
+	t:none,t:urlDecodeUni,t:jsDecode,t:lowercase,\
 	block,\
 	msg:'Possible XSS Attack Detected - HTML Tag Handler',\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -854,7 +854,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 	id:941330,\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	t:none,t:htmlEntityDecode,t:compressWhiteSpace,\
+	t:none,t:urlDecodeUni,t:htmlEntityDecode,t:compressWhiteSpace,\
 	block,\
 	msg:'IE XSS Filters - Attack Detected.',\
 	tag:'OWASP_CRS/WEB_ATTACK/XSS',\
@@ -878,7 +878,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 	id:941340,\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	t:none,t:htmlEntityDecode,t:compressWhiteSpace,\
+	t:none,t:urlDecodeUni,t:htmlEntityDecode,t:compressWhiteSpace,\
 	block,\
 	msg:'IE XSS Filters - Attack Detected.',\
 	tag:'OWASP_CRS/WEB_ATTACK/XSS',\

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -62,7 +62,7 @@ SecRule ARGS_NAMES "@rx ^(jsessionid|aspsessionid|asp.net_sessionid|phpsession|p
 	maturity:'2',\
 	accuracy:'7',\
 	id:943110,\
-	t:none,t:lowercase,\
+	t:none,t:urlDecodeUni,t:lowercase,\
 	capture,\
 	ctl:auditLogParts=+E,\
 	block,\
@@ -94,7 +94,7 @@ SecRule ARGS_NAMES "@rx ^(jsessionid|aspsessionid|asp.net_sessionid|phpsession|p
 	maturity:'2',\
 	accuracy:'7',\
 	id:943120,\
-	t:none,t:lowercase,\
+	t:none,t:urlDecodeUni,t:lowercase,\
 	capture,\
 	ctl:auditLogParts=+E,\
 	severity:'CRITICAL',\


### PR DESCRIPTION
- Add the urlDecodeUni transform operation to rules which inspect the
  ARGS/ARGS_NAMES collections, which do not currently call urlDecodeUni
- This operation should be here.  Some rules were written under the assumption
  that Apache/Nginx will automatically decode these collections prior to
  entering Modsecurity.
- This change shouldn't impact the rule quality, but will introduce additional decoding overhead

I am creating this PR to start the discussion

Thoughts?