### PR TITLE
Documentation update for Content-Type header

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -8,10 +8,10 @@
 # ------------------------------------------------------------------------
 
 #
-# Some protocol violations are common in application layer attacks. 
+# Some protocol violations are common in application layer attacks.
 # Validating HTTP requests eliminates a large number of application layer attacks.
 #
-# The purpose of this rules file is to enforce HTTP RFC requirements that state how 
+# The purpose of this rules file is to enforce HTTP RFC requirements that state how
 # the client is supposed to interact with the server.
 # http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html
 
@@ -36,14 +36,14 @@ SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:2,id:920012,nolog,pass,skipAfter:END-RE
 # Uses rule negation against the regex for positive security.  The regex specifies the proper
 # construction of URI request lines such as:
 #
-# 	"http:" "//" host [ ":" port ] [ abs_path [ "?" query ]] 
+# 	"http:" "//" host [ ":" port ] [ abs_path [ "?" query ]]
 #
-# It also outlines proper construction for CONNECT, OPTIONS and GET requests.  
+# It also outlines proper construction for CONNECT, OPTIONS and GET requests.
 #
 # -=[ References ]=-
 # http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.2.1
 # http://capec.mitre.org/data/definitions/272.html
-# 
+#
 SecRule REQUEST_LINE "!^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+)?)?/[^?#]*(?:\?[^#\s]*)?(?:#[\S]*)?|connect (?:\d{1,3}\.){3}\d{1,3}\.?(?::\d+)?|options \*)\s+[\w\./]+|get /[^?#]*(?:\?[^#\s]*)?(?:#[\S]*)?)$"\
   "msg:'Invalid HTTP Request Line',\
   severity:'WARNING',\
@@ -68,7 +68,7 @@ SecRule REQUEST_LINE "!^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+)?)?
 
 
 #
-# Identify multipart/form-data name evasion attempts 
+# Identify multipart/form-data name evasion attempts
 #
 # There are possible impedance mismatches between how
 # ModSecurity interprets multipart file names and how
@@ -121,7 +121,7 @@ SecRule FILES_NAMES|FILES "['\";=]" \
 #
 # -=[ References ]=-
 # https://sourceforge.net/apps/mediawiki/mod-security/index.php?title=Reference_Manual#REQBODY_ERROR
-# 
+#
 SecRule REQBODY_ERROR "!@eq 0" \
   "msg:'Failed to parse request body.',\
   severity:'CRITICAL',\
@@ -191,7 +191,7 @@ SecRule MULTIPART_STRICT_ERROR "!@eq 0" \
 
 
 #
-# Accept only digits in content length 
+# Accept only digits in content length
 #
 # -=[ Rule Logic ]=-
 # This rule uses ModSecurity's rule negation against the regex meaning if the Content-Length header
@@ -273,7 +273,7 @@ SecRule REQUEST_METHOD "^(?:GET|HEAD)$" \
 #
 # -=[ References ]=-
 # http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5
-# 
+#
 SecRule REQUEST_METHOD "^POST$" \
   "msg:'POST request missing Content-Length Header.',\
   severity:'WARNING',\
@@ -307,20 +307,20 @@ SecRule REQUEST_METHOD "^POST$" \
 # Automated programs and bots often do not obey the HTTP RFC
 #
 # -=[ Rule Logic ]=-
-# This rule inspects the Range request header to see if it starts with 0. 
+# This rule inspects the Range request header to see if it starts with 0.
 #
 # -=[ References ]=-
 # http://www.bad-behavior.ioerror.us/documentation/how-it-works/
 #
 # 2. Per RFC 2616 -
-#    "If the last-byte-pos value is present, it MUST be greater than or equal to the first-byte-pos in that byte-range-spec, 
+#    "If the last-byte-pos value is present, it MUST be greater than or equal to the first-byte-pos in that byte-range-spec,
 #    or the byte- range-spec is syntactically invalid."
 # -=[ Rule Logic ]=-
 # This rule compares the first and second byte ranges and flags when the first value is greater than the second.
 #
 # -=[ References ]=-
 # http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
-# http://seclists.org/fulldisclosure/2011/Aug/175 
+# http://seclists.org/fulldisclosure/2011/Aug/175
 #
 SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "(\d+)\-(\d+)\," \
   "capture,\
@@ -384,8 +384,8 @@ SecRule REQUEST_HEADERS:Connection "\b(keep-alive|close),\s?(keep-alive|close)\b
 #
 # -=[ Rule Logic ]=-
 # There are two different chained rules.  We need to separate them as we are inspecting two
-# different variables - REQUEST_URI and REQUEST_BODY.  For REQUEST_BODY, we only want to 
-# run the @validateUrlEncoding operator if the content-type is application/x-www-form-urlencoding. 
+# different variables - REQUEST_URI and REQUEST_BODY.  For REQUEST_BODY, we only want to
+# run the @validateUrlEncoding operator if the content-type is application/x-www-form-urlencoding.
 #
 # -=[ References ]=-
 # http://www.ietf.org/rfc/rfc1738.txt
@@ -474,7 +474,7 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
 # -=[ Rule Logic ]=-
 # This rule looks for full-width encoding by looking for %u followed by 2 'f'
 # characters and then 2 hex characters. It is a vulnerability that affected
-# IIS circa 2007 
+# IIS circa 2007
 #
 # -=[ References ]=-
 # http://www.kb.cert.org/vuls/id/739224
@@ -615,7 +615,7 @@ SecRule REQUEST_HEADERS:Host "^$" \
    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
 
 SecMarker END_HOST_CHECK
-    
+
 
 #
 # Empty Accept Header
@@ -623,10 +623,10 @@ SecMarker END_HOST_CHECK
 # -=[ Rule Logic ]=-
 # This rule checks if an Accept header exists, but has an empty value.
 # This is only allowed in combination with the OPTIONS method.
-# Additionally, there are some clients sending empty Accept headers. 
+# Additionally, there are some clients sending empty Accept headers.
 # They are covered in another chained rule checking the User-Agent.
-# This technique demands a separate rule to detect an empty 
-# Accept header if there is no user agent. This is checked via 
+# This technique demands a separate rule to detect an empty
+# Accept header if there is no user agent. This is checked via
 # the separate rule 920311.
 #
 # Exclude some common broken clients sending empty Accept header:
@@ -722,15 +722,17 @@ SecRule REQUEST_HEADERS:User-Agent "^$" \
    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
 
 #
-# Missing Content-Type Header with Request Body 
+# Missing Content-Type Header with Request Body
 #
-# -=[ Rule Logic ]=-
-# These rules will first check to see if a Content-Type header is missing.
-# The second check is to see if a Content-Length header is present and is
-# not empty or contains a 0.  If the Content-Length header contains other data
-# than this means that there is a request body and the RFC states that there
-# MUST be a Content-Type header so that the app knows how to parse the data.
+# -=[ Rule Logic]=-
+# This rule will first check to see if the value of the Content-Length header is
+# non-equal to 0. The chained rule is then checking the existence of the
+# Content-Type header. The RFCs do not state there must be a
+# Content-Type header. However, a request missing a Content-Header is a
+# strong indication of a non-compliant browser.
 #
+# -=[ References ]=-
+# http://httpwg.org/specs/rfc7231.html#header.content-type
 
 SecRule REQUEST_HEADERS:Content-Length "!^0$" \
   "msg:'Request Containing Content, but Missing Content-Type header',\
@@ -754,7 +756,7 @@ SecRule REQUEST_HEADERS:Content-Length "!^0$" \
         setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
         setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
 
-# Check that the host header is not an IP address 
+# Check that the host header is not an IP address
 # This is not an HTTP RFC violation but it is indicative of automated client access.
 # Many web-based worms propagate by scanning IP address blocks.
 #
@@ -1000,7 +1002,7 @@ SecRule REQUEST_METHOD "!^(?:GET|HEAD|PROPFIND|OPTIONS)$" \
              setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
              setvar:tx.%{rule.id}-OWASP_CRS/POLICY/CONTENT_TYPE_NOT_ALLOWED-%{matched_var_name}=%{matched_var}"
 
-# 
+#
 # Restrict protocol versions.
 #
 SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
@@ -1025,7 +1027,7 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
    logdata:'%{matched_var}',\
    setvar:'tx.msg=%{rule.msg}',\
    setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-   setvar:tx.%{rule.id}-OWASP_CRS/POLICY/PROTOCOL_NOT_ALLOWED-%{matched_var_name}=%{matched_var}" 
+   setvar:tx.%{rule.id}-OWASP_CRS/POLICY/PROTOCOL_NOT_ALLOWED-%{matched_var_name}=%{matched_var}"
 
 #
 # Restrict file extension
@@ -1059,8 +1061,8 @@ SecRule REQUEST_BASENAME "\.(.*)$" \
         setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
         setvar:tx.%{rule.id}-OWASP_CRS/POLICY/EXT_RESTRICTED-%{matched_var_name}=%{matched_var}"
 
-# 
-# Restricted HTTP headers 
+#
+# Restricted HTTP headers
 #
 # -=[ Rule Logic ]=-
 # The use of certain headers is restricted. They are listed in the variable
@@ -1349,7 +1351,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:2,id:920018,nolog,pass,skipAfter:END-RE
 # -= Paranoia Level 4 =- (apply only when tx.paranoia_level is sufficiently high: 4 or higher)
 #
 
-# 
+#
 # This is a stricter sibling of rule 920200
 #
 

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -128,7 +128,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 #
 # -=[ XSS Filters - Category 3 ]=-
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "(?i)[\s\S](?:x(?:link:href|html|mlns)|!ENTITY.*?SYSTEM|data:text\/html|pattern(?=.*?=)|formaction|\@import|base64)[\s\S]" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "(?i)[\s\S](?:x(?:link:href|html|mlns)|!ENTITY.*?SYSTEM|data:text\/html|pattern(?=.*?=)|formaction|\@import|base64)[\s\S]" \
 	"msg:'XSS Filter - Category 3: Attribute Vector',\
 	id:941130,\
 	phase:request,\
@@ -199,7 +199,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 # These are only checked/enforced if the Admin has set -
 # setvar:tx.allow_html=0
 # 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "(?i)\b(?:s(?:tyle|rc)|href)\b[\s\S]*?=" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "(?i)\b(?:s(?:tyle|rc)|href)\b[\s\S]*?=" \
 	"msg:'XSS Filter - Category 5: Disallowed HTML Attributes',\
 	id:941150,\
 	phase:request,\


### PR DESCRIPTION
The documentation should be updated to reflect the current RFC 7231 and it's wording as suggested by @mnot in #266. Thanks again!