### PR TITLE
Panic with error 500 on unconfigured CRS

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -55,7 +55,7 @@ SecRule &TX:setup_done "@eq 0" \
     deny,\
     status:500,\
     severity:CRITICAL,\
-    msg:'ModSecurity CRS is unconfigured. Please copy the crs-setup.conf.example template to crs-setup.conf, and include the crs-setup.conf file in your webserver configuration before including the CRS rules. See INSTALL file for detailed instructions.'"
+    msg:'ModSecurity Core Rule Set is deployed without configuration! Please copy the crs-setup.conf.example template to crs-setup.conf, and include the crs-setup.conf file in your webserver configuration before including the CRS rules. See the INSTALL file in the CRS directory for detailed instructions.'"
 
 
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -43,7 +43,7 @@ SecComponentSignature "OWASP_CRS/3.0.0"
 # changes. There have been many changes in settings syntax from CRS2
 # to CRS3, so an old setup file may cause unwanted behavior.
 #
-# If you are not planning to use the setup.conf template, you must
+# If you are not planning to use the crs-setup.conf template, you must
 # manually set the tx.setup_done variable in phase:1 before including
 # the CRS rules/* files.
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -35,25 +35,29 @@ SecComponentSignature "OWASP_CRS/3.0.0"
 # file is included at the correct time. This detects situations where
 # necessary settings are not defined, for instance if the file
 # inclusion order is incorrect, or if the user has forgotten to
-# configure the example setup template.
+# include the crs-setup.conf file.
 #
 # If you are upgrading from an earlier version of the CRS and you are
 # getting this error, please make a new copy of the setup template
-# crs-setup.conf.example, and re-apply your old
+# crs-setup.conf.example to crs-setup.conf, and re-apply your policy
 # changes. There have been many changes in settings syntax from CRS2
-# to CRS3, so an old file may cause unwanted behavior.
+# to CRS3, so an old setup file may cause unwanted behavior.
 #
 # If you are not planning to use the setup.conf template, you must
-# manually set the tx.setup_done variable before including the CRS
-# rules/* files.
+# manually set the tx.setup_done variable in phase:1 before including
+# the CRS rules/* files.
 #
 SecRule &TX:setup_done "@eq 0" \
     "id:901001,\
     phase:1,\
+    auditlog,\
     log,\
-    pass,\
-    severity:WARNING,\
-    msg:'ModSecurity Core Rules setup file has not been detected. Threat detection and blocking may be nonfunctional. Please ensure to make a copy of the setup template crs-setup.conf.example, and include your crs-setup.conf file in your webserver configuration before including the CRS rules.'"
+    ctl:ruleEngine=on,\
+    ctl:auditEngine=on,\
+    deny,\
+    status:500,\
+    severity:CRITICAL,\
+    msg:'ModSecurity CRS is unconfigured. Please copy the crs-setup.conf.example template to crs-setup.conf, and include the crs-setup.conf file in your webserver configuration before including the CRS rules. See INSTALL file for detailed instructions.'"
 
 
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -52,8 +52,6 @@ SecRule &TX:setup_done "@eq 0" \
     phase:1,\
     auditlog,\
     log,\
-    ctl:ruleEngine=on,\
-    ctl:auditEngine=on,\
     deny,\
     status:500,\
     severity:CRITICAL,\


### PR DESCRIPTION
If the CRS is not configured correctly (detected by tx.setup_done), panic with error 500.

Resolves #479.