### PR TITLE
allowed_http_versions: add 'HTTP/2.0' which is used by new Apache 2

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -300,8 +300,10 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|text/plain'"
 
 # Allowed HTTP versions.
-# Default: HTTP/1.0 HTTP/1.1 HTTP/2
-# Example for legacy clients: HTTP/0.9 HTTP/1.0 HTTP/1.1 HTTP/2
+# Default: HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0
+# Example for legacy clients: HTTP/0.9 HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0
+# Note that some web server versions use 'HTTP/2', some 'HTTP/2.0', so
+# we include both version strings by default.
 # Uncomment this rule to change the default.
 #SecAction \
 # "id:900230,\
@@ -309,7 +311,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2'"
+#  setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0'"
 
 # Forbidden file extensions.
 # Guards against unintended exposure of development/configuration files.

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -155,7 +155,7 @@ SecRule &TX:allowed_http_versions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2'"
+    setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0'"
 
 # Default HTTP policy: restricted_extensions (rule 900240)
 SecRule &TX:restricted_extensions "@eq 0" \


### PR DESCRIPTION
After upgrading our Apaches from 2.4.20 to 2.4.23, it seems that its string representation of the HTTP/2 protocol version has changed from `HTTP/2` to `HTTP/2.0`.

This broke the version check in CRS:

`Message: Warning. Match of "within %{tx.allowed_http_versions}" against "REQUEST_PROTOCOL" required. [file "/usr/local/etc/apache24/security2/activated_rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "1028"] [id "920430"] [rev "2"] [msg "HTTP protocol version is not allowed by policy"] [data "HTTP/2.0"] `

We have to accommodate LTS distros as well as people tracking the latest Apache. The quickest fix we can make is to just include both version strings.