### PR TITLE
LFI: add cmdLine transformation

### DIFF
--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -61,7 +61,7 @@ SecRule REQUEST_URI|REQUEST_BODY|REQUEST_HEADERS|XML:/*|!REQUEST_HEADERS:Referer
         maturity:'9',\
 	accuracy:'7',\
 	multiMatch,\
-        t:none,t:utf8toUnicode,t:urlDecodeUni,t:removeNulls,\
+        t:none,t:utf8toUnicode,t:urlDecodeUni,t:removeNulls,t:cmdLine,\
         block,\
         severity:CRITICAL,\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\


### PR DESCRIPTION
While testing I found that the LFI rule 930110 checking for `../` and `..\` did not use cmdLine transformation yet.

This would allow traversing the filesystem in a shell command. Due to FP, we are not so strict on all shell commands as I would have liked (e.g. `cat` and `more` commands are only blocked in limited circumstances), so it's important to watch the arguments of the shell command carefully.

Due to cmdLine transformation, these types of payloads are now caught (which weren't caught before):
```
more .'.'/passwd.txt
more .'.'\/passwd.txt
more ."./"passwd.txt
more .\./passwd.txt
.\/.\.\/passwd.txt
.\./blah
\.\./blah
^.^./foo
```

It did not have measurable effect on FP in my testing.

Windows quoting is kinda spotty for some reason, I would expect these two to match too (on Windows shell `^` is a quote character) but it's not happening:

```
^.^.\foo
..^\f^oo
```