### PR TITLE
add platform-windows tag to platform-iis rules

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -493,6 +493,7 @@ SecRule REQUEST_URI|REQUEST_BODY "\%u[fF]{2}[0-9a-fA-F]{2}" \
    tag:'application-multi',\
    tag:'language-multi',\
    tag:'platform-iis',\
+   tag:'platform-windows',\
    tag:'attack-protocol',\
    block,\
    setvar:'tx.msg=%{rule.msg}',\

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -34,6 +34,7 @@ SecRule RESPONSE_BODY "[a-z]:\\\\inetpub\b" \
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-iis',\
+	tag:'platform-windows',\
 	tag:'attack-disclosure',\
 	msg:'Disclosure of IIS install location',\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -63,6 +64,7 @@ SecRule RESPONSE_BODY "(?:Microsoft OLE DB Provider for SQL Server(?:<\/font>.{1
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-iis',\
+        tag:'platform-windows',\
         tag:'attack-disclosure',\
 	tag:'WASCTC/WASC-13',\
 	tag:'OWASP_TOP_10/A6',\
@@ -92,6 +94,7 @@ SecRule RESPONSE_BODY "(?:\b(?:A(?:DODB\.Command\b.{0,100}?\b(?:Application uses
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-iis',\
+        tag:'platform-windows',\
         tag:'attack-disclosure',\
 	tag:'OWASP_CRS/LEAKAGE/ERRORS_IIS',\
 	tag:'WASCTC/WASC-13',\
@@ -120,6 +123,7 @@ SecRule RESPONSE_STATUS "!^404$" \
         tag:'application-multi',\
         tag:'language-multi',\
         tag:'platform-iis',\
+        tag:'platform-windows',\
         tag:'attack-disclosure',\
 	tag:'OWASP_CRS/LEAKAGE/ERRORS_IIS',\
 	tag:'WASCTC/WASC-13',\


### PR DESCRIPTION
Earlier I introduced the `platform-windows` tag to help reduce FP for people not using Windows.

I noticed that I hadn't added these tags to other existing IIS related rules.

Very minor fix.