### PR TITLE
xss, sqli: add missing tags

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -346,6 +346,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'8',\
 	accuracy:'8',\
 	id:941190,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:removeNulls,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,\
@@ -374,6 +375,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'8',\
 	accuracy:'8',\
 	id:941200,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:removeNulls,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,\
@@ -403,6 +405,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'8',\
 	accuracy:'8',\
 	id:941210,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:removeNulls,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,\
@@ -432,6 +435,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'8',\
 	accuracy:'8',\
 	id:941220,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:removeNulls,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,\
@@ -461,6 +465,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'8',\
 	accuracy:'8',\
 	id:941230,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:removeNulls,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,\
@@ -490,6 +495,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'8',\
 	accuracy:'8',\
 	id:941240,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:lowercase,t:removeNulls,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,\
@@ -519,6 +525,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'8',\
 	accuracy:'8',\
 	id:941250,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:removeNulls,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,\
@@ -548,6 +555,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'8',\
 	accuracy:'8',\
 	id:941260,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:removeNulls,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,\
@@ -577,6 +585,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'8',\
 	accuracy:'8',\
 	id:941270,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:removeNulls,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,\
@@ -606,6 +615,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'8',\
 	accuracy:'8',\
 	id:941280,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:removeNulls,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,\
@@ -635,6 +645,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'8',\
 	accuracy:'8',\
 	id:941290,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:removeNulls,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,\
@@ -664,6 +675,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'8',\
 	accuracy:'8',\
 	id:941300,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:removeNulls,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,\
@@ -698,6 +710,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'7',\
 	accuracy:'8',\
 	id:941310,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:urlDecodeUni,t:lowercase,t:urlDecode,t:htmlEntityDecode,t:jsDecode,\
@@ -732,6 +745,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         maturity:'7',\
         accuracy:'8',\
         id:941350,\
+        severity:'CRITICAL',\
         capture,\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
         t:none,t:urlDecodeUni,t:lowercase,t:urlDecode,t:htmlEntityDecode,t:jsDecode,\
@@ -828,6 +842,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 	maturity:'8',\
 	accuracy:'8',\
 	id:941320,\
+	severity:'CRITICAL',\
 	capture,\
 	t:none,t:urlDecodeUni,t:jsDecode,t:lowercase,\
 	block,\
@@ -856,6 +871,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 	maturity:'8',\
 	accuracy:'8',\
 	id:941330,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:urlDecodeUni,t:htmlEntityDecode,t:compressWhiteSpace,\
@@ -884,6 +900,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 	maturity:'8',\
 	accuracy:'8',\
 	id:941340,\
+	severity:'CRITICAL',\
 	capture,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	t:none,t:urlDecodeUni,t:htmlEntityDecode,t:compressWhiteSpace,\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -833,6 +833,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 	block,\
 	msg:'Possible XSS Attack Detected - HTML Tag Handler',\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-xss',\
 	tag:'OWASP_CRS/WEB_ATTACK/XSS',\
 	tag:'WASCTC/WASC-8',\
 	tag:'WASCTC/WASC-22',\
@@ -857,6 +861,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 	t:none,t:urlDecodeUni,t:htmlEntityDecode,t:compressWhiteSpace,\
 	block,\
 	msg:'IE XSS Filters - Attack Detected.',\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-xss',\
 	tag:'OWASP_CRS/WEB_ATTACK/XSS',\
 	tag:'WASCTC/WASC-8',\
 	tag:'WASCTC/WASC-22',\
@@ -881,6 +889,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 	t:none,t:urlDecodeUni,t:htmlEntityDecode,t:compressWhiteSpace,\
 	block,\
 	msg:'IE XSS Filters - Attack Detected.',\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-xss',\
 	tag:'OWASP_CRS/WEB_ATTACK/XSS',\
 	tag:'WASCTC/WASC-8',\
 	tag:'WASCTC/WASC-22',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -771,6 +771,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         block,\
         msg:'SQL Injection Attack',\
         id:942380,\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'WASCTC/WASC-19',\
         tag:'OWASP_TOP_10/A1',\
@@ -796,6 +800,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         block,\
         msg:'SQL Injection Attack',\
         id:942390,\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'WASCTC/WASC-19',\
         tag:'OWASP_TOP_10/A1',\
@@ -821,6 +829,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         block,\
         msg:'SQL Injection Attack',\
         id:942400,\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'WASCTC/WASC-19',\
         tag:'OWASP_TOP_10/A1',\
@@ -846,6 +858,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         block,\
         msg:'SQL Injection Attack',\
         id:942410,\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'WASCTC/WASC-19',\
         tag:'OWASP_TOP_10/A1',\
@@ -888,6 +904,10 @@ SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'
         msg:'Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (12)',\
         capture,\
         logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'paranoia-level/2',\
         setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
@@ -931,6 +951,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         severity:'CRITICAL',\
         capture,\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'WASCTC/WASC-19',\
         tag:'OWASP_TOP_10/A1',\
@@ -959,6 +983,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
         msg:'SQL Hex Encoding Identified',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
         severity:'CRITICAL',\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'WASCTC/WASC-19',\
         tag:'OWASP_TOP_10/A1',\
@@ -1044,6 +1072,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQ
         msg:'Restricted SQL Character Anomaly Detection (cookies): # of special characters exceeded (8)',\
         capture,\
         logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'paranoia-level/3',\
         setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
@@ -1068,6 +1100,10 @@ SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'
         msg:'Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (6)',\
         capture,\
         logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'paranoia-level/3',\
         setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
@@ -1095,6 +1131,11 @@ SecRule ARGS "\W{4,}" \
         maturity:'9',\
         accuracy:'8',\
         severity:'WARNING',\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
+        tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'paranoia-level/3',\
         msg:'Meta-Character Anomaly Detection Alert - Repetitive Non-Word Characters',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -1126,6 +1167,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQ
         msg:'Restricted SQL Character Anomaly Detection (cookies): # of special characters exceeded (3)',\
         capture,\
         logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'paranoia-level/4',\
         setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\
@@ -1150,6 +1195,10 @@ SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'
         msg:'Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (2)',\
         capture,\
         logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-sqli',\
         tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
         tag:'paranoia-level/4',\
         setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -43,6 +43,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:2,id:942012,nolog,pass,skipAfter:END-RE
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@detectSQLi" \
   "msg:'SQL Injection Attack Detected via libinjection',\
    id:942100,\
+   severity:'CRITICAL',\
    rev:'1',\
    ver:'OWASP_CRS/3.0.0',\
    maturity:'1',\
@@ -897,6 +898,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'
         t:none,t:urlDecodeUni,\
         block,\
         id:942430,\
+        severity:'WARNING',\
         rev:'2',\
         ver:'OWASP_CRS/3.0.0',\
         maturity:'9',\
@@ -1065,6 +1067,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQ
         t:none,t:urlDecodeUni,\
         block,\
         id:942420,\
+        severity:'WARNING',\
         rev:'2',\
         ver:'OWASP_CRS/3.0.0',\
         maturity:'9',\
@@ -1093,6 +1096,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'
         t:none,t:urlDecodeUni,\
         block,\
         id:942431,\
+        severity:'WARNING',\
         rev:'2',\
         ver:'OWASP_CRS/3.0.0',\
         maturity:'9',\
@@ -1160,6 +1164,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQ
         t:none,t:urlDecodeUni,\
         block,\
         id:942421,\
+        severity:'WARNING',\
         rev:'2',\
         ver:'OWASP_CRS/3.0.0',\
         maturity:'9',\
@@ -1188,6 +1193,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'
         t:none,t:urlDecodeUni,\
         block,\
         id:942432,\
+        severity:'WARNING',\
         rev:'2',\
         ver:'OWASP_CRS/3.0.0',\
         maturity:'9',\


### PR DESCRIPTION
Every attack rule must have correct tags, most importantly the `attack-` and `OWASP_CRS` tags, in order to be excluded properly with ruleRemoveTargetByTag.

Validated our rule files and added tags for the rules that were missing them.