### PR TITLE
Optimize 'special char' regexps to not exceed PCRE limits

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -876,7 +876,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 # SecRuleUpdateTargetById 942430 "!ARGS:foo"
 #
 
-SecRule ARGS_NAMES|ARGS|XML:/* "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){12})" \
+SecRule ARGS_NAMES|ARGS|XML:/* "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>][^\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>]*?){12})" \
         "phase:request,\
         t:none,t:urlDecodeUni,\
         block,\
@@ -1032,7 +1032,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # SecRuleUpdateTargetById 942420 "!REQUEST_COOKIES:foo_id"
 #
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){8})" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>][^\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>]*?){8})" \
         "phase:request,\
         t:none,t:urlDecodeUni,\
         block,\
@@ -1056,7 +1056,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQ
 # This is a stricter sibling of rule 942430.
 #
 
-SecRule ARGS_NAMES|ARGS|XML:/* "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){6})" \
+SecRule ARGS_NAMES|ARGS|XML:/* "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>][^\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>]*?){6})" \
         "phase:request,\
         t:none,t:urlDecodeUni,\
         block,\
@@ -1114,7 +1114,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:2,id:942018,nolog,pass,skipAfter:END-RE
 # This is a stricter sibling of rule 942420.
 #
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){3})" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>][^\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>]*?){3})" \
         "phase:request,\
         t:none,t:urlDecodeUni,\
         block,\
@@ -1138,7 +1138,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQ
 # This is a stricter sibling of rule 942430.
 #
 
-SecRule ARGS_NAMES|ARGS|XML:/* "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){2})" \
+SecRule ARGS_NAMES|ARGS|XML:/* "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>][^\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>]*?){2})" \
         "phase:request,\
         t:none,t:urlDecodeUni,\
         block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -876,7 +876,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 # SecRuleUpdateTargetById 942430 "!ARGS:foo"
 #
 
-SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){12,}" \
+SecRule ARGS_NAMES|ARGS|XML:/* "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){12})" \
         "phase:request,\
         t:none,t:urlDecodeUni,\
         block,\
@@ -1032,7 +1032,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # SecRuleUpdateTargetById 942420 "!REQUEST_COOKIES:foo_id"
 #
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){8,}" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){8})" \
         "phase:request,\
         t:none,t:urlDecodeUni,\
         block,\
@@ -1056,7 +1056,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQ
 # This is a stricter sibling of rule 942430.
 #
 
-SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){6,}" \
+SecRule ARGS_NAMES|ARGS|XML:/* "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){6})" \
         "phase:request,\
         t:none,t:urlDecodeUni,\
         block,\
@@ -1084,7 +1084,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'
 #
 # The pattern may occur in some normal texts, e.g. "foo...." will match.
 #
-SecRule ARGS "\W{4,}" \
+SecRule ARGS "\W{4}" \
         "phase:request,\
         capture,\
         t:none,t:urlDecodeUni,\
@@ -1114,7 +1114,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:2,id:942018,nolog,pass,skipAfter:END-RE
 # This is a stricter sibling of rule 942420.
 #
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){3,}" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){3})" \
         "phase:request,\
         t:none,t:urlDecodeUni,\
         block,\
@@ -1138,7 +1138,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQ
 # This is a stricter sibling of rule 942430.
 #
 
-SecRule ARGS_NAMES|ARGS|XML:/* "([\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){2,}" \
+SecRule ARGS_NAMES|ARGS|XML:/* "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\"\'\´\’\‘\`\<\>].*?){2})" \
         "phase:request,\
         t:none,t:urlDecodeUni,\
         block,\


### PR DESCRIPTION
A CRS3 setup can give many "PCRE limits exceeded" errors on a default ModSecurity configuration, for instance on rule 942430 and related ones on lots of traffic such as WordPress.

One option could be to note this error in the known issues, and/or advocate setting higher PCRE limits. In my WordPress testing, `SecPcreMatchLimit 60000` was enough to make the errors go away, but that might be pretty high. However, we could also tweak our regexps so that they don't blow up so quickly.

This PR tries to prevent "PRCE limits exceeded" errors in some SQLI rules due to use of nested `.*` after the special char. Replaced `.*` by a search for non-special chars to limit the explosion of search trees. Now the engine can match linearly and won't need to create a lot of nodes to backtrack to earlier parts of a string like `foo-bar-baz-...`. This seems to fix the errors on the test payloads I had. I think it should match equivalent payloads, am I correct?

Also I removed some unbounded repetitions, after all, if we are looking for 12 or more special characters i.e. `{12,}` we might just as well look for `{12}`, stop matching on the 12th char and save resources.

Also I stopped capturing the inner groups, and added a single outer group, to nicely put the full payload in the log.

An example of a request giving PCRE limits exceeded in CRS3 is from WordPress. You need to have PL2 or higher to activate rule 942430.

```
curl 'http://localhost/wp-admin/load-scripts.php?c=0&load%5B%5D=hoverIntent,common,admin-bar,heartbeat,autosave,wp-ajax-response,jquery-color,wp-lists,quicktags,jquery-query,admin-comments,sug&load%5B%5D=gest,jquery-ui-core,jquery-ui-widget,jquery-ui-mouse,jquery-ui-sortable,postbox,tags-box,underscore,word-count,wp-a11y,post,edit&load%5B%5D=or-expand,thickbox,shortcode,backbone,wp-util,wp-backbone,media-models,wp-plupload,mediaelement,wp-mediaelement,media-views,medi&load%5B%5D=a-editor,media-audiovideo,mce-view,imgareaselect,image-edit,svg-painter,wp-auth-check,editor,wplink,jquery-ui-position,jquery-ui&load%5B%5D=-menu,jquery-ui-autocomplete,media-upload,wp-embed&ver=4.6.1'
```

This would give:

```
Message: Rule 80a0bdbf8 [id "942430"][file "/usr/local/etc/apache24/security2/activated_rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf"][line "896"] - Execution error - PCRE limits exceeded (-8): (null).
Message: Rule 80a0bdbf8 [id "942430"][file "/usr/local/etc/apache24/security2/activated_rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf"][line "896"] - Execution error - PCRE limits exceeded (-8): (null).
Message: Rule 80a0bdbf8 [id "942430"][file "/usr/local/etc/apache24/security2/activated_rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf"][line "896"] - Execution error - PCRE limits exceeded (-8): (null).
Message: Rule 80a0bdbf8 [id "942430"][file "/usr/local/etc/apache24/security2/activated_rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf"][line "896"] - Execution error - PCRE limits exceeded (-8): (null).
```

Some small tests done which should match:

```
curl --cookie 'bla=a--b--c--d--e--q+r' 'http://localhost/'
curl 'http://localhost/bla?x=a-b-c-d-e-f-g-h-i-j-k-l-m-n'
curl 'http://localhost/bla?x=a----------------b'
```

Note that these rules are quite scary and I haven't had the time to do more formal testing, so careful review is definitely appreciated.