### PR TITLE
Fix 'msdb' false positive by adding word boundaries to 942140

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -71,7 +71,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 #
 # -=[ Detect DB Names ]=-
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:m(?:s(?:ysaccessobjects|ysaces|ysobjects|ysqueries|ysrelationships|ysaccessstorage|ysaccessxml|ysmodules|ysmodules2|db)|aster\.\.sysdatabases|ysql\.db)|s(?:ys(?:\.database_name|aux)|chema(?:\W*\(|_name)|qlite(_temp)?_master)|d(?:atabas|b_nam)e\W*\(|information_schema|pg_(catalog|toast)|northwind|tempdb))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:\b(?:m(?:s(?:ysaccessobjects|ysaces|ysobjects|ysqueries|ysrelationships|ysaccessstorage|ysaccessxml|ysmodules|ysmodules2|db)|aster\.\.sysdatabases|ysql\.db)\b|s(?:ys(?:\.database_name|aux)\b|chema(?:\W*\(|_name\b)|qlite(_temp)?_master\b)|d(?:atabas|b_nam)e\W*\(|information_schema\b|pg_(catalog|toast)\b|northwind\b|tempdb\b))" \
 	"phase:request,\
 	rev:'2',\
 	ver:'OWASP_CRS/3.0.0',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -73,7 +73,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 #
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:\b(?:m(?:s(?:ysaccessobjects|ysaces|ysobjects|ysqueries|ysrelationships|ysaccessstorage|ysaccessxml|ysmodules|ysmodules2|db)|aster\.\.sysdatabases|ysql\.db)\b|s(?:ys(?:\.database_name|aux)\b|chema(?:\W*\(|_name\b)|qlite(_temp)?_master\b)|d(?:atabas|b_nam)e\W*\(|information_schema\b|pg_(catalog|toast)\b|northwind\b|tempdb\b))" \
 	"phase:request,\
-	rev:'2',\
+	rev:'3',\
 	ver:'OWASP_CRS/3.0.0',\
 	maturity:'9',\
 	accuracy:'8',\


### PR DESCRIPTION
Fix issue #248 by adding word boundaries to the appropriate parts of rule 942140. I kept the regexp as-is but only added `\b` where needed.

Quick tests done show that detection stays OK but now no longer hits on longer strings containing the words.

```
test sco rules                               payload
---- --- ----------------------------------- -----------------------------------
ok   5   942140                              msysaccessobjects
ok   5   942140                              msysaces
ok   5   942140                              msysobjects
ok   5   942140                              msysqueries
ok   5   942140                              msysrelationships
ok   5   942140                              msysaccessstorage
ok   5   942140                              msysaccessxml
ok   5   942140                              msysmodules
ok   5   942140                              msysmodules2
ok   5   942140                              msdb
ok   5   942140                              MSDb
ok   5   942140                              msdb,
ok   5   942140                              msdb.
ok   5   942140                              sys.database_name
ok   5   942140                              sysaux
ok   10  942140,942190                       schema  (
ok   10  942140,942190                       schema  (x
ok   10  942140,942190                       schema  ('x
ok   10  942140,942190                       Schema  ( 'x
ok   5   942140                              schema_name
ok   5   942140                              ,sqlite_master
ok   5   942140                              sqlite_temp_master.
ok   10  942140,942190                       database (
ok   10  942140,942190                       database (x
ok   10  942140,942190                       database ('x
ok   10  942140,942190                       database ( 'x
ok   5   942140                              db_name (
ok   5   942140                              db_name (x
ok   5   942140                              DB_name ('x
ok   5   942140                              db_name ( 'x
ok   5   942140                              information_schema
ok   5   942140                              pg_catalog
ok   5   942140                              pg_toast
ok   5   942140                              northwind
ok   5   942140                              tempdb
ok   5   942140                              tempdb.
ok   0                                       xmsysaccessobjects
ok   0                                       xmsysaces
ok   0                                       xmsysobjects
ok   0                                       xmsysqueries
ok   0                                       xmsysrelationships
ok   0                                       xmsysaccessstorage
ok   0                                       xmsysaccessxml
ok   0                                       xmsysmodules
ok   0                                       xmsysmodules2
ok   0                                       xmsdb
ok   0                                       xsys.database_name
ok   0                                       xsysaux
ok   5   942190                              xschema  (
ok   0                                       xschema_name
ok   0                                       xsqlite_master
ok   0                                       xsqlite_temp_master
ok   5   942190                              xdatabase (
ok   0                                       xdb_name (
ok   0                                       xinformation_schema
ok   0                                       xpg_catalog
ok   0                                       xpg_toast
ok   0                                       xnorthwind
ok   0                                       xtempdb
ok   0                                       msysaccessobjectsx
ok   0                                       msysacesx
ok   0                                       msysobjectsx
ok   0                                       msysqueriesx
ok   0                                       msysrelationshipsx
ok   0                                       msysaccessstoragex
ok   0                                       msysaccessxmlx
ok   0                                       msysmodulesx
ok   0                                       msysmodules2x
ok   0                                       msdbx
ok   0                                       sys.database_namex
ok   0                                       sysauxx
ok   0                                       schema_namex
ok   0                                       sqlite_masterx
ok   0                                       sqlite_temp_masterx
ok   0                                       databasex (
ok   0                                       db_namex (
ok   0                                       information_schemax
ok   0                                       pg_catalogx
ok   0                                       pg_toastx
ok   0                                       northwindx
ok   0                                       tempdbx
ok   0                                       zakqbNDy6paKRiugz54XMSDBDfiRE8QwbnmTtjI

Number of tests: 82
Score distribution:
   44 requests had score 0
   30 requests had score 5
    8 requests had score 10
Rule distribution:
   36 requests triggered rule 942140
   10 requests triggered rule 942190
Tests:
   82 success
```

Before the PR this was:
```
Rule distribution:
   80 requests triggered rule 942140
   10 requests triggered rule 942190
Tests:
   38 success
   44 FAIL
```