### PR TITLE
PHP source leakage: exclude this rule in case of gzip output

### DIFF
--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -51,6 +51,8 @@ SecRule RESPONSE_BODY "@pmf php-errors.data" \
 #
 # -=[ PHP source code leakage ]=-
 #
+# Detect some common PHP keywords in output.
+#
 SecRule RESPONSE_BODY "(?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scanf|write|open|read)|gz(?:(?:encod|writ)e|compress|open|read)|s(?:ession_start|candir)|read(?:(?:gz)?file|dir)|move_uploaded_file|(?:proc_|bz)open|call_user_func)|\$_(?:(?:pos|ge)t|session))\b" \
 	"phase:response,\
 	rev:'2',\
@@ -78,7 +80,13 @@ SecRule RESPONSE_BODY "(?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scanf|wr
 	setvar:tx.anomaly_score=+%{tx.error_anomaly_score},\
 	setvar:tx.%{rule.id}-OWASP_CRS/LEAKAGE/SOURCE_CODE-%{matched_var_name}=%{tx.0}"
 
-
+# Detect the presence of the PHP open tag "<?" or "<?php" in output.
+#
+# To prevent false positives due to the short "<?" sequence, an attempt
+# is made to stop alerts in binary output. This is done by detecting
+# some common binary file format headers, such as gzip (\x1f\x8b\x08),
+# png (IHDR), mp3 (ID3), movie formats et cetera.
+#
 SecRule RESPONSE_BODY "<\?(?!xml)" \
 	"phase:response,\
 	rev:'2',\

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -101,14 +101,13 @@ SecRule RESPONSE_BODY "<\?(?!xml)" \
 	tag:'WASCTC/WASC-13',\
 	tag:'OWASP_TOP_10/A6',\
 	tag:'PCI/6.5.6',severity:'ERROR'"
-		SecRule RESPONSE_BODY "!(?:\b(?:(?:i(?:nterplay|hdr|d3)|m(?:ovi|thd)|r(?:ar!|iff)|(?:ex|jf)if|f(?:lv|ws)|varg|cws)\b|gif)|B(?:%pdf|\.ra)\b)" \
+		SecRule RESPONSE_BODY "!(?:\x1f\x8b\x08|\b(?:(?:i(?:nterplay|hdr|d3)|m(?:ovi|thd)|r(?:ar!|iff)|(?:ex|jf)if|f(?:lv|ws)|varg|cws)\b|gif)|B(?:%pdf|\.ra)\b)" \
 			"t:none,\
 			capture,\
 			setvar:'tx.msg=%{rule.msg}',\
 			setvar:tx.outbound_anomaly_score=+%{tx.error_anomaly_score},\
 			setvar:tx.anomaly_score=+%{tx.error_anomaly_score},\
 			setvar:tx.%{rule.id}-OWASP_CRS/LEAKAGE/SOURCE_CODE-%{matched_var_name}=%{tx.0}"
-
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:3,id:953013,nolog,pass,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"


### PR DESCRIPTION
In my testing, rule 953120 (PHP source code leakage) often triggers as a false positive in gzipped responses, as the PHP tag `<?` is present in gzip data.

The rule contains a neat exclusion mechanism where it checks various file headers for binary file types. If one of these headers is present, the file is seen as a binary and the rule is skipped.

Add a gzip signature `\x1f\x8b\x08` to these headers.
