### PR TITLE
Check restricted file names

### DIFF
--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -107,6 +107,37 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-%{matched_var_name}=%{tx.0}"
 
+#
+# -=[ Restricted File Access ]=-
+#
+# Detects attempts to retrieve application source code, metadata,
+# credentials and version control history possibly reachable in a web root.
+#
+SecRule REQUEST_FILENAME "@pmf restricted-files.data" \
+	"phase:request,\
+	msg:'Restricted File Access Attempt',\
+	rev:'1',\
+	ver:'OWASP_CRS/3.0.0',\
+	maturity:'7',\
+	accuracy:'8',\
+	capture,\
+	t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,\
+	block,\
+	id:930130,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-lfi',\
+	tag:'OWASP_CRS/WEB_ATTACK/FILE_INJECTION',\
+	tag:'WASCTC/WASC-33',\
+	tag:'OWASP_TOP_10/A4',\
+	tag:'PCI/6.5.4',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.lfi_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-%{matched_var_name}=%{tx.0}"
 
 
 

--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -1,0 +1,45 @@
+# Apache
+# (no slash; also guards against old.htaccess, old.htpasswd, etc.)
+.htaccess
+.htdigest
+.htpasswd
+# Version control
+/.git/
+/.gitignore
+/.hg/
+/.hgignore
+/.svn/
+# Wordpress
+wp-config.php
+wp-config.bak
+wp-config.old
+wp-config.temp
+wp-config.tmp
+wp-config.txt
+# Symfony
+/config/config.yml
+/config/config_dev.yml
+/config/config_prod.yml
+/config/config_test.yml
+/config/parameters.yml
+/config/routing.yml
+/config/security.yml
+/config/services.yml
+# Drupal
+/sites/default/default.settings.php
+/sites/default/settings.php
+# Magento
+/app/etc/local.xml
+# Sublime Text
+/sftp-config.json
+# ASP.NET
+/Web.config
+# Node
+/gruntfile.js
+/npm-debug.log
+# Composer
+/composer.json
+/composer.lock
+/packages.json
+# dotenv
+/.env


### PR DESCRIPTION
Testing CRS3 I saw quite a few attempts to retrieve version control internals (`.git`), variations of WordPress config files (e.g. Google inurl:wp-config.txt), Apache config files, et cetera.

I turned detection for those probes into one restricted filename check rule. I included some from my earlier `lfi-os-files.data` additions in this rule, since those files might also be retrieved without a LFI vector if the web server is misconfigured to serve their contents (a common mistake).

I am already scanning for many of these file names for a long time with no FP, so I don't expect many FP. This may not strictly be a LFI attack so I'm open for better tagging suggestions. Also, do I have the transformations right?
