### PR TITLE
HTTP header injection: move ARGS_GET check to PL2 to mitigate FP

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -189,8 +189,12 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "(\n|\r)" \
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}"
 
 
-SecRule ARGS_NAMES|ARGS_GET "(\n|\r)" \
-	"msg:'HTTP Header Injection Attack via payload (CR/LF deteced)',\
+# Detect newlines in argument names.
+# Checking for GET arguments has been moved to paranoia level 2 (921151)
+# in order to mitigate possible false positives.
+#
+SecRule ARGS_NAMES "(\n|\r)" \
+	"msg:'HTTP Header Injection Attack via payload (CR/LF detected)',\
 	phase:request,\
 	id:921150,\
 	rev:'1',\
@@ -203,7 +207,7 @@ SecRule ARGS_NAMES|ARGS_GET "(\n|\r)" \
 	tag:'language-multi',\
 	tag:'platform-multi',\
 	tag:'attack-protocol',\
-	t:none,t:urlDecodeUni,t:htmlEntityDecode,t:lowercase,\
+	t:none,t:urlDecodeUni,t:htmlEntityDecode,\
 	ctl:auditLogParts=+E,\
 	block,\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -244,6 +248,36 @@ SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:921014,nolog,pass,skipAfter:END-RE
 # -= Paranoia Level 2 =- (apply only when tx.paranoia_level is sufficiently high: 2 or higher)
 #
 
+
+# Detect newlines in GET argument values.
+# These may point to a HTTP header injection attack, but can also sometimes
+# occur in benign query parameters.
+#
+# See also: rule 921140, 921150
+#
+SecRule ARGS_GET "(\n|\r)" \
+	"msg:'HTTP Header Injection Attack via payload (CR/LF detected)',\
+	phase:request,\
+	id:921151,\
+	rev:'1',\
+	ver:'OWASP_CRS/3.0.0',\
+	maturity:'5',\
+	accuracy:'5',\
+	severity:'CRITICAL',\
+	capture,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-protocol',\
+	tag:'paranoia-level/2',\
+	t:none,t:urlDecodeUni,t:htmlEntityDecode,\
+	ctl:auditLogParts=+E,\
+	block,\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}"
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:1,id:921015,nolog,pass,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"


### PR DESCRIPTION
Resolves #623 false positives when a newline is used in GET parameter value.

I've been experimented a bit with XSS this week and consider this check more useful than I did originally. So especially since I'm the only one who complained about this FP, I am going for a compromise and move it to **PL2** instead of my proposal of PL3.

Super-complex query parameters and free-form GET forms should be sufficiently rare nowadays that my impression is that PL2 users will be able to handle the FP. If it turns out to still be a dog, we can change it in a later release.