### PR TITLE
byte range validation: allow tab and newline in PL2

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -517,7 +517,7 @@ SecRule REQUEST_URI|REQUEST_BODY "\%u[fF]{2}[0-9a-fA-F]{2}" \
 # 	  ASCII 1-255 : Full ASCII range without null character
 #
 # 920271: PL2 : REQUEST_URI, REQUEST_HEADERS, ARGS and ARGS_NAMES
-#         ASCII 32-126,128-255 : Full visible ASCII range
+#         ASCII 9,10,13,32-126,128-255 : Full visible ASCII range, tab, newline
 #
 # 920272: PL3 : REQUEST_URI, REQUEST_HEADERS, ARGS, ARGS_NAMES and REQUEST_BODY
 #         ASCII 32-36,38-126 : Visible lower ASCII range without percent symbol
@@ -1260,7 +1260,7 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
 #
 # PL2: This is a stricter sibling of 920270.
 #
-SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 32-126,128-255" \
+SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,32-126,128-255" \
   "phase:request,\
    rev:'2',\
    ver:'OWASP_CRS/3.0.0',\


### PR DESCRIPTION
Rule 920271 (Invalid character in request (non printable characters)) did not allow tabs and newline chars - `\t` `\r` `\n` - in ARGS when running at PL2. While there is a good case for char whitelisting, I feel it is untenable at this paranoia level.

Any form containing a newline is simply rejected in PL2, which is basically any contact form, comment form, etc... People typing spacing chars in them is terribly common. In PL2 we can't expect users to create an exclusion for every textarea.

With this change, the most frequent FP was resolved in my internal testing.

I'd preferred more discussion on the #624 but my time window is compressed so I made the PR anyway.