### PR TITLE
pull request to resolve word-boundaries issue #246

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -153,7 +153,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:\s*?(?:exec|execute).*?(?:\W)xp_cmdshell)|(?:[\"'`]\s*?!\s*?[\"'`\w])|(?:from\W+information_schema\W)|(?:(?:(?:current_)?user|database|schema|connection_id)\s*?\([^\)]*?)|(?:[\"'`];?\s*?(?:select|union|having)\s*?[^\s])|(?:\wiif\s*?\()|(?:(?:exec|execute)\s+master\.)|(?:union select @)|(?:union[\w(\s]*?select)|(?:select.*?\w?user\()|(?:into[\s+]+(?:dump|out)file\s*?[\"'`]))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:\s*?(?:exec|execute).*?(?:\W)xp_cmdshell)|(?:[\"'`]\s*?!\s*?[\"'`\w])|(?:from\W+information_schema\W)|(?:(?:(?:current_)?user|database|schema|connection_id)\s*?\([^\)]*?)|(?:[\"'`];?\s*?(?:select|union|having)\b\s*?[^\s])|(?:\wiif\s*?\()|(?:(?:exec|execute)\s+master\.)|(?:union select @)|(?:union[\w(\s]*?select)|(?:select.*?\w?user\()|(?:into[\s+]+(?:dump|out)file\s*?[\"'`]))" \
 	"phase:request,\
 	rev:'2',\
 	ver:'OWASP_CRS/3.0.0',\


### PR DESCRIPTION
This pull request is a proposal to resolve issue #246.

I’ve added a word boundary after this group (?:select|union|having)\b.

I’ve considered three different options:
1)     Add a word boundary at the end, after the whole regexp.
2)     Add a word boundary at the end of the whole group ()
3)     Add a word boundary just after the command select.

I thougt 1) is inappropriate because the other alternatives (|) have different anchors and don’t hit FP so easily. At least we got no issues yet.
Between 2) and 3) it was not easy to choose.
Now I’ve chosen number 2) because I think it’s possible to get a FP with “union some character or “having some character. And it’s more readable. And a word boundary just after these words doesn’t raise the risk to get a false negative.

If you don’t agree, feel free to reject this PR.

Regards,
Franziska