### PR TITLE
PR to resolve issue #243: semicolon in FILES

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -80,12 +80,24 @@ SecRule REQUEST_LINE "!^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+)?)?
 # -=[ Rule Logic ]=-
 # These rules check for the existence of the ' " ; = meta-characters in
 # either the file or file name variables.
+# HTML entities may lead to false positives, why they are allowed on PL1.
+# Negative look behind assertions allow frequently used entities &_;
+#
+# -=[ Targets, characters and html entities ]=-
+#
+# 920120: PL1 : FILES_NAMES, FILES
+#         ['\";=] but allowed:
+#         &[aAoOuUyY]uml); &[aAeEiIoOuU]circ; &[eEiIoOuUyY]acute;
+#         &[aAeEiIoOuU]grave; &[cC]cedil; &[aAnNoO]tilde; &amp; &apos;
+#
+# 920121: PL2 : FILES_NAMES, FILES
+#         ['\";=] : ' " ; = meta-characters
 #
 # -=[ References ]=-
 # https://www.owasp.org/index.php/ModSecurity_CRS_RuleID-960000
 # http://www.ietf.org/rfc/rfc2183.txt
 #
-SecRule FILES_NAMES|FILES "['\";=]" \
+SecRule FILES_NAMES|FILES "(?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:[eEiIoOuUyY]acute)|&(?:[aAeEiIoOuU]grave)|&(?:[cC]cedil)|&(?:[aAnNoO]tilde)|&(?:amp)|&(?:apos));|['\"=]" \
   "msg:'Attempted multipart/form-data bypass',\
   severity:'CRITICAL',\
   id:920120,\
@@ -1312,6 +1324,33 @@ SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
    setvar:'tx.msg=%{rule.msg}',\
    setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
+
+
+#
+# PL2: This is a stricter sibling of 920120.
+#
+SecRule FILES_NAMES|FILES "['\";=]" \
+  "msg:'Attempted multipart/form-data bypass',\
+  severity:'CRITICAL',\
+  id:920121,\
+  ver:'OWASP_CRS/3.0.0',\
+  rev:'1',\
+  maturity:'9',\
+  accuracy:'7',\
+  logdata:'%{matched_var}',\
+  phase:request,\
+  block,\
+  t:none,t:urlDecodeUni,\
+  tag:'application-multi',\
+  tag:'language-multi',\
+  tag:'platform-multi',\
+  tag:'attack-protocol',\
+  tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ',\
+  tag:'CAPEC-272',\
+  tag:'paranoia-level/2',\
+  setvar:'tx.msg=%{rule.msg}',\
+  setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+  setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ-%{matched_var_name}=%{matched_var}'"
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:1,id:920015,nolog,pass,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"


### PR DESCRIPTION
Extended regex in rule id 920120 with negative look behind assertions to allow html entities in files.
Added new rule 920121 on PL2 with original, short and stricter regex.

Resolves issue #243.