### PR TITLE
Simplify Drupal exclusions around form_build_id

### DIFF
--- a/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
@@ -75,12 +75,14 @@ SecRule &TX:crs_exclusions_drupal|TX:crs_exclusions_drupal "@eq 0" \
 #
 # 9001100 Session Cookie
 # 9001110 Password
-# 9001120 Admin Settings (general)
+# 9001120 FREE for use
+# 9001130 FREE for use
 # 9001140 Content and Descriptions
-# 9001150 Themes Settings
+# 9001150 FREE for use
 # 9001160 Form Token
 # 9001170 Text Formats and Editors
 # 9001180 WYSIWYG/CKEditor Assets and Upload
+# 9001190 FREE for use
 # 9001200 Content and Descriptions
 #
 # The rule id range from 9001200 to 9001999 is reserved for future
@@ -150,19 +152,11 @@ SecRule REQUEST_FILENAME "@rx /user/[0-9]+/edit$" \
 # Disable known false positives for various fields used on admin pages.
 #
 # Rule Exclusion: 920271 Invalid character in request on multiple fields/paths
-# Rule Exclusion: 942440 SQL Comment Sequence Detected on multiple fields/paths
 # Rule Exclusion: 942430 Restricted SQL Character Anomaly Detection (args)
 #                        Disabled completely for admin/config pages
 # For the people/accounts page, we disable the CRS completely for a number of
 # freeform text fields.
 #
-SecRule REQUEST_FILENAME "@contains /admin/appearance/settings/" \
-        "id:9001120,\
-        phase:2,\
-        nolog,\
-        pass,\
-        ctl:ruleRemoveTargetById=942440;ARGS:form_build_id"
-
 SecRule REQUEST_FILENAME "@contains /admin/config/" \
         "id:9001122,\
         phase:2,\
@@ -219,23 +213,9 @@ SecRule REQUEST_FILENAME "@endsWith /contextual/render" \
 
 
 #
-# [ Themes Settings ]
-#
-# Disable known false positives.
-#
-# Rule Exclusion for form_build_id: 942440 SQL Comment Sequence Detected
-#
-SecRule REQUEST_FILENAME "@contains /admin/appearance/settings/" \
-        "id:9001150,\
-        phase:2,\
-        nolog,\
-        pass,\
-        ctl:ruleRemoveTargetById=942440;ARGS:form_build_id"
-
-
-#
 # [ Form Token / Build ID ]
 #
+# Rule Exclusion for form_build_id: 942440 SQL Comment Sequence Detected on ...
 # Rule Exclusion for form_token:    942450 SQL Hex Encoding
 # Rule Exclusion for form_build_id: 942450 SQL Hex Encoding
 #
@@ -245,6 +225,7 @@ SecAction "id:9001160,\
         phase:2,\
         nolog,\
         pass,\
+        ctl:ruleRemoveTargetById=942440;ARGS:form_build_id,\
         ctl:ruleRemoveTargetById=942450;ARGS:form_token,\
         ctl:ruleRemoveTargetById=942450;ARGS:form_build_id"
 


### PR DESCRIPTION
This picks up #666 by @ damienmckenna but targeted the wrong branch. Worked on the comments a bit.

In essence it addresses #661 by @lifeforms.