### PR TITLE
Resolves issue #659 JSON in KNOWN_BUGS

### DIFF
--- a/KNOWN_BUGS
+++ b/KNOWN_BUGS
@@ -27,3 +27,9 @@ or the CRS mailinglist at
   which converts the rules into a format that works around the bug.
   You have to re-run this script whenever you modify or update 
   the CRS rules.
+* Debian up to and including Jessie lacks YAJL/JSON support in ModSecurity,
+  which causes the following error in the Apache ErrorLog or SecAuditLog:
+    'ModSecurity: JSON support was not enabled.'
+  JSON support was enabled in Debian's package version 2.8.0-4 (Nov 2014).
+  You can either use backports.debian.org to install the latest ModSecurity
+  release or disable rule id 200001.


### PR DESCRIPTION
Adds a note about missing YAJL/JSON support in Debian ModSecurity in KNOWN_BUGS:
Issue #659.