### PR TITLE
Adding application/octet-stream to default tx.allowed_request_content…

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -329,7 +329,9 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
 # Content-Types that a client is allowed to send in a request.
-# Default: application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|text/plain
+# Default: application/x-www-form-urlencoded|multipart/form-data|text/xml|\
+# application/xml|application/x-amf|application/json|application/octet-stream|\
+# text/plain
 # Uncomment this rule to change the default.
 #SecAction \
 # "id:900220,\
@@ -337,7 +339,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|text/plain'"
+#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|application/octet-stream|text/plain'"
 
 # Allowed HTTP versions.
 # Default: HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -161,7 +161,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|text/plain'"
+    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|application/octet-stream|text/plain'"
 
 # Default HTTP policy: allowed_http_versions (rule 900230)
 SecRule &TX:allowed_http_versions "@eq 0" \


### PR DESCRIPTION
Resolves issue #657 by adding application/octet-stream to default list of allowed request content types (`tx.allowed_request_content_type`).

For 3.1, this content type will be forbidden in a new rule at PL2 or PL3.