### PR TITLE
Remove unnecessasry capture actions

### DIFF
--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -41,7 +41,6 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
   ver:'OWASP_CRS/3.0.0',\
   maturity:'9',\
   accuracy:'9',\
-  capture,\
   logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
   tag:'application-multi',\
   tag:'language-multi',\
@@ -141,7 +140,6 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scripting-user-agents.data" \
   ver:'OWASP_CRS/3.0.0',\
   maturity:'9',\
   accuracy:'7',\
-  capture,\
   logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
   tag:'application-multi',\
   tag:'language-multi',\
@@ -181,7 +179,6 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile crawlers-user-agents.data" \
   ver:'OWASP_CRS/3.0.0',\
   maturity:'9',\
   accuracy:'9',\
-  capture,\
   logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
   tag:'application-multi',\
   tag:'language-multi',\


### PR DESCRIPTION
capture has no value when the operator is not `@rx`.