### PR TITLE
Lowercase transform when pmf is used

### DIFF
--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -38,6 +38,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
   phase:request,\
   block,\
   t:none,\
+  t:lowercase,\
   ver:'OWASP_CRS/3.0.0',\
   maturity:'9',\
   accuracy:'9',\
@@ -68,6 +69,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmf scanners-headers.data" \
   maturity:'9',\
   accuracy:'9',\
   t:none,\
+  t:lowercase,\
   block,\
   logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
   tag:'application-multi',\
@@ -96,6 +98,7 @@ SecRule REQUEST_FILENAME|ARGS "@pmf scanners-urls.data" \
   maturity:'9',\
   accuracy:'9',\
   t:none,\
+  t:lowercase,\
   block,\
   logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
   tag:'application-multi',\
@@ -138,6 +141,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scripting-user-agents.data" \
   phase:request,\
   block,\
   t:none,\
+  t:lowercase,\
   ver:'OWASP_CRS/3.0.0',\
   maturity:'9',\
   accuracy:'7',\
@@ -178,6 +182,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile crawlers-user-agents.data" \
   phase:request,\
   block,\
   t:none,\
+  t:lowercase,\
   ver:'OWASP_CRS/3.0.0',\
   maturity:'9',\
   accuracy:'9',\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -121,7 +121,7 @@ SecRule REQUEST_FILENAME "@pmf restricted-files.data" \
 	maturity:'7',\
 	accuracy:'8',\
 	capture,\
-	t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,\
+	t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,t:lowercase,\
 	block,\
 	id:930130,\
 	tag:'application-multi',\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -245,7 +245,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'1',\
 	accuracy:'7',\
 	capture,\
-	t:none,t:urlDecodeUni,t:cmdLine,\
+	t:none,t:urlDecodeUni,t:cmdLine,t:lowercase,\
 	ctl:auditLogParts=+E,\
 	block,\
 	id:932120,\
@@ -428,7 +428,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'1',\
 	accuracy:'8',\
 	capture,\
-	t:none,t:urlDecodeUni,t:cmdLine,t:normalizePath,\
+	t:none,t:urlDecodeUni,t:cmdLine,t:normalizePath,t:lowercase,\
 	ctl:auditLogParts=+E,\
 	block,\
 	id:932160,\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -114,7 +114,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         maturity:'1',\
         accuracy:'8',\
         capture,\
-        t:none,t:urlDecodeUni,t:normalisePath,\
+        t:none,t:urlDecodeUni,t:normalisePath,t:lowercase,\
         ctl:auditLogParts=+E,\
         block,\
         id:933120,\
@@ -146,7 +146,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         maturity:'1',\
         accuracy:'8',\
         capture,\
-        t:none,t:normalisePath,t:urlDecodeUni,\
+        t:none,t:normalisePath,t:urlDecodeUni,t:lowercase,\
         ctl:auditLogParts=+E,\
         block,\
         id:933130,\
@@ -259,7 +259,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
         maturity:'1',\
         accuracy:'9',\
         capture,\
-        t:none,\
+        t:none,t:lowercase,\
         ctl:auditLogParts=+E,\
         block,\
         id:933150,\
@@ -481,7 +481,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
         maturity:'1',\
         accuracy:'7',\
         capture,\
-        t:none,\
+        t:none,t:lowercase,\
         ctl:auditLogParts=+E,\
         block,\
         id:933151,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -569,7 +569,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	maturity:'9',\
 	accuracy:'8',\
 	capture,\
-	t:none,t:urlDecodeUni,\
+	t:none,t:urlDecodeUni,t:lowercase,\
 	ctl:auditLogParts=+E,\
 	block,\
 	msg:'SQL Injection Attack',\

--- a/rules/scanners-headers.data
+++ b/rules/scanners-headers.data
@@ -5,4 +5,4 @@ acunetix-user-agreement
 myvar=1234
 x-ratproxy-loop
 bytes=0-,5-0,5-1,5-2,5-3,5-4,5-5,5-6,5-7,5-8,5-9,5-10,5-11,5-12,5-13,5-14
-X-Scanner
+x-scanner


### PR DESCRIPTION
Some Aho-Corasick implementations are case sensitive, so the lack
of this transformation results in a false negative for these rules.