### PR TITLE
Revert "Remove unnecessasry capture actions"

### DIFF
--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -41,6 +41,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
   ver:'OWASP_CRS/3.0.0',\
   maturity:'9',\
   accuracy:'9',\
+  capture,\
   logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
   tag:'application-multi',\
   tag:'language-multi',\
@@ -140,6 +141,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scripting-user-agents.data" \
   ver:'OWASP_CRS/3.0.0',\
   maturity:'9',\
   accuracy:'7',\
+  capture,\
   logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
   tag:'application-multi',\
   tag:'language-multi',\
@@ -179,6 +181,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile crawlers-user-agents.data" \
   ver:'OWASP_CRS/3.0.0',\
   maturity:'9',\
   accuracy:'9',\
+  capture,\
   logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
   tag:'application-multi',\
   tag:'language-multi',\


### PR DESCRIPTION
This reverts commit e02e93c7177bcaf4b3872c4ad7348c5064429331.

Okay. this is a little annoying. Apparently, capture does have a valid (semi-undocumented) use in populating `TX.0` when `@pm` and friends are used. This is not documented in the `capture` reference doc:

https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#capture

But it is in `TX`:

https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#tx

Additionally, there are other places in the reference doc alluding to operators supporting `capture`:

https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#sanitisematchedbytes

> You must use capture action with sanitiseMatchedBytes, so the operator must support capture action. ie: `@rx`, `@verifyCC`.

It would make sense to have it in `@verifyCC` and friends that leverage regex parsing, though as it stands it appears not all operators that have support for this action in the 2.x branch use it in v3. It seems some more research is warranted here, but this change was certainly wrong; my bad!