### PR TITLE
Resolves issue #663: libinjection XSS FP with 'on' in URLs

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -784,6 +784,38 @@ SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:941014,nolog,pass,skipAfter:END-RE
 # -= Paranoia Level 2 =- (apply only when tx.paranoia_level is sufficiently high: 2 or higher)
 #
 
+#
+# This is a stricter sibling of rule 941100.
+#
+SecRule REQUEST_HEADERS:Referer "@detectXSS" \
+        "msg:'XSS Attack Detected via libinjection',\
+        id:941101,\
+        phase:request,\
+        severity:'CRITICAL',\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'1',\
+        accuracy:'9',\
+        t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
+        block,\
+        ctl:auditLogParts=+E,\
+        capture,\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-xss',\
+        tag:'OWASP_CRS/WEB_ATTACK/XSS',\
+        tag:'WASCTC/WASC-8',\
+        tag:'WASCTC/WASC-22',\
+        tag:'OWASP_TOP_10/A3',\
+        tag:'OWASP_AppSensor/IE1',\
+        tag:'CAPEC-242',\
+        tag:'paranoia-level/2',\
+        logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:tx.xss_score=+%{tx.critical_anomaly_score},\
+        setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+        setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}"
 
 # Detect tags that are the most common direct HTML injection points.
 #
@@ -930,38 +962,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}"
 
-#
-# This is a stricter sibling of rule 941100.
-#
-SecRule REQUEST_HEADERS:Referer "@detectXSS" \
-        "msg:'XSS Attack Detected via libinjection',\
-        id:941101,\
-        phase:request,\
-        severity:'CRITICAL',\
-        rev:'2',\
-        ver:'OWASP_CRS/3.0.0',\
-        maturity:'1',\
-        accuracy:'9',\
-        t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
-        block,\
-        ctl:auditLogParts=+E,\
-        capture,\
-        tag:'application-multi',\
-        tag:'language-multi',\
-        tag:'platform-multi',\
-        tag:'attack-xss',\
-        tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-        tag:'WASCTC/WASC-8',\
-        tag:'WASCTC/WASC-22',\
-        tag:'OWASP_TOP_10/A3',\
-        tag:'OWASP_AppSensor/IE1',\
-        tag:'CAPEC-242',\
-        tag:'paranoia-level/2',\
-        logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-        setvar:'tx.msg=%{rule.msg}',\
-        setvar:tx.xss_score=+%{tx.critical_anomaly_score},\
-        setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-        setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}"
 
 
 

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -32,9 +32,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:2,id:941012,nolog,pass,skipAfter:END-RE
 #               REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|
 #               ARGS_NAMES|ARGS|XML:/*
 #
-# 941101: PL2 : REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|
-#               REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|
-#               REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/*
+# 941101: PL2 : REQUEST_HEADERS:Referer
 #
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@detectXSS" \
 	"msg:'XSS Attack Detected via libinjection',\
@@ -932,7 +930,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}"
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@detectXSS" \
+#
+# This is a stricter sibling of rule 941100.
+#
+SecRule REQUEST_HEADERS:Referer "@detectXSS" \
         "msg:'XSS Attack Detected via libinjection',\
         id:941101,\
         phase:request,\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -59,7 +59,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 	tag:'OWASP_TOP_10/A3',\
 	tag:'OWASP_AppSensor/IE1',\
 	tag:'CAPEC-242',\
-	tag:'paranoia-level/1',\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	setvar:'tx.msg=%{rule.msg}',\
 	setvar:tx.xss_score=+%{tx.critical_anomaly_score},\
@@ -956,7 +955,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
         tag:'OWASP_TOP_10/A3',\
         tag:'OWASP_AppSensor/IE1',\
         tag:'CAPEC-242',\
-	tag:'paranoia-level/2',\
+        tag:'paranoia-level/2',\
         logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.xss_score=+%{tx.critical_anomaly_score},\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -26,7 +26,17 @@ SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:2,id:941012,nolog,pass,skipAfter:END-RE
 # Ref: https://libinjection.client9.com/
 # Ref: https://speakerdeck.com/ngalbreath/libinjection-from-sqli-to-xss
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@detectXSS" \
+# -=[ Targets ]=-
+#
+# 941100: PL1 : REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|
+#               REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|
+#               ARGS_NAMES|ARGS|XML:/*
+#
+# 941101: PL2 : REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|
+#               REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|
+#               REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/*
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@detectXSS" \
 	"msg:'XSS Attack Detected via libinjection',\
 	id:941100,\
 	phase:request,\
@@ -49,6 +59,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 	tag:'OWASP_TOP_10/A3',\
 	tag:'OWASP_AppSensor/IE1',\
 	tag:'CAPEC-242',\
+	tag:'paranoia-level/1',\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	setvar:'tx.msg=%{rule.msg}',\
 	setvar:tx.xss_score=+%{tx.critical_anomaly_score},\
@@ -921,6 +932,36 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 	setvar:tx.xss_score=+%{tx.critical_anomaly_score},\
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}"
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@detectXSS" \
+        "msg:'XSS Attack Detected via libinjection',\
+        id:941101,\
+        phase:request,\
+        severity:'CRITICAL',\
+        rev:'2',\
+        ver:'OWASP_CRS/3.0.0',\
+        maturity:'1',\
+        accuracy:'9',\
+        t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
+        block,\
+        ctl:auditLogParts=+E,\
+        capture,\
+        tag:'application-multi',\
+        tag:'language-multi',\
+        tag:'platform-multi',\
+        tag:'attack-xss',\
+        tag:'OWASP_CRS/WEB_ATTACK/XSS',\
+        tag:'WASCTC/WASC-8',\
+        tag:'WASCTC/WASC-22',\
+        tag:'OWASP_TOP_10/A3',\
+        tag:'OWASP_AppSensor/IE1',\
+        tag:'CAPEC-242',\
+	tag:'paranoia-level/2',\
+        logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:tx.xss_score=+%{tx.critical_anomaly_score},\
+        setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+        setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}"
 
 
 


### PR DESCRIPTION
Removed check of request header referer from rule 941100 on PL1 and added new rule 941101 on PL2 which checks request header referer again.
Resolves issue #663.