### PR TITLE
 According to the RFC 3902 (application/soap+xml) 

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -330,8 +330,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 # Content-Types that a client is allowed to send in a request.
 # Default: application/x-www-form-urlencoded|multipart/form-data|text/xml|\
-# application/xml|application/x-amf|application/json|application/octet-stream|\
-# text/plain
+# application/xml|application/soap+xml|application/x-amf|application/json|\
+# application/octet-stream|text/plain
 # Uncomment this rule to change the default.
 #SecAction \
 # "id:900220,\

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -339,7 +339,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|application/octet-stream|text/plain'"
+#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|text/plain'"
 
 # Allowed HTTP versions.
 # Default: HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -161,7 +161,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf|application/json|application/octet-stream|text/plain'"
+    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|text/plain'"
 
 # Default HTTP policy: allowed_http_versions (rule 900230)
 SecRule &TX:allowed_http_versions "@eq 0" \


### PR DESCRIPTION
According to the RFC 3902 (application/soap+xml) shoud be also allowed.

https://www.ietf.org/rfc/rfc3902.txt

```
SOAP HTTP binding

In the SOAP 1.2 HTTP binding, the SOAPAction HTTP header defined in SOAP 1.1 has been removed, and a new HTTP status code 427 has been sought from IANA for indicating (at the discretion of the HTTP origin server) that its presence is required by the server application. The contents of the former SOAPAction HTTP header are now expressed as a value of an (optional) "action" parameter of the "application/soap+xml" media type that is signaled in the HTTP binding.
In the SOAP 1.2 HTTP binding, the Content-type header should be "application/soap+xml" instead of "text/xml" as in SOAP 1.1. The IETF registration for this new media type is [RFC 3902].
SOAP 1.2 provides a finer grained description of use of the various 2xx, 3xx, 4xx HTTP status codes.
Support of the HTTP extensions framework has been removed from SOAP 1.2.
SOAP 1.2 provides an additional message exchange pattern which may be used as a part of the HTTP binding that allows the use of HTTP GET for safe and idempotent information retrievals.
```

