### PR TITLE
Resolve additional false positives in WordPress

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -162,6 +162,25 @@ SecRule REQUEST_FILENAME "@endsWith /wp-cron.php" \
 	ctl:ruleRemoveById=920180,\
 	ctl:ruleRemoveById=920300"
 
+
+#
+# [ Cookies ]
+
+# WP Session Manager
+# Cookie: _wp_session=[hex]||[timestamp]||[timestamp]
+# detected SQLi using libinjection with fingerprint 'n&1'
+SecRule REQUEST_COOKIES:_wp_session "@rx ^[0-9a-f]+||\d+||\d+$" \
+	"id:9002300,\
+	phase:1,\
+	t:none,\
+	nolog,\
+	pass,\
+	chain"
+	SecRule &REQUEST_COOKIES:_wp_session "@eq 1" \
+		"t:none,\
+		ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:_wp_session"
+
+
 #
 # -=[ WordPress Administration Back-End (wp-admin) ]=-
 #
@@ -240,6 +259,8 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
 	SecRule &ARGS:action "@eq 1" \
 		"t:none,\
 		ctl:ruleRemoveTargetById=931130;ARGS:url,\
+		ctl:ruleRemoveTargetById=931130;ARGS:facebook,\
+		ctl:ruleRemoveTargetById=931130;ARGS:googleplus,\
 		ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
 		ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
 		ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"
@@ -285,7 +306,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-new.php" \
 # [ General exclusions ]
 #
 
-# _wp_http_referer is passed on a lot of wp-admin pages
+# _wp_http_referer and wp_http_referer are passed on a lot of wp-admin pages
 SecAction \
 	"id:9002600,\
 	phase:2,\
@@ -294,11 +315,20 @@ SecAction \
 	pass,\
 	ctl:ruleRemoveTargetById=920230;ARGS:_wp_http_referer,\
 	ctl:ruleRemoveTargetById=931130;ARGS:_wp_http_referer,\
+	ctl:ruleRemoveTargetById=932150;ARGS:_wp_http_referer,\
+	ctl:ruleRemoveTargetById=941100;ARGS:_wp_http_referer,\
 	ctl:ruleRemoveTargetById=942130;ARGS:_wp_http_referer,\
 	ctl:ruleRemoveTargetById=942200;ARGS:_wp_http_referer,\
 	ctl:ruleRemoveTargetById=942260;ARGS:_wp_http_referer,\
-	ctl:ruleRemoveTargetById=942431;ARGS:_wp_http_referer"
-
+	ctl:ruleRemoveTargetById=942431;ARGS:_wp_http_referer,\
+	ctl:ruleRemoveTargetById=920230;ARGS:wp_http_referer,\
+	ctl:ruleRemoveTargetById=931130;ARGS:wp_http_referer,\
+	ctl:ruleRemoveTargetById=932150;ARGS:wp_http_referer,\
+	ctl:ruleRemoveTargetById=941100;ARGS:wp_http_referer,\
+	ctl:ruleRemoveTargetById=942130;ARGS:wp_http_referer,\
+	ctl:ruleRemoveTargetById=942200;ARGS:wp_http_referer,\
+	ctl:ruleRemoveTargetById=942260;ARGS:wp_http_referer,\
+	ctl:ruleRemoveTargetById=942431;ARGS:wp_http_referer"
 
 #
 # [ Content editing ]
@@ -404,7 +434,27 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
 		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[16][text],\
 		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[17][text],\
 		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[18][text],\
-		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[19][text]"
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[19][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[20][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[21][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[22][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[23][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[24][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[25][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[26][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[27][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[28][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[29][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[30][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[31][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[32][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[33][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[34][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[35][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[36][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[37][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[38][text],\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[39][text]"
 
 # Reorder widgets
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
@@ -448,6 +498,21 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
 	SecRule &ARGS:action "@eq 1" \
 		"t:none,\
 		ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:new_title"
+
+# Add external link to menu
+SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
+	"id:9002760,\
+	phase:2,\
+	t:none,\
+	nolog,\
+	pass,\
+	chain"
+	SecRule ARGS:action "@streq add-menu-item" \
+		"t:none,\
+		chain"
+	SecRule &ARGS:action "@eq 1" \
+		"t:none,\
+		ctl:ruleRemoveTargetById=931130;ARGS:menu-item[-1][menu-item-url]"
 
 
 #

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -594,6 +594,15 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
 # admin-bar,buttons,media-views,common,forms,admin-menu,dashboard,
 # list-tables,edit,revisions,media,themes,about,nav-menu&load%5B%5D=
 # s,widgets,site-icon,l10n,wp-auth-check&ver=4.6.1
+#
+# /wp-admin/load-scripts.php?c=0&load%5B%5D=hoverIntent,common,
+# admin-bar,jquery-ui-widget,jquery-ui-position,wp-pointer,
+# wp-ajax-response,jquery-color,wp-lists,quicktags,
+# jqu&load%5B%5D=ery-query,admin-comments,jquery-ui-core,
+# jquery-ui-mouse,jquery-ui-sortable,postbox,dashboard,underscore,
+# customize-base,customize&load%5B%5D=-loader,thickbox,plugin-install,
+# wp-util,wp-a11y,updates,shortcode,media-upload,svg-painter,
+# jquery-ui-accordion&ver=3f9999390861a0133beda3ee8acf152e
 SecRule REQUEST_FILENAME "@rx /wp-admin/load-(scripts|styles)\.php$" \
 	"id:9002900,\
 	phase:2,\
@@ -603,6 +612,7 @@ SecRule REQUEST_FILENAME "@rx /wp-admin/load-(scripts|styles)\.php$" \
 	ctl:ruleRemoveById=921180,\
 	ctl:ruleRemoveTargetById=920273;ARGS_NAMES:load[],\
 	ctl:ruleRemoveTargetById=942432;ARGS_NAMES:load[],\
+	ctl:ruleRemoveTargetById=942360;ARGS:load[],\
 	ctl:ruleRemoveTargetById=942430;ARGS:load[],\
 	ctl:ruleRemoveTargetById=942431;ARGS:load[],\
 	ctl:ruleRemoveTargetById=942432;ARGS:load[]"


### PR DESCRIPTION
Addresses additional false positives in WordPress:

- libinjection match in WP Session Manager cookie
- adding Facebook and Google+ urls in user profile 
- self URLs in wp_http_referer parameter
- adding custom HTML in widgets when having up to 40 widgets on a page
- adding an external URL to a menu
- SQLi match in load-scripts.php, reported by @YbyMMbPh

Resolves issue #680.
