### PR TITLE
preventing unwanted positives that evade the log

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -231,13 +231,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 	tag:'OWASP_AppSensor/IE1',\
 	tag:'CAPEC-242',\
 	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-	setvar:'tx.msg=%{rule.msg}',\
-	setvar:tx.xss_score=+%{tx.critical_anomaly_score},\
-	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
-	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0},\
 	chain"
 		SecRule TX:ALLOW_HTML "@eq 0"
-
+			"setvar:'tx.msg=%{rule.msg}',\
+			setvar:tx.xss_score=+%{tx.critical_anomaly_score},\
+			setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+			setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}"
 
 #
 # -=[ NoScript XSS Filters ]=-


### PR DESCRIPTION
If TX:ALLOW_HTML is set to anything but 0 (which isn't the default), this chain doesn't log, however it still changes the anomaly score (because setvar works even within an unfinished chain). This not only leads to unwanted positives (and possibly blocks), it also does not log properly since the chain is not finished. Therefore, the setting of the variables should be in the very last link of the chain.

Here is an example; it is the whole "H" section of the audit log:
```
--WOt7HMCojD4AABarFqMAAAAM-H--
Message: Warning. Operator GE matched 5 at TX:anomaly_score. [file "/etc/httpd/modsecurity.d/activated_rules/REQUEST-949-BLOCKING-EVALUATION.conf"] [line "55"] [id "949110"] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"] [severity "CRITICAL"] [tag "Host: xxx"] [tag "application-multi"] [tag "platform-multi"] [tag "attack-generic"]
Message: Warning. Operator GE matched 5 at TX:inbound_anomaly_score. [file "/etc/httpd/modsecurity.d/activated_rules/RESPONSE-980-CORRELATION.conf"] [line "73"] [id "980130"] [msg "Inbound Anomaly Score Exceeded (Total Inbound Score: 5 - SQLI=0,XSS=5,RFI=0,LFI=0,RCE=0,PHPI=0,HTTP=0,SESS=0): XSS Filter - Category 5: Disallowed HTML Attributes"] [tag "Host: xxx"] [tag "event-correlation"]
Apache-Handler: fcgid-script
Stopwatch: 1491827484922151 190189 (- - -)
Stopwatch2: 1491827484922151 190189; combined=36096, p1=688, p2=31114, p3=126, p4=3909, p5=259, sr=0, sw=0, l=0, gc=0
Response-Body-Transformed: Dechunked
Producer: ModSecurity for Apache/2.9.1 (http://www.modsecurity.org/); OWASP_CRS/3.0.0.
Server: Apache
Engine-Mode: "DETECTION_ONLY"
```