### PR TITLE
REMOTE_ADDR for internal loopback & HTTP/2.0 compatibility

### DIFF
--- a/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+++ b/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
@@ -32,7 +32,7 @@ SecRule REQUEST_LINE "@streq GET /" \
 #
 # Exception for Apache internal dummy connection
 #
-SecRule REQUEST_LINE "^(GET /|OPTIONS \*) HTTP/1\.[01]$" \
+SecRule REQUEST_LINE "^(GET /|OPTIONS \*) HTTP/[12]\.[01]$" \
 	"phase:1,\
 	id:905110,\
 	t:none,\

--- a/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+++ b/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
@@ -24,7 +24,7 @@ SecRule REQUEST_LINE "@streq GET /" \
 	tag:'platform-apache',\
 	tag:'attack-generic',\
 	chain"
-		SecRule TX:REAL_IP "@ipMatch 127.0.0.1,::1" \
+		SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
 			"t:none,\
 			ctl:ruleEngine=Off,\
 			ctl:auditEngine=Off"
@@ -43,7 +43,7 @@ SecRule REQUEST_LINE "^(GET /|OPTIONS \*) HTTP/1\.[01]$" \
         tag:'platform-apache',\
         tag:'attack-generic',\
 	chain"
-		SecRule TX:REAL_IP "@ipMatch 127.0.0.1,::1" \
+		SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
 		"t:none,\
 		chain"
 			SecRule REQUEST_HEADERS:User-Agent "^.*\(internal dummy connection\)$" \


### PR DESCRIPTION
An exception for an internal loopback makes no sense with TX:REAL_IP.
The remote address will be always 127.0.0.1,::1.
It should be better to use REMOTE_ADDR instead

https://wiki.apache.org/httpd/InternalDummyConnection


The rule 905110 should be compatible to HTTP/2.0