### PR TITLE
Fixing bug in 912160 (dos_burst_counter jumping from 0 to 2)

### DIFF
--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -182,7 +182,8 @@ SecRule REQUEST_BASENAME ".*?(\.[a-z0-9]{1,10})?$" \
 # - 912161: raise from 1 to 2
 #
 # This approach with two rules avoids raising the burst counter
-# from 0 to 2 via two concurrent requests.
+# from 0 to 2 via two concurrent requests. We do not raise the
+# burst counter beyond 2.
 #
 # 
 SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \

--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -185,7 +185,7 @@ SecRule REQUEST_BASENAME ".*?(\.[a-z0-9]{1,10})?$" \
 # from 0 to 2 via two concurrent requests. We do not raise the
 # burst counter beyond 2.
 #
-# 
+#
 SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
 	"phase:5,\
 	id:912160,\

--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -177,11 +177,17 @@ SecRule REQUEST_BASENAME ".*?(\.[a-z0-9]{1,10})?$" \
 #
 # Check DOS Counter
 # If the request count is greater than or equal to user settings,
-# we set the burst counter.
+# we then raise the burst counter. This happens via two separate rules:
+# - 912160: raise from 0 to 1
+# - 912161: raise from 1 to 2
 #
-SecRule IP:DOS_COUNTER "@gt %{tx.dos_counter_threshold}" \
+# This approach with two rules avoids raising the burst counter
+# from 0 to 2 via two concurrent requests.
+#
+# 
+SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
 	"phase:5,\
-	id:912160,\
+	id:'912160',\
 	t:none,\
 	nolog,\
 	pass,\
@@ -189,9 +195,28 @@ SecRule IP:DOS_COUNTER "@gt %{tx.dos_counter_threshold}" \
 	tag:'language-multi',\
 	tag:'platform-multi',\
 	tag:'attack-dos',\
-	setvar:ip.dos_burst_counter=+1,\
-	expirevar:ip.dos_burst_counter=%{tx.dos_burst_time_slice},\
-	setvar:!ip.dos_counter"
+	chain"
+	SecRule &IP:DOS_BURST_COUNTER "@eq 0" \
+		"setvar:ip.dos_burst_counter=1,\
+		expirevar:ip.dos_burst_counter=%{tx.dos_burst_time_slice},\
+		setvar:!ip.dos_counter"
+
+
+SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
+	"phase:5,\
+	id:'912161',\
+	t:none,\
+	nolog,\
+	pass,\
+	tag:'application-multi',\
+	tag:'language-multi',\
+	tag:'platform-multi',\
+	tag:'attack-dos',\
+	chain"
+	SecRule &IP:DOS_BURST_COUNTER "@ge 1" \
+		"setvar:ip.dos_burst_counter=2,\
+		expirevar:ip.dos_burst_counter=%{tx.dos_burst_time_slice},\
+		setvar:!ip.dos_counter"
 
 
 #

--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -177,7 +177,7 @@ SecRule REQUEST_BASENAME ".*?(\.[a-z0-9]{1,10})?$" \
 #
 # Check DOS Counter
 # If the request count is greater than or equal to user settings,
-# we then raise the burst counter. This happens via two separate rules:
+# we raise the burst counter. This happens via two separate rules:
 # - 912160: raise from 0 to 1
 # - 912161: raise from 1 to 2
 #
@@ -187,7 +187,7 @@ SecRule REQUEST_BASENAME ".*?(\.[a-z0-9]{1,10})?$" \
 # 
 SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
 	"phase:5,\
-	id:'912160',\
+	id:912160,\
 	t:none,\
 	nolog,\
 	pass,\
@@ -204,7 +204,7 @@ SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
 
 SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
 	"phase:5,\
-	id:'912161',\
+	id:912161,\
 	t:none,\
 	nolog,\
 	pass,\


### PR DESCRIPTION
This PR fixes an old issue in the anti-ddos rules. It incorporates a fix by @loudly-soft proposed in issue #346.