### PR TITLE
RCE: fix SAML fp by requiring whitespace after windows IF keyword

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -331,7 +331,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Regexp generated from util/regexp-assemble/regexp-932140.data using Regexp::Assemble.
 # See http://blog.modsecurity.org/2007/06/optimizing-regu.html for usage.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \b(?:if(?:/i)?(?: not)? ?(?:exist\b|defined\b|errorlevel\b|cmdextversion\b|.*(?:\bgeq\b|\bequ\b|\bneq\b|\bleq\b|\bgtr\b|\blss\b|==))|for(/[dflr].*)* %+[^ ]+ in\(.*\)\s?do)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \b(?:if(?:/i)?(?: not)?(?: exist\b| defined\b| errorlevel\b| cmdextversion\b|(?: |\().*(?:\bgeq\b|\bequ\b|\bneq\b|\bleq\b|\bgtr\b|\blss\b|==))|for(/[dflr].*)* %+[^ ]+ in\(.*\)\s?do)" \
 	"msg:'Remote Command Execution: Windows FOR/IF Command Found',\
 	phase:request,\
 	rev:'1',\

--- a/util/regexp-assemble/regexp-932140.data
+++ b/util/regexp-assemble/regexp-932140.data
@@ -1,2 +1,2 @@
 \bfor(/[dflr].*)* %+[^ ]+ in\(.*\)\s?do
-\bif(?:/i)?(?: not)? ?(?:exist\b|defined\b|errorlevel\b|cmdextversion\b|.*(?:\bgeq\b|\bequ\b|\bneq\b|\bleq\b|\bgtr\b|\blss\b|==))
+\bif(?:/i)?(?: not)?(?: exist\b| defined\b| errorlevel\b| cmdextversion\b|(?: |\().*(?:\bgeq\b|\bequ\b|\bneq\b|\bleq\b|\bgtr\b|\blss\b|==))


### PR DESCRIPTION
Resolves a false positive in #671.

Due to t:cmdLine removing spaces before `(`, I was not requiring a space after the Windows `IF` keyword in the Windows IF/FOR command detection regexp. However, this had the problem of generating false positives for inputs in the form of:

```
num test sco actual-rules           expected-rules         payload
--- ---- --- ---------------------- ---------------------- -----------------------------
639 FAIL 5   932140                 !*                     ifq a==b foo
640 FAIL 5   932140                 !*                     iffoo a==b foo
641 FAIL 5   932140                 !*                     if3 a==b foo
642 FAIL 5   932140                 !*                     if3q a==b foo
```

The updated regexp fixes this problem, while it should still correctly deal with parentheses like `if (1) equ (1) echo hey`.