### PR TITLE
Workaround 'altersvorsorge' FP in SQL rules

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -423,7 +423,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
 	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\d\W]\s+as\s*?[\"'`\w]+\s*?from)|(?:^[\W\d]+\s*?(?:union|select|create|rename|truncate|load|alter|delete|update|insert|desc))|(?:(?:select|create|rename|truncate|load|alter|delete|update|insert|desc)\s+(?:(?:group_)concat|char|load_file)\s?\(?)|(?:end\s*?\);)|([\"'`]\s+regexp\W)|(?:[\s(]load_file\s*?\())" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\d\W]\s+as\s*?[\"'`\w]+\s*?from)|(?:^[\W\d]+\s*?(?:union|select|create|rename|truncate|load|alter|delete|update|insert|desc)\b)|(?:(?:select|create|rename|truncate|load|alter|delete|update|insert|desc)\s+(?:(?:group_)concat|char|load_file)\s?\(?)|(?:end\s*?\);)|([\"'`]\s+regexp\W)|(?:[\s(]load_file\s*?\())" \
 	"phase:request,\
 	rev:'2',\
 	ver:'OWASP_CRS/3.0.0',\


### PR DESCRIPTION
Rule 942360 matches payloads like `(alter` which could be abused to inject SQL subqueries among other things.

This hit a false positive for input `/altersvorsorge/`, which has been worked around by requiring a word separator after the SQL keyword like `ALTER`. Payloads like this won't hit FP any longer, but an input like `/alter/` still would.

It's a specific remediation and for sure this rule will hit more false positives in the future. We might one day narrow those down further by adopting a blacklist of special characters to look for.
