### PR TITLE
Fix quiet option and git pull command in util/upgrade.py

### DIFF
--- a/util/upgrade.py
+++ b/util/upgrade.py
@@ -33,7 +33,7 @@ def upgrade_crs(crs_directory, quiet):
 
     # Do a git 'git pull'
     os.chdir(crs_directory)
-    gitcmd = "git pull origin v3.0/master --ff-only"
+    gitcmd = "git pull origin HEAD --ff-only"
     try:
         git_output = check_output(gitcmd, stderr=STDOUT, shell=True)        
         returncode = 0


### PR DESCRIPTION
Pull request to allow "git pull" command of the Upgrade CRS functionality in upgrade.py script to work on the current checked out branch instead of explicitly relying on a specific branch name to avoid future issues with versioning.

This pr is related with issue #718 on which a [commit](https://github.com/SpiderLabs/owasp-modsecurity-crs/commit/cfc95ee6a22ccd8c61ee19aa5c0f8f15414c7675) was mistakenly done prior to the proper pull request to be reviewed by the project maintainers.