### PR TITLE
Update WordPress exclusion rules

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -322,7 +322,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/post.php" \
 	SecRule &ARGS:action "@eq 1" \
 		"t:none,\
 		ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:post_title,\
-		ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\ 
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
 		ctl:ruleRemoveTargetById=920270;ARGS:content,\
 		ctl:ruleRemoveTargetById=920271;ARGS:content,\
 		ctl:ruleRemoveTargetById=920272;ARGS:content,\

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -322,10 +322,10 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/post.php" \
 	SecRule &ARGS:action "@eq 1" \
 		"t:none,\
 		ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:post_title,\
-		ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
-		ctl:ruleRemoveById=920272,\
-		ctl:ruleRemoveById=920271,\
-		ctl:ruleRemoveById=920270,\
+		ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\ 
+		ctl:ruleRemoveTargetById=920270;ARGS:content,\
+		ctl:ruleRemoveTargetById=920271;ARGS:content,\
+		ctl:ruleRemoveTargetById=920272;ARGS:content,\
 		ctl:ruleRemoveById=921180"
 
 # Autosave posts and pages

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -324,6 +324,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/post.php" \
 		ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:post_title,\
 		ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
 		ctl:ruleRemoveById=920272,\
+		ctl:ruleRemoveById=920271,\
 		ctl:ruleRemoveById=920270,\
 		ctl:ruleRemoveById=921180"
 

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -324,6 +324,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/post.php" \
 		ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:post_title,\
 		ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
 		ctl:ruleRemoveById=920272,\
+		ctl:ruleRemoveById=920270,\
 		ctl:ruleRemoveById=921180"
 
 # Autosave posts and pages


### PR DESCRIPTION
Added `ctl:ruleRemoveById=920270` to avoid matching: Invalid character in request (null character) for /wp-admin/post.php

Blocked Request ([...] == omissis):
```
POST /wp-admin/post.php HTTP/1.1
content-type: application/x-www-form-urlencoded
user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.81 Safari/537.36
content-length: 1392
connection: keep-alive
host: [...]
accept-encoding: gzip, deflate
cookie: [...]
accept-language: it-IT,it;q=0.8,en-US;q=0.6,en;q=0.4,fr;q=0.2

_wpnonce=7468906088&[...]&content=asdasd%0D%0A%7C%21%22%C2%A3%24%25%26%2F%28%29%3D%3F%5E%2C.-%C3%B2%C3%A0%C3%A8%C3%B9%2B&save=[...]
```

Changed SecRule:
```
SecRule REQUEST_FILENAME "@endsWith /wp-admin/post.php" \
        "id:9002700,\
        phase:2,\
        t:none,\
        nolog,\
        pass,\
        chain"
        SecRule ARGS:action "@rx ^(?:edit|editpost)$" \
                "t:none,\
                chain"
        SecRule &ARGS:action "@eq 1" \
                "t:none,\
                ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:post_title,\
                ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
                ctl:ruleRemoveById=920272,\
                ctl:ruleRemoveById=920270,\
                ctl:ruleRemoveById=921180"
```