### PR TITLE
Updating documentation to reflect #719

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -507,8 +507,6 @@ SecRule REQUEST_URI|REQUEST_BODY "\%u[fF]{2}[0-9a-fA-F]{2}" \
    maturity:'6',\
    accuracy:'8',\
    phase:request,\
-   t:urldecodeuni,\
-   t:utf8tounicode,\
    t:none,\
    tag:'application-multi',\
    tag:'language-multi',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -486,12 +486,18 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
 # -=[ Rule Logic ]=-
 # This rule looks for full-width encoding by looking for %u followed by 2 'f'
 # characters and then 2 hex characters. It is a vulnerability that affected
-# IIS circa 2007
+# IIS circa 2007.
+# The rule will trigger on %uXXXX formatted chars that are full or half
+# width, as explained above. This %uXXXX format is passed as a raw parameter
+# and is (seemingly only) accepted by IIS (5.0, 6.0, 7.0, and 8.0). Other
+# webservers will only process unicode chars presented as hex UTF-8 bytes.
 #
 # -=[ References ]=-
 # http://www.kb.cert.org/vuls/id/739224
 # https://www.checkpoint.com/defense/advisories/public/2007/cpai-2007-201.html
+# https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/719
 #
+SecRule REQUEST_URI "(.*)" "msg:'got %{tx.0}',id:22,capture"
 SecRule REQUEST_URI|REQUEST_BODY "\%u[fF]{2}[0-9a-fA-F]{2}" \
   "msg:'Unicode Full/Half Width Abuse Attack Attempt',\
    id:920260,\
@@ -501,6 +507,8 @@ SecRule REQUEST_URI|REQUEST_BODY "\%u[fF]{2}[0-9a-fA-F]{2}" \
    maturity:'6',\
    accuracy:'8',\
    phase:request,\
+   t:urldecodeuni,\
+   t:utf8tounicode,\
    t:none,\
    tag:'application-multi',\
    tag:'language-multi',\


### PR DESCRIPTION
This outlines the research done for id 920260. It was initially assumed this needed t:utf8tounicode, but it was determined that IIS will parse %uXXXX provided parameters as therefore was still relevant. 