### PR TITLE
Fix comment for 920370

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -876,7 +876,7 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
         setvar:tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{matched_var_name}=%{matched_var}"
 
 #
-# Limit value name length
+# Limit argument value length
 #
 SecRule &TX:ARG_LENGTH "@eq 1" \
   "chain,\


### PR DESCRIPTION
The description of 920370 is wrong. The variable does not limit the name, but the value. The new comment is parallel to the one of 920360.