### PR TITLE
Constrain PHP tag rule from XML false positives

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -28,12 +28,18 @@ SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:2,id:933012,nolog,pass,skipAfter:END-RE
 #
 
 #
-# [ Opening/Closing PHP Tag Found ]
+# [ PHP Open Tag Found ]
 #
+# Detects PHP open tags "<?" and "<?php".
 # http://www.php.net/manual/en/language.basic-syntax.phptags.php
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:<\?(?!xml\s)|<\?php|^(?!<\?xml\s).*\?>|\[(?:/|\\\\)?php\])" \
-	"msg:'PHP Injection Attack: Opening/Closing Tag Found',\
+# Care is taken to avoid false positives in XML declarations "<?xml..."
+#
+# Also detects "[php]", "[/php]" and "[\php]" tags used by some applications
+# to indicate PHP dynamic content.
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:<\?(?!xml\s)|<\?php|\[(?:/|\\\\)?php\])" \
+	"msg:'PHP Injection Attack: PHP Open Tag Found',\
 	phase:request,\
 	ver:'OWASP_CRS/3.0.0',\
 	maturity:'9',\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -32,7 +32,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:2,id:933012,nolog,pass,skipAfter:END-RE
 #
 # http://www.php.net/manual/en/language.basic-syntax.phptags.php
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pm <? <?php ?> [php] [\php]" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:<\?(?!xml\s)|<\?php|^(?!<\?xml\s).*\?>|\[(?:/|\\\\)?php\])" \
 	"msg:'PHP Injection Attack: Opening/Closing Tag Found',\
 	phase:request,\
 	ver:'OWASP_CRS/3.0.0',\


### PR DESCRIPTION
Constrain the PHP rule tag from false positives in XML content by making two changes:

- Only block on the short open tag `<?` if it's not part of a `<?xml` pattern
- No longer block the closing tag `?>`. We will reintroduce detection for it at PL3 in version 3.1.

Please see issue #654 for analysis and discussion.