### PR TITLE
Stop using X-Forwarded-For header

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -241,25 +241,7 @@ SecRule REQUEST_HEADERS:User-Agent "^(.*)$" \
   nolog, \
   pass"
 
-SecRule REQUEST_HEADERS:x-forwarded-for "^\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b" \
-  "id:901319, \
-  phase:1, \
-  t:none, \
-  capture, \
-  setvar:tx.real_ip=%{tx.1}, \
-  nolog, \
-  pass"
-
-SecRule &TX:REAL_IP "!@eq 0" \
-  "id:901320, \
-  phase:1, \
-  t:none, \
-  initcol:global=global, \
-  initcol:ip=%{tx.real_ip}_%{tx.ua_hash}, \
-  nolog, \
-  pass"
-
-SecRule &TX:REAL_IP "@eq 0" \
+SecAction \
   "id:901321, \
   phase:1, \
   t:none, \


### PR DESCRIPTION
In issue #724 @emphazer reported that CRS 3.0.0 trusted the untrusted `X-Forwarded-For` header for determining the `real_ip` variable used later in DoS protection and RBL checks. This is a security hole.

We discussed and tried various options to resolve this problem (see discussion in issue #724). Ultimately it was decided for 3.0.1 to completely remove our usage of the header, and let the user configure their proxy trust relationships using the webserver's native functionality.

This patch was tested in a simple DoS scenario with a single client, and also in a reverse proxy situation on Apache with mod_remoteip, and a client behind the trusted proxy. In the last situation, correctly the real client got blocked, and not the proxy.