### PR TITLE
Removes duplicated logdata for rule id 920440

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1071,7 +1071,7 @@ SecRule REQUEST_BASENAME "\.(.*)$" \
    tag:'OWASP_CRS/POLICY/EXT_RESTRICTED',\
    tag:'WASCTC/WASC-15',\
    tag:'OWASP_TOP_10/A7',\
-   tag:'PCI/6.5.10',logdata:'%{TX.0}',\
+   tag:'PCI/6.5.10',\
    setvar:tx.extension=.%{tx.1}/"
      SecRule TX:EXTENSION "@within %{tx.restricted_extensions}" \
        "t:none,\


### PR DESCRIPTION
We noticed logdata being set twice for this rule. The culprit was a duplicated
call to logdata hidden next to a tag.