### PR TITLE
Ignore Whitespaces in Rule 942110

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -465,7 +465,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:942014,nolog,pass,skipAfter:END-RE
 # Identifies common initial SQLi probing requests where attackers insert/append
 # quote characters to the existing normal payload to see how the app/db responds.
 #
-SecRule ARGS_NAMES|ARGS|XML:/* "(^[\"'`;]+|[\"'`]+$)" \
+SecRule ARGS_NAMES|ARGS|XML:/* "(^\s*[\"'`;]+|[\"'`]+\s*$)" \
 	"phase:request,\
 	rev:'4',\
 	ver:'OWASP_CRS/3.0.0',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -468,7 +468,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:942014,nolog,pass,skipAfter:END-RE
 SecRule ARGS_NAMES|ARGS|XML:/* "(^\s*[\"'`;]+|[\"'`]+\s*$)" \
 	"phase:request,\
 	rev:'4',\
-	ver:'OWASP_CRS/3.0.1',\
+	ver:'OWASP_CRS/3.1.0',\
 	maturity:'9',\
 	accuracy:'8',\
 	capture,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -468,7 +468,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:942014,nolog,pass,skipAfter:END-RE
 SecRule ARGS_NAMES|ARGS|XML:/* "(^\s*[\"'`;]+|[\"'`]+\s*$)" \
 	"phase:request,\
 	rev:'4',\
-	ver:'OWASP_CRS/3.0.0',\
+	ver:'OWASP_CRS/3.0.1',\
 	maturity:'9',\
 	accuracy:'8',\
 	capture,\


### PR DESCRIPTION
Whitespaces should be ignored at the beginning and at the end of rule 942110