### PR TITLE
Update outdated rule versions

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -37,7 +37,7 @@ SecRule REQUEST_HEADERS:'/(Content-Length|Transfer-Encoding)/' "," \
 	phase:request,\
 	id:921100,\
 	rev:'2',\
-	ver:'OWASP_CRS/2.2.7',\
+	ver:'OWASP_CRS/3.0.0',\
 	maturity:'9',\
 	accuracy:'9',\
 	severity:'CRITICAL',\
@@ -109,7 +109,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	phase:request,\
 	id:921120,\
 	rev:'2',\
-	ver:'OWASP_CRS/2.2.7',\
+	ver:'OWASP_CRS/3.0.0',\
 	maturity:'9',\
 	accuracy:'9',\
 	severity:'CRITICAL',\
@@ -133,7 +133,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	phase:request,\
 	id:921130,\
 	rev:'2',\
-	ver:'OWASP_CRS/2.2.7',\
+	ver:'OWASP_CRS/3.0.0',\
 	maturity:'9',\
 	accuracy:'9',\
 	severity:'CRITICAL',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -565,7 +565,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	"chain,\
 	phase:request,\
 	rev:'2',\
-	ver:'OWASP_CRS/2.2.6',\
+	ver:'OWASP_CRS/3.0.0',\
 	maturity:'9',\
 	accuracy:'8',\
 	capture,\


### PR DESCRIPTION
Seems like these just got missed in a migration at some point?