### PR TITLE
Removing deprecated t:removeComments from 942100

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -51,7 +51,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
    phase:request,\
    block,\
    multiMatch,\
-   t:none,t:utf8toUnicode,t:urlDecodeUni,t:removeNulls,t:removeComments,\
+   t:none,t:utf8toUnicode,t:urlDecodeUni,t:removeNulls,\
    capture,\
    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
    tag:'application-multi',\


### PR DESCRIPTION
This solves issue #796. Basing against v3.1/dev, but should be backported to 3.0 branch.