### PR TITLE
Update lfi-os-files.data  #REQUEST-930-APPLICATION-ATTACK-LFI 

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.0.0
+# OWASP ModSecurity Core Rule Set ver.3.0.1
 # Copyright (c) 2006-2016 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -771,4 +771,4 @@ SecAction \
   nolog,\
   pass,\
   t:none,\
-  setvar:tx.crs_setup_version=300"
+  setvar:tx.crs_setup_version=301"

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.0.0
+# OWASP ModSecurity Core Rule Set ver.3.0.1
 # Copyright (c) 2006-2016 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -25,7 +25,7 @@
 #
 # Ref: https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#wiki-SecComponentSignature
 #
-SecComponentSignature "OWASP_CRS/3.0.0"
+SecComponentSignature "OWASP_CRS/3.0.1"
 
 
 #

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -37,7 +37,7 @@ SecRule REQUEST_HEADERS:'/(Content-Length|Transfer-Encoding)/' "," \
 	phase:request,\
 	id:921100,\
 	rev:'2',\
-	ver:'OWASP_CRS/2.2.7',\
+	ver:'OWASP_CRS/3.0.0',\
 	maturity:'9',\
 	accuracy:'9',\
 	severity:'CRITICAL',\
@@ -109,7 +109,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	phase:request,\
 	id:921120,\
 	rev:'2',\
-	ver:'OWASP_CRS/2.2.7',\
+	ver:'OWASP_CRS/3.0.0',\
 	maturity:'9',\
 	accuracy:'9',\
 	severity:'CRITICAL',\
@@ -133,7 +133,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	phase:request,\
 	id:921130,\
 	rev:'2',\
-	ver:'OWASP_CRS/2.2.7',\
+	ver:'OWASP_CRS/3.0.0',\
 	maturity:'9',\
 	accuracy:'9',\
 	severity:'CRITICAL',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -565,7 +565,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 	"chain,\
 	phase:request,\
 	rev:'2',\
-	ver:'OWASP_CRS/2.2.6',\
+	ver:'OWASP_CRS/3.0.0',\
 	maturity:'9',\
 	accuracy:'8',\
 	capture,\

--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -1052,3 +1052,7 @@ config/database.php
 # phpBB
 # Note: this string might be benign in REQUEST_FILENAME
 /config.php
+#Missing Debian based sensitive directories  
+var/mail/www-data
+etc/network/
+etc/init/


### PR DESCRIPTION
Update the  `lfi-os-files.data` to block accessing the sensitive directories through LFI.

```
#Missing Debian based sensitive directories  
var/mail/www-data
etc/network/
etc/init/
```
For more information check my [Github](https://github.com/umarfarook882/WAF-Rule-Testing-LFI-attack)
Issue status : [Open](https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/814)   
