### PR TITLE
Fix XSS requesting 'capture' action

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -46,7 +46,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 	t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
 	block,\
 	ctl:auditLogParts=+E,\
-	capture,\
 	tag:'application-multi',\
 	tag:'language-multi',\
 	tag:'platform-multi',\
@@ -57,7 +56,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 	tag:'OWASP_TOP_10/A3',\
 	tag:'OWASP_AppSensor/IE1',\
 	tag:'CAPEC-242',\
-	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	logdata:'Matched Data: XSS data found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
 	setvar:'tx.msg=%{rule.msg}',\
 	setvar:tx.xss_score=+%{tx.critical_anomaly_score},\
 	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\


### PR DESCRIPTION
the Capture action isn't supported by @ detectxss but is supported by @ detectsqli. This is pretty awful in general and should probably be fixed. In any event the current capture was actually not setting TX.0 and therefore getting it from the previous rule that set it.

Thanks to @fschwindt for pointing this out.