### PR TITLE
Block uploads of files with .phps extension

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -67,7 +67,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # [ PHP Script Uploads ]
 #
-# Block file uploads with PHP extensions (.php, .php5, .phtml etc).
+# Block file uploads with filenames ending in PHP related extensions
+# (.php, .phps, .phtml, .php5 etc).
 #
 # Many application contain Unrestricted File Upload vulnerabilities.
 # https://www.owasp.org/index.php/Unrestricted_File_Upload
@@ -84,7 +85,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # X_Filename, or X-File-Name to transmit the file name to the server;
 # scan these request headers as well as multipart/form-data file names.
 #
-SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X-File-Name "@rx .*\.(?:php\d*|phtml)\.*$" \
+SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X-File-Name "@rx .*\.(?:php\d*|phps|phtml)\.*$" \
         "msg:'PHP Injection Attack: PHP Script File Upload Found',\
         phase:request,\
         ver:'OWASP_CRS/3.0.0',\
@@ -614,8 +615,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 #
 # [ PHP Script Uploads: Superfluous extension ]
 #
-# Block file uploads with PHP extensions (.php, .php5, .phtml etc)
-# anywhere in the name, followed by a dot.
+# Block file uploads with PHP related extensions (.php, .phps, .phtml,
+# .php5 etc) anywhere in the name, followed by a dot.
 #
 # Example: index.php.tmp
 #
@@ -632,7 +633,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 #
 # This rule is a stricter sibling of rule 933110.
 #
-SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X-File-Name "@rx .*\.(?:php\d*|phtml)\..*$" \
+SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X-File-Name "@rx .*\.(?:php\d*|phps|phtml)\..*$" \
         "msg:'PHP Injection Attack: PHP Script File Upload Found',\
         phase:request,\
         ver:'OWASP_CRS/3.0.0',\


### PR DESCRIPTION
Block uploading of `.phps` files, as suggested by @umarfarook882 in #817 .