### PR TITLE
RCE whitespace fix

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -534,8 +534,10 @@ SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:2,id:932016,nolog,pass,skipAfter:END-RE
 # -= Paranoia Level 3 =- (apply only when tx.paranoia_level is sufficiently high: 3 or higher)
 #
 
-# Missing Unix commands have been updated in new word list i.e util/regexp-assemble/regexp-932106.txt
-# Therefore, they have been split off to a separate rule.
+# Missing Unix commands have been added to a new word list i.e.
+# util/regexp-assemble/regexp-932106.txt
+# These commands may have a higher risk of false positives.
+# Therefore, they have been split off to a separate rule in PL3.
 # For explanation of this rule, see rule 932100.
 #
 # To rebuild the word list regexp:
@@ -550,7 +552,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 3" "phase:2,id:932016,nolog,pass,skipAfter:END-RE
 #
 # This rule is a stricter sibling of rule 932100.
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:;|\{|\||\|\||&|&&|\n|\r|\$\(|\$\(\(|`|\${|<\(|>\(|\(\s*\))\s*(?:{|\s*\(\s*|\w+=(?:[^\s]*|\$.*|\$.*|<.*|>.*|\'.*\'|\".*\")\s+|!\s*|\$)*\s*(?:'|\")*(?:[\?\*\[\]\(\)\-\|+\w'\"\./\\\\]+/)?[\\\\'\"]*(?:(?:(?:a[\\\\'\"]*p[\\\\'\"]*t[\\\\'\"]*i[\\\\'\"]*t[\\\\'\"]*u[\\\\'\"]*d|u[\\\\'\"]*p[\\\\'\"]*2[\\\\'\"]*d[\\\\'\"]*a[\\\\'\"]*t)[\\\\'\"]*e|d[\\\\'\"]*n[\\\\'\"]*f|v[\\\\'\"]*i)[\\\\'\"]*(?:\s|<|>).*|p[\\\\'\"]*(?:a[\\\\'\"]*c[\\\\'\"]*m[\\\\'\"]*a[\\\\'\"]*n[\\\\'\"]*(?:\s|<|>).*|s[\\\\'\"]*|w[\\\\'\"]*d)|w[\\\\'\"]*(?:(?:\s|<|>).*|h[\\\\'\"]*o))\b" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:;|\{|\||\|\||&|&&|\n|\r|\$\(|\$\(\(|`|\${|<\(|>\(|\(\s*\))\s*(?:{|\s*\(\s*|\w+=(?:[^\s]*|\$.*|\$.*|<.*|>.*|\'.*\'|\".*\")\s+|!\s*|\$)*\s*(?:'|\")*(?:[\?\*\[\]\(\)\-\|+\w'\"\./\\\\]+/)?[\\\\'\"]*(?:(?:(?:a[\\\\'\"]*p[\\\\'\"]*t[\\\\'\"]*i[\\\\'\"]*t[\\\\'\"]*u[\\\\'\"]*d|u[\\\\'\"]*p[\\\\'\"]*2[\\\\'\"]*d[\\\\'\"]*a[\\\\'\"]*t)[\\\\'\"]*e|d[\\\\'\"]*n[\\\\'\"]*f|v[\\\\'\"]*i)[\\\\'\"]*(?:\s|<|>).*|p[\\\\'\"]*(?:a[\\\\'\"]*c[\\\\'\"]*m[\\\\'\"]*a[\\\\'\"]*n[\\\\'\"]*(?:\s|<|>).*|w[\\\\'\"]*d|s)|w[\\\\'\"]*(?:(?:\s|<|>).*|h[\\\\'\"]*o))\b" \
     "msg:'Remote Command Execution: Unix Command Injection',\
     phase:request,\
     rev:'4',\

--- a/util/regexp-assemble/regexp-932106.txt
+++ b/util/regexp-assemble/regexp-932106.txt
@@ -16,7 +16,7 @@
 #   diff+
 
 vi+
-ps 
+ps
 pwd
 who
 w+

--- a/util/regexp-assemble/regexp-cmdline.py
+++ b/util/regexp-assemble/regexp-cmdline.py
@@ -57,7 +57,7 @@ del sys.argv[1]
 
 # Process lines from input file, or if not specified, standard input
 for line in fileinput.input():
-    line = line.rstrip('\n')
+    line = line.rstrip('\n ')
     line = line.split('#')[0]
     if line != '':
         print(regexp_str(line, evasion))


### PR DESCRIPTION
This fixes the problem in PL3 RCE rule 932106 where `ps` was only detected when followed by whitespace, as debated in #812, and also patches `regexp-cmdline.py` so the problem cannot be reintroduced later.