### PR TITLE
Classic SQL injection probing rule split 942370

### DIFF
--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -32,8 +32,6 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     block,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\

--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -40,8 +40,6 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     t:none,\
     t:lowercase,\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     capture,\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -66,8 +64,6 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmf scanners-headers.data" \
     phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     t:lowercase,\
     block,\
@@ -95,8 +91,6 @@ SecRule REQUEST_FILENAME|ARGS "@pmf scanners-urls.data" \
     phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     t:lowercase,\
     block,\
@@ -143,8 +137,6 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scripting-user-agents.data" \
     t:none,\
     t:lowercase,\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'7',\
     capture,\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -184,8 +176,6 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile crawlers-user-agents.data" \
     t:none,\
     t:lowercase,\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     capture,\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -50,8 +50,6 @@ SecRule REQUEST_LINE "!^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+)?)?
     id:920100,\
     ver:'OWASP_CRS/3.0.0',\
     rev:'2',\
-    maturity:'9',\
-    accuracy:'9',\
     logdata:'%{request_line}',\
     phase:request,\
     block,\
@@ -103,8 +101,6 @@ SecRule FILES_NAMES|FILES "(?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:[eEi
     id:920120,\
     ver:'OWASP_CRS/3.0.0',\
     rev:'1',\
-    maturity:'9',\
-    accuracy:'7',\
     logdata:'%{matched_var}',\
     phase:request,\
     block,\
@@ -140,8 +136,6 @@ SecRule REQBODY_ERROR "!@eq 0" \
     id:920130,\
     ver:'OWASP_CRS/3.0.0',\
     rev:'1',\
-    maturity:'9',\
-    accuracy:'9',\
     logdata:'%{REQBODY_ERROR_MSG}',\
     phase:request,\
     block,\
@@ -186,8 +180,6 @@ SecRule MULTIPART_STRICT_ERROR "!@eq 0" \
     id:920140,\
     ver:'OWASP_CRS/3.0.0',\
     rev:'1',\
-    maturity:'8',\
-    accuracy:'7',\
     phase:request,\
     block,\
     t:none,\
@@ -218,8 +210,6 @@ SecRule REQUEST_HEADERS:Content-Length "!^\d+$" \
     id:920160,\
     ver:'OWASP_CRS/3.0.0',\
     rev:'1',\
-    maturity:'9',\
-    accuracy:'9',\
     phase:1,\
     block,\
     logdata:'%{matched_var}',\
@@ -256,8 +246,6 @@ SecRule REQUEST_METHOD "^(?:GET|HEAD)$" \
     id:920170,\
     ver:'OWASP_CRS/3.0.0',\
     rev:'1',\
-    maturity:'9',\
-    accuracy:'9',\
     phase:request,\
     block,\
     logdata:'%{matched_var}',\
@@ -292,8 +280,6 @@ SecRule REQUEST_METHOD "^POST$" \
     id:920180,\
     ver:'OWASP_CRS/3.0.0',\
     rev:'1',\
-    maturity:'9',\
-    accuracy:'9',\
     phase:request,\
     block,\
     logdata:'%{matched_var}',\
@@ -339,8 +325,6 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "(\d+)\-(\d+)\," \
     phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'6',\
-    accuracy:'8',\
     t:none,\
     block,\
     msg:'Range: Invalid Last Byte Value.',\
@@ -374,8 +358,6 @@ SecRule REQUEST_HEADERS:Connection "\b(keep-alive|close),\s?(keep-alive|close)\b
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'6',\
-    accuracy:'8',\
     t:none,\
     block,\
     msg:'Multiple/Conflicting Connection Header Data Found.',\
@@ -406,8 +388,6 @@ SecRule REQUEST_URI "\%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'6',\
-    accuracy:'8',\
     t:none,\
     block,\
     msg:'URL Encoding Abuse Attack Attempt',\
@@ -428,8 +408,6 @@ SecRule REQUEST_HEADERS:Content-Type "^(application\/x-www-form-urlencoded|text\
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'6',\
-    accuracy:'8',\
     t:none,\
     block,\
     msg:'URL Encoding Abuse Attack Attempt',\
@@ -461,8 +439,6 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'6',\
-    accuracy:'8',\
     t:none,\
     block,\
     msg:'UTF8 Encoding Abuse Attack Attempt',\
@@ -503,8 +479,6 @@ SecRule REQUEST_URI|REQUEST_BODY "\%u[fF]{2}[0-9a-fA-F]{2}" \
     severity:'WARNING',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'6',\
-    accuracy:'8',\
     phase:request,\
     t:none,\
     tag:'application-multi',\
@@ -557,8 +531,6 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     block,\
     msg:'Invalid character in request (null character)',\
     id:920270,\
@@ -593,8 +565,6 @@ SecRule &REQUEST_HEADERS:Host "@eq 0" \
     phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     pass,\
     id:920280,\
@@ -618,8 +588,6 @@ SecRule REQUEST_HEADERS:Host "^$" \
     phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     pass,\
     id:920290,\
@@ -661,8 +629,6 @@ SecRule REQUEST_HEADERS:Accept "^$" \
     phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     t:none,\
     pass,\
     severity:'NOTICE',\
@@ -689,8 +655,6 @@ SecRule REQUEST_HEADERS:Accept "^$" \
     phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     t:none,\
     pass,\
     severity:'NOTICE',\
@@ -728,8 +692,6 @@ SecRule REQUEST_HEADERS:User-Agent "^$" \
     id:920330,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -758,8 +720,6 @@ SecRule REQUEST_HEADERS:Content-Length "!^0$" \
     phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     block,\
     tag:'application-multi',\
@@ -790,8 +750,6 @@ SecRule REQUEST_HEADERS:Host "^[\d.:]+$" \
     phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     block,\
     logdata:'%{matched_var}',\
@@ -833,8 +791,6 @@ SecRule &TX:MAX_NUM_ARGS "@eq 1" \
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -860,8 +816,6 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -887,8 +841,6 @@ SecRule &TX:ARG_LENGTH "@eq 1" \
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -914,8 +866,6 @@ SecRule &TX:TOTAL_ARG_LENGTH "@eq 1" \
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -942,8 +892,6 @@ SecRule &TX:MAX_FILE_SIZE "@eq 1" \
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -970,8 +918,6 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -996,8 +942,6 @@ SecRule REQUEST_METHOD "!^(?:GET|HEAD|PROPFIND|OPTIONS)$" \
     msg:'Request content type is not allowed by policy',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     id:920420,\
     severity:'CRITICAL',\
     logdata:'%{matched_var}',\
@@ -1031,8 +975,6 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     id:920430,\
     tag:'application-multi',\
     tag:'language-multi',\
@@ -1060,8 +1002,6 @@ SecRule REQUEST_BASENAME "\.(.*)$" \
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     id:920440,\
     logdata:'%{TX.0}',\
     tag:'application-multi',\
@@ -1112,8 +1052,6 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^(.*)$" \
     block,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     id:920450,\
     capture,\
     logdata:' Restricted header detected: %{matched_var}',\
@@ -1167,8 +1105,6 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "^bytes=((\d+)?\-(\d
     capture,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'6',\
-    accuracy:'8',\
     t:none,\
     block,\
     msg:'Range: Too many fields (6 or more)',\
@@ -1196,8 +1132,6 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     capture,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'6',\
-    accuracy:'8',\
     t:none,\
     block,\
     msg:'Range: Too many fields for pdf request (63 or more)',\
@@ -1221,8 +1155,6 @@ SecRule ARGS "\%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'6',\
-    accuracy:'8',\
     t:none,\
     block,\
     msg:'Multiple URL Encoding Detected',\
@@ -1251,8 +1183,6 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
     phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     t:none,\
     pass,\
     severity:'NOTICE',\
@@ -1281,8 +1211,6 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     block,\
     msg:'Invalid character in request (non printable characters)',\
     id:920271,\
@@ -1312,8 +1240,6 @@ SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     pass,\
     id:920320,\
@@ -1340,8 +1266,6 @@ SecRule FILES_NAMES|FILES "['\";=]" \
     id:920121,\
     ver:'OWASP_CRS/3.0.0',\
     rev:'1',\
-    maturity:'9',\
-    accuracy:'7',\
     logdata:'%{matched_var}',\
     phase:request,\
     block,\
@@ -1371,8 +1295,6 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     block,\
     msg:'Invalid character in request (outside of printable chars below ascii 127)',\
     id:920272,\
@@ -1404,8 +1326,6 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     capture,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'6',\
-    accuracy:'8',\
     t:none,\
     block,\
     msg:'Range: Too many fields for pdf request (6 or more)',\
@@ -1432,8 +1352,6 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     block,\
     msg:'Invalid character in request (outside of very strict set)',\
     id:920273,\
@@ -1456,8 +1374,6 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     block,\
     msg:'Invalid character in request headers (outside of very strict set)',\
     id:920274,\
@@ -1505,8 +1421,6 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "(?<!\Q\\\E)\Q\\\E[cdeghijkl
     "phase:request,\
     id:920460,\
     rev:'1',\
-    accuracy:'1',\
-    maturity:'1',\
     ver:'OWASP_CRS/3.0.0',\
     block,\
     log,\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -38,8 +38,6 @@ SecRule REQUEST_HEADERS:'/(Content-Length|Transfer-Encoding)/' "," \
     id:921100,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     severity:'CRITICAL',\
     t:none,\
     capture,\
@@ -75,8 +73,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "(?:\n|\r)+(?:get|post|head|options|connect|put|d
     id:921110,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'5',\
-    accuracy:'5',\
     severity:'CRITICAL',\
     capture,\
     tag:'application-multi',\
@@ -110,8 +106,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     id:921120,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     severity:'CRITICAL',\
     t:none,t:urlDecodeUni,t:lowercase,\
     capture,\
@@ -134,8 +128,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     id:921130,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     severity:'CRITICAL',\
     capture,\
     tag:'application-multi',\
@@ -171,8 +163,6 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "(\n|\r)" \
     id:921140,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'5',\
-    accuracy:'5',\
     severity:'CRITICAL',\
     capture,\
     tag:'application-multi',\
@@ -199,8 +189,6 @@ SecRule ARGS_NAMES "(\n|\r)" \
     id:921150,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'5',\
-    accuracy:'5',\
     severity:'CRITICAL',\
     capture,\
     tag:'application-multi',\
@@ -223,8 +211,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "(?:\n|\r)+(?:\s+|location|refresh|(?:set-)?cooki
     id:921160,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'5',\
-    accuracy:'5',\
     severity:'CRITICAL',\
     capture,\
     tag:'application-multi',\
@@ -261,8 +247,6 @@ SecRule ARGS_GET "(\n|\r)" \
     id:921151,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'5',\
-    accuracy:'5',\
     severity:'CRITICAL',\
     capture,\
     tag:'application-multi',\
@@ -327,8 +311,6 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
     id:921180,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'8',\
     severity:'CRITICAL',\
     pass,\
     tag:'application-multi',\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -32,8 +32,6 @@ SecRule REQUEST_URI_RAW|REQUEST_BODY|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XM
     id:930100,\
     ver:'OWASP_CRS/3.0.0',\
     rev:'3',\
-    maturity:'9',\
-    accuracy:'7',\
     t:none,\
     block,\
     severity:CRITICAL,\
@@ -58,8 +56,6 @@ SecRule REQUEST_URI|REQUEST_BODY|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/*
     id:930110,\
     ver:'OWASP_CRS/3.0.0',\
     rev:'1',\
-    maturity:'9',\
-    accuracy:'7',\
     multiMatch,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:removeNulls,t:cmdLine,\
     block,\
@@ -86,8 +82,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     msg:'OS File Access Attempt',\
     rev:'4',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     capture,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,t:lowercase,\
     block,\
@@ -118,8 +112,6 @@ SecRule REQUEST_FILENAME "@pmf restricted-files.data" \
     msg:'Restricted File Access Attempt',\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'8',\
     capture,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,t:lowercase,\
     block,\

--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -40,8 +40,6 @@ SecRule ARGS "^(?i)(?:file|ftps?|https?):\/\/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}
     id:931100, \
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -61,8 +59,6 @@ SecRule QUERY_STRING|REQUEST_BODY "(?i:(\binclude\s*\([^)]*|mosConfig_absolute_p
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,t:urlDecodeUni,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -85,8 +81,6 @@ SecRule ARGS "^(?i)(?:file|ftps?|https?)(.*?)\?+$" \
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -118,8 +112,6 @@ SecRule ARGS "^(?i)(?:file|ftps?|https?)://(.*)$" \
     phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -65,8 +65,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'4',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     capture,\
     t:none,\
     ctl:auditLogParts=+E,\
@@ -106,8 +104,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'4',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     capture,\
     t:none,\
     ctl:auditLogParts=+E,\
@@ -169,8 +165,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'4',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,\
     ctl:auditLogParts=+E,\
@@ -210,8 +204,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'4',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,\
     ctl:auditLogParts=+E,\
@@ -249,8 +241,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'7',\
     capture,\
     t:none,t:urlDecodeUni,t:cmdLine,t:lowercase,\
     ctl:auditLogParts=+E,\
@@ -292,8 +282,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'7',\
     capture,\
     t:none,t:urlDecodeUni,t:cmdLine,\
     ctl:auditLogParts=+E,\
@@ -343,8 +331,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'7',\
     capture,\
     t:none,t:urlDecodeUni,t:cmdLine,\
     ctl:auditLogParts=+E,\
@@ -396,8 +382,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'7',\
     capture,\
     t:none,\
     ctl:auditLogParts=+E,\
@@ -432,8 +416,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,t:cmdLine,t:normalizePath,t:lowercase,\
     ctl:auditLogParts=+E,\
@@ -469,8 +451,6 @@ SecRule REQUEST_HEADERS|REQUEST_LINE "^\(\s*\)\s+{" \
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'9',\
     capture,\
     t:none,t:urlDecode,\
     ctl:auditLogParts=+E,\
@@ -496,8 +476,6 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "^\(\s*\)\s+{" \
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'9',\
     capture,\
     t:none,t:urlDecode,t:urlDecodeUni,\
     ctl:auditLogParts=+E,\
@@ -555,8 +533,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'4',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     capture,\
     t:none,\
     ctl:auditLogParts=+E,\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -42,8 +42,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "msg:'PHP Injection Attack: PHP Open Tag Found',\
     phase:request,\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,t:urlDecodeUni,t:lowercase,\
     ctl:auditLogParts=+E,\
     block,\
@@ -86,8 +84,6 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     "msg:'PHP Injection Attack: PHP Script File Upload Found',\
     phase:request,\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'8',\
     t:none,t:lowercase,\
     ctl:auditLogParts=+E,\
     block,\
@@ -115,8 +111,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,t:normalisePath,t:lowercase,\
     ctl:auditLogParts=+E,\
@@ -147,8 +141,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'8',\
     capture,\
     t:none,t:normalisePath,t:urlDecodeUni,t:lowercase,\
     ctl:auditLogParts=+E,\
@@ -188,8 +180,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "msg:'PHP Injection Attack: I/O Stream Found',\
     phase:request,\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     ctl:auditLogParts=+E,\
     block,\
@@ -260,8 +250,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'9',\
     capture,\
     t:none,t:lowercase,\
     ctl:auditLogParts=+E,\
@@ -312,8 +300,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'8',\
     capture,\
     t:none,\
     ctl:auditLogParts=+E,\
@@ -373,8 +359,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'9',\
     t:none,\
     ctl:auditLogParts=+E,\
     block,\
@@ -433,8 +417,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'7',\
     capture,\
     t:none,\
     ctl:auditLogParts=+E,\
@@ -482,8 +464,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'7',\
     capture,\
     t:none,t:lowercase,\
     ctl:auditLogParts=+E,\
@@ -541,8 +521,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'7',\
     capture,\
     t:none,t:normalisePath,t:urlDecodeUni,\
     ctl:auditLogParts=+E,\
@@ -587,8 +565,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'7',\
     capture,\
     t:none,\
     ctl:auditLogParts=+E,\
@@ -634,8 +610,6 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     "msg:'PHP Injection Attack: PHP Script File Upload Found',\
     phase:request,\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'7',\
     t:none,t:lowercase,\
     ctl:auditLogParts=+E,\
     block,\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -41,8 +41,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'9',\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
     block,\
     ctl:auditLogParts=+E,\
@@ -75,8 +73,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'4',\
-    accuracy:'9',\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
     block,\
     ctl:auditLogParts=+E,\
@@ -109,8 +105,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'4',\
-    accuracy:'8',\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
     block,\
     ctl:auditLogParts=+E,\
@@ -142,8 +136,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'8',\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
     block,\
     ctl:auditLogParts=+E,\
@@ -177,8 +169,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'8',\
     block,\
     ctl:auditLogParts=+E,\
     capture,\
@@ -213,8 +203,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'8',\
     block,\
     ctl:auditLogParts=+E,\
     capture,\
@@ -246,8 +234,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'8',\
     block,\
     ctl:auditLogParts=+E,\
     capture,\
@@ -280,8 +266,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:lowercase,t:removeNulls,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'8',\
     block,\
     ctl:auditLogParts=+E,\
     capture,\
@@ -311,8 +295,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941190,\
     severity:'CRITICAL',\
     capture,\
@@ -340,8 +322,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941200,\
     severity:'CRITICAL',\
     capture,\
@@ -370,8 +350,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941210,\
     severity:'CRITICAL',\
     capture,\
@@ -400,8 +378,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941220,\
     severity:'CRITICAL',\
     capture,\
@@ -430,8 +406,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941230,\
     severity:'CRITICAL',\
     capture,\
@@ -460,8 +434,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941240,\
     severity:'CRITICAL',\
     capture,\
@@ -490,8 +462,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941250,\
     severity:'CRITICAL',\
     capture,\
@@ -520,8 +490,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941260,\
     severity:'CRITICAL',\
     capture,\
@@ -550,8 +518,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941270,\
     severity:'CRITICAL',\
     capture,\
@@ -580,8 +546,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941280,\
     severity:'CRITICAL',\
     capture,\
@@ -610,8 +574,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941290,\
     severity:'CRITICAL',\
     capture,\
@@ -640,8 +602,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941300,\
     severity:'CRITICAL',\
     capture,\
@@ -675,8 +635,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'8',\
     id:941310,\
     severity:'CRITICAL',\
     capture,\
@@ -710,8 +668,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'8',\
     id:941350,\
     severity:'CRITICAL',\
     capture,\
@@ -752,8 +708,6 @@ SecRule REQUEST_HEADERS:Referer "@detectXSS" \
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'9',\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
     block,\
     ctl:auditLogParts=+E,\
@@ -787,8 +741,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     severity:'CRITICAL',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'8',\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
     block,\
     ctl:auditLogParts=+E,\
@@ -873,8 +825,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941320,\
     severity:'CRITICAL',\
     capture,\
@@ -902,8 +852,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941330,\
     severity:'CRITICAL',\
     capture,\
@@ -931,8 +879,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:941340,\
     severity:'CRITICAL',\
     capture,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -46,8 +46,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     severity:'CRITICAL',\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'1',\
-    accuracy:'8',\
     phase:request,\
     block,\
     multiMatch,\
@@ -75,8 +73,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     ctl:auditLogParts=+E,\
@@ -109,8 +105,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -130,8 +124,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -157,8 +149,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -184,8 +174,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -211,8 +199,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -238,8 +224,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -265,8 +249,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -292,8 +274,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -319,8 +299,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -346,8 +324,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -373,8 +349,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -400,8 +374,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -427,8 +399,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -469,8 +439,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "(^\s*[\"'`;]+|[\"'`]+\s*$)" \
     "phase:request,\
     rev:'4',\
     ver:'OWASP_CRS/3.1.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,\
     block,\
@@ -501,8 +469,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "(?i:(\!\=|\&\&|\|\||>>|<<|>=|<=|<>|<=>|\bxor\b|\
     "phase:request,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,\
     block,\
@@ -533,8 +499,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "(?i:([\s'\"`\(\)]*?)([\d\w]++)([\s'\"`\(\)]*?)(?
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     multiMatch,t:none,t:urlDecodeUni,t:replaceComments,\
     block,\
@@ -566,8 +530,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,t:lowercase,\
     ctl:auditLogParts=+E,\
@@ -596,8 +558,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -624,8 +584,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -652,8 +610,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -680,8 +636,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -708,8 +662,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -736,8 +688,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -764,8 +714,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.1.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -792,8 +740,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -820,8 +766,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.1.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -848,8 +792,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     ctl:auditLogParts=+E,\
@@ -877,8 +819,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     ctl:auditLogParts=+E,\
@@ -906,8 +846,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     ctl:auditLogParts=+E,\
@@ -935,8 +873,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     ctl:auditLogParts=+E,\
@@ -985,8 +921,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\
     severity:'WARNING',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     msg:'Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (12)',\
     capture,\
     logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -1032,8 +966,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     id:942440,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -1065,8 +997,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     id:942450,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'8',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -1111,8 +1041,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'6',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -1162,8 +1090,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQ
     severity:'WARNING',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     msg:'Restricted SQL Character Anomaly Detection (cookies): # of special characters exceeded (8)',\
     capture,\
     logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -1195,8 +1121,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\
     severity:'WARNING',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     msg:'Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (6)',\
     capture,\
     logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -1232,8 +1156,6 @@ SecRule ARGS "\W{4}" \
     id:942460,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     severity:'WARNING',\
     tag:'application-multi',\
     tag:'language-multi',\
@@ -1255,8 +1177,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.1.0',\
-    maturity:'9',\
-    accuracy:'8',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
@@ -1301,8 +1221,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|!REQ
     severity:'WARNING',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     msg:'Restricted SQL Character Anomaly Detection (cookies): # of special characters exceeded (3)',\
     capture,\
     logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -1334,8 +1252,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "((?:[\~\!\@\#\$\%\^\&\*\(\)\-\+\=\{\}\[\]\|\:\;\
     severity:'WARNING',\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'8',\
     msg:'Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (2)',\
     capture,\
     logdata:'Matched Data: %{TX.1} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -763,7 +763,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s*?(x?or|div|like|between|and)\s*?[\"'`]?\d)|(?:\\\\x(?:23|27|3d))|(?:^.?[\"'`]$)|(?:(?:^[\"'`\\\\]*?(?:[\d\"'`]+|[^\"'`]+[\"'`]))+\s*?(?:n?and|x?x?or|div|like|between|and|not|\|\||\&\&)\s*?[\w\"'`][+&!@(),.-])|(?:[^\w\s]\w+\s*?[|-]\s*?[\"'`]\s*?\w)|(?:@\w+\s+(and|x?or|div|like|between|and)\s*?[\"'`\d]+)|(?:@[\w-]+\s(and|x?or|div|like|between|and)\s*?[^\w\s])|(?:[^\w\s:]\s*?\d\W+[^\w\s]\s*?[\"'`].)|(?:\Winformation_schema|table_name\W))" \
     "phase:request,\
     rev:'2',\
-    ver:'OWASP_CRS/3.0.0',\
+    ver:'OWASP_CRS/3.1.0',\
     maturity:'9',\
     accuracy:'8',\
     capture,\
@@ -819,7 +819,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s*?\*.+(?:x?or|div|like|between|and|id)\W*?[\"'`]\d)|(?:\^[\"'`])|(?:^[\w\s\"'`-]+(?<=and\s)(?<=or|xor|div|like|between|and\s)(?<=xor\s)(?<=nand\s)(?<=not\s)(?<=\|\|)(?<=\&\&)\w+\()|(?:[\"'`]\s*?[^\w\s?]+\s*?[^\w\s]+\s*?[\"'`])|(?:[\"'`]\s*?[^\w\s]+\s*?[\W\d].*?(?:#|--))|(?:[\"'`].*?\*\s*?\d)|(?:[\"'`]\s*?(x?or|div|like|between|and)\s[^\d]+[\w-]+.*?\d)|(?:[()\*<>%+-][\w-]+[^\w\s]+[\"'`][^,]))" \
     "phase:request,\
     rev:'2',\
-    ver:'OWASP_CRS/3.0.0',\
+    ver:'OWASP_CRS/3.1.0',\
     maturity:'9',\
     accuracy:'8',\
     capture,\
@@ -1251,7 +1251,7 @@ SecRule ARGS "\W{4}" \
     setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION-%{matched_var_name}=%{tx.0}"
 
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`][\s\d]*?[^\w\s]+\W*?\d\W*?.*?[\"'`\d]))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?:[\"'`][\s\d]*?[^\w\s]+\W*?\d\W*?.*?[\"'`\d])" \
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.1.0',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -769,7 +769,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
-    msg:'Detects classic SQL injection probings 1/2',\
+    msg:'Detects classic SQL injection probings 1/3',\
     id:942330,\
     tag:'application-multi',\
     tag:'language-multi',\
@@ -816,7 +816,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s*?\*.+(?:x?or|div|like|between|and|id)\W*?[\"'`]\d)|(?:\^[\"'`])|(?:^[\w\s\"'`-]+(?<=and\s)(?<=or|xor|div|like|between|and\s)(?<=xor\s)(?<=nand\s)(?<=not\s)(?<=\|\|)(?<=\&\&)\w+\()|(?:[\"'`][\s\d]*?[^\w\s]+\W*?\d\W*?.*?[\"'`\d])|(?:[\"'`]\s*?[^\w\s?]+\s*?[^\w\s]+\s*?[\"'`])|(?:[\"'`]\s*?[^\w\s]+\s*?[\W\d].*?(?:#|--))|(?:[\"'`].*?\*\s*?\d)|(?:[\"'`]\s*?(x?or|div|like|between|and)\s[^\d]+[\w-]+.*?\d)|(?:[()\*<>%+-][\w-]+[^\w\s]+[\"'`][^,]))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s*?\*.+(?:x?or|div|like|between|and|id)\W*?[\"'`]\d)|(?:\^[\"'`])|(?:^[\w\s\"'`-]+(?<=and\s)(?<=or|xor|div|like|between|and\s)(?<=xor\s)(?<=nand\s)(?<=not\s)(?<=\|\|)(?<=\&\&)\w+\()|(?:[\"'`]\s*?[^\w\s?]+\s*?[^\w\s]+\s*?[\"'`])|(?:[\"'`]\s*?[^\w\s]+\s*?[\W\d].*?(?:#|--))|(?:[\"'`].*?\*\s*?\d)|(?:[\"'`]\s*?(x?or|div|like|between|and)\s[^\d]+[\w-]+.*?\d)|(?:[()\*<>%+-][\w-]+[^\w\s]+[\"'`][^,]))" \
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
@@ -825,7 +825,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
-    msg:'Detects classic SQL injection probings 2/2',\
+    msg:'Detects classic SQL injection probings 2/3',\
     id:942370,\
     tag:'application-multi',\
     tag:'language-multi',\
@@ -1249,6 +1249,36 @@ SecRule ARGS "\W{4}" \
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},setvar:'tx.msg=%{rule.msg}',\
     setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION-%{matched_var_name}=%{tx.0}"
+
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`][\s\d]*?[^\w\s]+\W*?\d\W*?.*?[\"'`\d]))" \
+    "phase:request,\
+    rev:'2',\
+    ver:'OWASP_CRS/3.1.0',\
+    maturity:'9',\
+    accuracy:'8',\
+    capture,\
+    t:none,t:urlDecodeUni,\
+    block,\
+    msg:'Detects classic SQL injection probings 3/3',\
+    id:942470,\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-sqli',\
+    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+    tag:'WASCTC/WASC-19',\
+    tag:'OWASP_TOP_10/A1',\
+    tag:'OWASP_AppSensor/CIE1',\
+    tag:'PCI/6.5.2',\
+    tag:'paranoia-level/3',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    severity:'CRITICAL',\
+    setvar:'tx.msg=%{rule.msg}',\
+    setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
+    setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'
+
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:1,id:942017,nolog,pass,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -32,8 +32,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     severity:'CRITICAL',\
     t:none,t:urlDecodeUni,\
     capture,\
@@ -59,8 +57,6 @@ SecRule ARGS_NAMES "@rx ^(jsessionid|aspsessionid|asp.net_sessionid|phpsession|p
     phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'2',\
-    accuracy:'7',\
     id:943110,\
     t:none,t:urlDecodeUni,t:lowercase,\
     capture,\
@@ -91,8 +87,6 @@ SecRule ARGS_NAMES "@rx ^(jsessionid|aspsessionid|asp.net_sessionid|phpsession|p
     phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'2',\
-    accuracy:'7',\
     id:943120,\
     t:none,t:urlDecodeUni,t:lowercase,\
     capture,\

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -31,8 +31,6 @@ SecRule RESPONSE_BODY "(?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Index of
     "phase:response,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -69,8 +67,6 @@ SecRule RESPONSE_STATUS "^5\d{2}$" \
     "phase:response,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -45,8 +45,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951110,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -74,8 +72,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951120,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -103,8 +99,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951130,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -132,8 +126,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951140,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -161,8 +153,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951150,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -190,8 +180,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951160,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -219,8 +207,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951170,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -248,8 +234,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951180,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -278,8 +262,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951190,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -308,8 +290,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951200,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -337,8 +317,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951210,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -366,8 +344,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951220,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -395,8 +371,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951230,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -424,8 +398,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951240,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -453,8 +425,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951250,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -482,8 +452,6 @@ SecRule TX:sql_error_match "@eq 1" \
     id:951260,\
     rev:'1',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'7',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -26,8 +26,6 @@ SecRule RESPONSE_BODY "@pmFromFile java-code-leakages.data" \
     "phase:4,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -58,8 +56,6 @@ SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
     "phase:4,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -28,8 +28,6 @@ SecRule RESPONSE_BODY "@pmf php-errors.data" \
     phase:response,\
     ver:'OWASP_CRS/3.0.0',\
     rev:'3',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -57,8 +55,6 @@ SecRule RESPONSE_BODY "(?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scanf|wr
     "phase:response,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -91,8 +87,6 @@ SecRule RESPONSE_BODY "<\?(?!xml)" \
     "phase:response,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     chain,\
     t:none,\
     capture,\

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -24,8 +24,6 @@ SecRule RESPONSE_BODY "[a-z]:\\\\inetpub\b" \
     "phase:4,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     capture,\
     t:lowercase,\
@@ -52,8 +50,6 @@ SecRule RESPONSE_BODY "(?:Microsoft OLE DB Provider for SQL Server(?:<\/font>.{1
     "phase:4,\
     rev:'3',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -82,8 +78,6 @@ SecRule RESPONSE_BODY "(?:\b(?:A(?:DODB\.Command\b.{0,100}?\b(?:Application uses
     "phase:4,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\
@@ -111,8 +105,6 @@ SecRule RESPONSE_STATUS "!^404$" \
     "phase:4,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
-    maturity:'9',\
-    accuracy:'9',\
     t:none,\
     capture,\
     ctl:auditLogParts=+E,\


### PR DESCRIPTION
Rule 942370 has led to many false positives on a recent implementation of a CMS. Here is an extract of the POST request body that matched;

````
a:4:s:10:"@extension";s:4:"Form";s:11:"@controller";s:8:"Frontend";s:7:"@action";s:4:"show";s:7:"@vendor";s:9:"TYPO3\CMS";}2c0bd52d2261306ac8851dddef4bceafefab451a
````
This kind of payload is not out of the ordinary for certain CMS.
The only part that actually matched is ```` ";}2c0 ```` . It was only matched by a small portion of the regular expression, which is completely seperated from the rest of the regexp by an OR-operator.

This separation means that said part of the expression acts like a completely separate rule. That rule seems to be very sensitive. It only requires a quotation mark followed by a special character, then two random numbers that may be separated, for example ````"#22```` would match. This seems to be too strict to include in PL2. Because of its sensitivity seems to be a perfect addition to rule 942460 , which is in PL3 and matches any four special characters in sequence.

Therefore, I would suggest splitting the rule in two and moving this sensitive part to PL3.