### PR TITLE
Classic SQL injection probing rule split 942370

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -762,7 +762,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s*?\*.+(?:x?or|div|like|between|and|id)\W*?[\"'`]\d)|(?:\^[\"'`])|(?:^[\w\s\"'`-]+(?<=and\s)(?<=or|xor|div|like|between|and\s)(?<=xor\s)(?<=nand\s)(?<=not\s)(?<=\|\|)(?<=\&\&)\w+\()|(?:[\"'`]\s*?[^\w\s?]+\s*?[^\w\s]+\s*?[\"'`])|(?:[\"'`]\s*?[^\w\s]+\s*?[\W\d].*?(?:#|--))|(?:[\"'`].*?\*\s*?\d)|(?:[\"'`]\s*?(x?or|div|like|between|and)\s[^\d]+[\w-]+.*?\d)|(?:[()\*<>%+-][\w-]+[^\w\s]+[\"'`][^,]))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:[\"'`]\s*?\*.+(?:x?or|div|like|between|and|id)\W*?[\"'`]\d)|(?:\^[\"'`])|(?:^[\w\s\"'`-]+(?<=and\s)(?<=or|xor|div|like|between|and\s)(?<=xor\s)(?<=nand\s)(?<=not\s)(?<=\|\|)(?<=\&\&)\w+\()|(?:[\"'`]\s*?[^\w\s?]+\s*?[^\w\s]+\s*?[\"'`])|(?:[\"'`]\s*?[^\w\s]+\s*?[\W\d].*?(?:#|--))|(?:[\"'`].*?\*\s*?\d)|(?:[\"'`]\s*?(x?or|div|like|between|and)\s[^\d]+[\w-]+.*?\d)|(?:[()\*<>%+-][\w-]+[^\w\s]+[\"'`][^,]))" \
     "phase:2,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
@@ -1173,7 +1173,7 @@ SecRule ARGS "\W{4}" \
     setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION-%{matched_var_name}=%{tx.0}"
 
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`][\s\d]*?[^\w\s]+\W*?\d\W*?.*?[\"'`\d]))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:[\"'`][\s\d]*?[^\w\s]+\W*?\d\W*?.*?[\"'`\d])" \
     "phase:2,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -710,7 +710,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s*?(x?or|div|like|between|and)\s*?[\"'`]?\d)|(?:\\\\x(?:23|27|3d))|(?:^.?[\"'`]$)|(?:(?:^[\"'`\\\\]*?(?:[\d\"'`]+|[^\"'`]+[\"'`]))+\s*?(?:n?and|x?x?or|div|like|between|and|not|\|\||\&\&)\s*?[\w\"'`][+&!@(),.-])|(?:[^\w\s]\w+\s*?[|-]\s*?[\"'`]\s*?\w)|(?:@\w+\s+(and|x?or|div|like|between|and)\s*?[\"'`\d]+)|(?:@[\w-]+\s(and|x?or|div|like|between|and)\s*?[^\w\s])|(?:[^\w\s:]\s*?\d\W+[^\w\s]\s*?[\"'`].)|(?:\Winformation_schema|table_name\W))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:[\"'`]\s*?(x?or|div|like|between|and)\s*?[\"'`]?\d)|(?:\\\\x(?:23|27|3d))|(?:^.?[\"'`]$)|(?:(?:^[\"'`\\\\]*?(?:[\d\"'`]+|[^\"'`]+[\"'`]))+\s*?(?:n?and|x?x?or|div|like|between|and|not|\|\||\&\&)\s*?[\w\"'`][+&!@(),.-])|(?:[^\w\s]\w+\s*?[|-]\s*?[\"'`]\s*?\w)|(?:@\w+\s+(and|x?or|div|like|between|and)\s*?[\"'`\d]+)|(?:@[\w-]+\s(and|x?or|div|like|between|and)\s*?[^\w\s])|(?:[^\w\s:]\s*?\d\W+[^\w\s]\s*?[\"'`].)|(?:\Winformation_schema|table_name\W))" \
     "phase:2,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -711,7 +711,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s*?(x?or|div|like|between|and)\s*?[\"'`]?\d)|(?:\\\\x(?:23|27|3d))|(?:^.?[\"'`]$)|(?:(?:^[\"'`\\\\]*?(?:[\d\"'`]+|[^\"'`]+[\"'`]))+\s*?(?:n?and|x?x?or|div|like|between|and|not|\|\||\&\&)\s*?[\w\"'`][+&!@(),.-])|(?:[^\w\s]\w+\s*?[|-]\s*?[\"'`]\s*?\w)|(?:@\w+\s+(and|x?or|div|like|between|and)\s*?[\"'`\d]+)|(?:@[\w-]+\s(and|x?or|div|like|between|and)\s*?[^\w\s])|(?:[^\w\s:]\s*?\d\W+[^\w\s]\s*?[\"'`].)|(?:\Winformation_schema|table_name\W))" \
-    "phase:request,\
+    "phase:2,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
     capture,\
@@ -763,7 +763,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s*?\*.+(?:x?or|div|like|between|and|id)\W*?[\"'`]\d)|(?:\^[\"'`])|(?:^[\w\s\"'`-]+(?<=and\s)(?<=or|xor|div|like|between|and\s)(?<=xor\s)(?<=nand\s)(?<=not\s)(?<=\|\|)(?<=\&\&)\w+\()|(?:[\"'`]\s*?[^\w\s?]+\s*?[^\w\s]+\s*?[\"'`])|(?:[\"'`]\s*?[^\w\s]+\s*?[\W\d].*?(?:#|--))|(?:[\"'`].*?\*\s*?\d)|(?:[\"'`]\s*?(x?or|div|like|between|and)\s[^\d]+[\w-]+.*?\d)|(?:[()\*<>%+-][\w-]+[^\w\s]+[\"'`][^,]))" \
-    "phase:request,\
+    "phase:2,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
     capture,\
@@ -1174,9 +1174,9 @@ SecRule ARGS "\W{4}" \
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`][\s\d]*?[^\w\s]+\W*?\d\W*?.*?[\"'`\d]))" \
-    "phase:request,\
+    "phase:2,\
     rev:'2',\
-    ver:'OWASP_CRS/3.1.0',\
+    ver:'OWASP_CRS/3.0.0',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -717,7 +717,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
-    msg:'Detects classic SQL injection probings 1/2',\
+    msg:'Detects classic SQL injection probings 1/3',\
     id:942330,\
     tag:'application-multi',\
     tag:'language-multi',\
@@ -762,14 +762,14 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s*?\*.+(?:x?or|div|like|between|and|id)\W*?[\"'`]\d)|(?:\^[\"'`])|(?:^[\w\s\"'`-]+(?<=and\s)(?<=or|xor|div|like|between|and\s)(?<=xor\s)(?<=nand\s)(?<=not\s)(?<=\|\|)(?<=\&\&)\w+\()|(?:[\"'`][\s\d]*?[^\w\s]+\W*?\d\W*?.*?[\"'`\d])|(?:[\"'`]\s*?[^\w\s?]+\s*?[^\w\s]+\s*?[\"'`])|(?:[\"'`]\s*?[^\w\s]+\s*?[\W\d].*?(?:#|--))|(?:[\"'`].*?\*\s*?\d)|(?:[\"'`]\s*?(x?or|div|like|between|and)\s[^\d]+[\w-]+.*?\d)|(?:[()\*<>%+-][\w-]+[^\w\s]+[\"'`][^,]))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`]\s*?\*.+(?:x?or|div|like|between|and|id)\W*?[\"'`]\d)|(?:\^[\"'`])|(?:^[\w\s\"'`-]+(?<=and\s)(?<=or|xor|div|like|between|and\s)(?<=xor\s)(?<=nand\s)(?<=not\s)(?<=\|\|)(?<=\&\&)\w+\()|(?:[\"'`]\s*?[^\w\s?]+\s*?[^\w\s]+\s*?[\"'`])|(?:[\"'`]\s*?[^\w\s]+\s*?[\W\d].*?(?:#|--))|(?:[\"'`].*?\*\s*?\d)|(?:[\"'`]\s*?(x?or|div|like|between|and)\s[^\d]+[\w-]+.*?\d)|(?:[()\*<>%+-][\w-]+[^\w\s]+[\"'`][^,]))" \
     "phase:request,\
     rev:'2',\
     ver:'OWASP_CRS/3.0.0',\
     capture,\
     t:none,t:urlDecodeUni,\
     block,\
-    msg:'Detects classic SQL injection probings 2/2',\
+    msg:'Detects classic SQL injection probings 2/3',\
     id:942370,\
     tag:'application-multi',\
     tag:'language-multi',\
@@ -1171,6 +1171,34 @@ SecRule ARGS "\W{4}" \
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     setvar:tx.anomaly_score=+%{tx.warning_anomaly_score},setvar:'tx.msg=%{rule.msg}',\
     setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION-%{matched_var_name}=%{tx.0}"
+
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?i:(?:[\"'`][\s\d]*?[^\w\s]+\W*?\d\W*?.*?[\"'`\d]))" \
+    "phase:request,\
+    rev:'2',\
+    ver:'OWASP_CRS/3.1.0',\
+    capture,\
+    t:none,t:urlDecodeUni,\
+    block,\
+    msg:'Detects classic SQL injection probings 3/3',\
+    id:942470,\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-sqli',\
+    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+    tag:'WASCTC/WASC-19',\
+    tag:'OWASP_TOP_10/A1',\
+    tag:'OWASP_AppSensor/CIE1',\
+    tag:'PCI/6.5.2',\
+    tag:'paranoia-level/3',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    severity:'CRITICAL',\
+    setvar:'tx.msg=%{rule.msg}',\
+    setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},\
+    setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'
+
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:1,id:942017,nolog,pass,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"


### PR DESCRIPTION
Rule 942370 has led to many false positives on a recent implementation of a CMS. Here is an extract of the POST request body that matched;

````
a:4:s:10:"@extension";s:4:"Form";s:11:"@controller";s:8:"Frontend";s:7:"@action";s:4:"show";s:7:"@vendor";s:9:"TYPO3\CMS";}2c0bd52d2261306ac8851dddef4bceafefab451a
````
This kind of payload is not out of the ordinary for certain CMS.
The only part that actually matched is ```` ";}2c0 ```` . It was only matched by a small portion of the regular expression, which is completely seperated from the rest of the regexp by an OR-operator.

This separation means that said part of the expression acts like a completely separate rule. That rule seems to be very sensitive. It only requires a quotation mark followed by a special character, then two random numbers that may be separated, for example ````"#22```` would match. This seems to be too strict to include in PL2. Because of its sensitivity seems to be a perfect addition to rule 942460 , which is in PL3 and matches any four special characters in sequence.

Therefore, I would suggest splitting the rule in two and moving this sensitive part to PL3.