### PR TITLE
RCE regexps: add explanations in comments

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -33,6 +33,42 @@ SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:2,id:932012,nolog,pass,skipAfter:END-RE
 #
 # To prevent false positives, we look for a 'starting sequence' that
 # precedes a command in shell syntax, such as: ; | & $( ` <( >(
+# Anatomy of the regexp with examples of patterns caught:
+#
+# 1. Starting tokens
+#
+# ;        ;ifconfig
+# \{       {ifconfig}
+# \|       |ifconfig
+# \|\|     ||ifconfig
+# &        &ifconfig
+# &&       &&ifconfig
+# \n       ;\nifconfig
+# \r       ;\rifconfig
+# \$\(     $(ifconfig)
+# $\(\(    $((ifconfig))
+# `        `ifconfig`
+# \${      ${ifconfig}
+# <\(      <( ifconfig )
+# >\(      >( ifconfig )
+# \(\s*\)  a() ( ifconfig; ); a
+#
+# 2. Command prefixes
+#
+# {        { ifconfig }
+# \s*\(\s* ( ifconfig )
+# \w+=(?:[^\s]*|\$.*|\$.*|<.*|>.*|\'.*\'|\".*\")\s+   VARNAME=xyz ifconfig
+# !\s*     ! ifconfig
+# \$       $ifconfig
+#
+# 3. Quoting
+#
+# '        'ifconfig'
+# \"       "ifconfig"
+#
+# 4. Paths
+#
+# [\?\*\[\]\(\)\-\|+\w'\"\./\\\\]+/   /sbin/ifconfig, /s?in/./ifconfig, /s[a-b]in/ifconfig etc.
 #
 # This rule is case-sensitive to prevent FP ("Cat" vs. "cat").
 #

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -177,6 +177,45 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # To prevent false positives, we look for a 'starting sequence' that
 # precedes a command in CMD syntax, such as: ; | & `
 #
+# Anatomy of the regexp:
+#
+# 1. Starting tokens
+#
+# ;        ;cmd
+# \{       {cmd
+# \|       |cmd
+# \|\|     ||cmd
+# &        &cmd
+# &&       &&cmd
+# \n       \ncmd
+# \r       \rcmd
+# `        `cmd
+#
+# 2. Command prefixes
+#
+# (        (cmd)
+# ,        ,cmd
+# @        @cmd
+# '        'cmd'
+# "        "cmd"
+# \s       spacing+cmd
+#
+# 3. Paths
+#
+# [\w'\"\./]+/                          /path/cmd
+# [\\\\'\"\^]*\w[\\\\'\"\^]*:.*\\\\     C:\Program Files\cmd
+# [\^\.\w '\"/\\\\]*\\\\)?[\"\^]*       \\net\share\dir\cmd
+#
+# 4. Quoting
+#
+# \"       "cmd"
+# \^       ^cmd
+#
+# 5. Extension/switches
+#
+# \.[\"\^]*\w+      cmd.com, cmd.exe, etc.
+# /b                cmd/h
+#
 # An effort is made to combat evasions by CMD syntax; for example,
 # the following strings are valid: c^md, @cmd, "c"md. ModSecurity
 # has a t:cmdLine transformation built-in to deal with some of these,


### PR DESCRIPTION
@fgsch has offered to review and if possible improve the RCE regexps, but they are quite long and are missing some examples, so I added a breakdown in the comments of rule 932100 (unix) and (windows).