### PR TITLE
unix-shell.data: add small omissions

### DIFF
--- a/rules/unix-shell.data
+++ b/rules/unix-shell.data
@@ -1,8 +1,10 @@
 bin/bash
+bin/cat
 bin/csh
 bin/dash
 bin/du
 bin/echo
+bin/grep
 bin/less
 bin/ls
 bin/more
@@ -34,6 +36,7 @@ usr/bin/cc
 usr/bin/clang
 usr/bin/clang++
 usr/bin/curl
+usr/bin/diff
 usr/bin/env
 usr/bin/fetch
 usr/bin/file


### PR DESCRIPTION
Add some common shell commands to the Unix RCE blacklist (rule 932160).