### PR TITLE
duplicated header bypax fix and chunk support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,3 +9,4 @@ Contributors:
 	Christoph Hansen (emphazer)
 	Franziska Buehler (franbuehler)
 	Victor Hora (victorhora)
+	Manuel Leos Rivas (spartantri)

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -288,7 +288,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # It is recommended if you run multiple web applications on your site to limit
 # the effects of the exclusion to only the path where the excluded webapp
 # resides using a rule similar to the following example:
-# SecRule REQUEST_URI "@beginsWith /wordpress/" setvar:crs_exclusions_wordpress=1
+# SecRule REQUEST_URI "@beginsWith /wordpress/" setvar:tx.crs_exclusions_wordpress=1
 
 #
 # Modify and uncomment this rule to select which application:

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -269,10 +269,11 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
 #
 # -=[ Rule Logic ]=-
 # This chained rule checks if the request method is POST, if so, it checks that a Content-Length
-# header is also present.
+# header is also present and that chunked Transfer-Encoding is not being used.
 #
 # -=[ References ]=-
 # http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5
+# https://tools.ietf.org/html/rfc7230#section-3.3.1
 #
 SecRule REQUEST_METHOD "@rx ^POST$" \
     "id:920180,\
@@ -288,14 +289,15 @@ SecRule REQUEST_METHOD "@rx ^POST$" \
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.0.0',\
-    rev:'1',\
+    rev:'2',\
     severity:'WARNING',\
     chain"
-    SecRule &REQUEST_HEADERS:Content-Length "@eq 0" \
-        "t:none,\
-        setvar:'tx.msg=%{rule.msg}',\
-        setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
+    SecRule &REQUEST_HEADERS:Content-Length "@eq 0" "chain"
+        SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
+            "t:none,\
+            setvar:'tx.msg=%{rule.msg}',\
+            setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+            setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
 
 
 #
@@ -702,6 +704,42 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
     setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
     setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
 
+
+#
+# Transfer-Encoding was added in HTTP/1.1.  It is generally assumed that implementations advertising
+# only HTTP/1.0 support will not understand how to process a transfer-encoded payload.  A client MUST
+# NOT send a request containing Transfer-Encoding unless it knows the server will handle HTTP/1.1
+# (or later) requests; such knowledge might be in the form of specific user configuration or by
+# remembering the version of a prior received response.  A server MUST NOT send a response containing
+# Transfer-Encoding unless the corresponding request indicates HTTP/1.1 (or later).
+#
+# A server that receives a request message with a transfer coding it does not understand
+# SHOULD respond with 501 (Not Implemented).
+#
+# -=[ References ]=-
+# https://tools.ietf.org/html/rfc7230#section-3.3.1
+
+SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
+    "id:920335,\
+    phase:2,\
+    block,\
+    t:none,\
+    msg:'Request Using Transfer-Encoding, but HTTP/1.1 or later is not in use',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    rev:'1',\
+    ver:'OWASP_CRS/3.1.0',\
+    severity:'NOTICE',\
+    chain"
+    SecRule REQUEST_PROTOCOL "!^HTTP/(?:1\.1|2)" \
+        "t:none,\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+        setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
+
+
 #
 # Missing Content-Type Header with Request Body
 #
@@ -712,8 +750,12 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
 # Content-Type header. However, a request missing a Content-Header is a
 # strong indication of a non-compliant browser.
 #
+# If the Transfer-Encoding is chunked there should be no Content-Length as the length is specified at the
+# beginning of every chunk
+#
 # -=[ References ]=-
 # http://httpwg.org/specs/rfc7231.html#header.content-type
+# https://tools.ietf.org/html/rfc7230#section-3.3.1
 
 SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     "id:920340,\
@@ -725,11 +767,32 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    rev:'3',\
-    ver:'OWASP_CRS/3.0.0',\
+    rev:'4',\
+    ver:'OWASP_CRS/3.1.0',\
     severity:'NOTICE',\
     chain"
-    SecRule &REQUEST_HEADERS:Content-Type "@eq 0" \
+    SecRule &REQUEST_HEADERS:Content-Type "@eq 0" "chain"
+        SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
+            "t:none,\
+            setvar:'tx.msg=%{rule.msg}',\
+            setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+            setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
+
+SecRule REQUEST_HEADERS:Transfer-Encoding "@rx chunked" \
+    "id:920345,\
+    phase:2,\
+    block,\
+    t:none,\
+    msg:'Request Using chunks, but Content-Length header is present',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    rev:'1',\
+    ver:'OWASP_CRS/3.1.0',\
+    severity:'NOTICE',\
+    chain"
+    SecRule &REQUEST_HEADERS:Content-Length "!@eq 0" \
         "t:none,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
@@ -1442,6 +1505,51 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?<!\Q\\\E)\Q\\\E[cdegh
     setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
     setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/ABNORMAL-ESCAPE-%{matched_var_name}=%{matched_var}"
 
+
+SecRule &REQUEST_HEADERS:Content-Type "@gt 1" \
+    "id:920470,\
+    phase:2,\
+    pass,\
+    t:none,\
+    msg:'More than one Content-Type Header detected',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'OWASP_CRS/PROTOCOL_VIOLATION/DUPLICATED_HEADER',\
+    tag:'WASCTC/WASC-21',\
+    tag:'OWASP_TOP_10/A7',\
+    tag:'PCI/6.5.10',\
+    tag:'paranoia-level/4',\
+    rev:'1',\
+    ver:'OWASP_CRS/3.1.0',\
+    severity:'NOTICE',\
+    setvar:'tx.msg=%{rule.msg}',\
+    setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
+
+
+SecRule &REQUEST_HEADERS:Content-Length "@gt 1" \
+    "id:920480,\
+    phase:2,\
+    pass,\
+    t:none,\
+    msg:'More than one Content-Length Header detected',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'OWASP_CRS/PROTOCOL_VIOLATION/DUPLICATED_HEADER',\
+    tag:'WASCTC/WASC-21',\
+    tag:'OWASP_TOP_10/A7',\
+    tag:'PCI/6.5.10',\
+    tag:'paranoia-level/4',\
+    rev:'1',\
+    ver:'OWASP_CRS/3.1.0',\
+    severity:'NOTICE',\
+    setvar:'tx.msg=%{rule.msg}',\
+    setvar:tx.anomaly_score=+%{tx.notice_anomaly_score},\
+    setvar:tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}"
 
 #
 # -= Paranoia Levels Finished =-


### PR DESCRIPTION
Added support for Transfer-Encoding header that breaks requests 
using chunks and some possible bypasses due to duplicated headers
and bad modsecurity capture then chain behavior:
- 920180 added check for REQUEST_HEADER:Transfer-Encoding use
- 920335 (new rule) check REQUEST_HEADER:Transfer-Encoding used
  with HTTP/1.1 and later
- 920340 added check for REQUEST_HEADER:Transfer-Encoding use
- 920345 (new rule) check REQUEST_HEADERS:Transfer-Encoding is not used
  with Content-Length, headers are mutually exclusive
- 920470 (new rule) check for duplicated REQUEST_HEADERS:Content-Type
- 920480 (new rule) check for duplicated REQUEST_HEADERS:Content-Length

Check with:  
curl -XPOST http://localhost/index.html -H'Content-Type: \
application/x-www-form-urlencoded' -H'Transfer-Encoding: chunked' \
-d @/tmp/chunk