### PR TITLE
Catch GET or HEAD with Transfer-Encoding

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -265,6 +265,33 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
 
 
 #
+# This is a sibling of rule 920170
+#
+SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
+    "id:920171,\
+    phase:2,\
+    block,\
+    t:none,\
+    msg:'GET or HEAD Request with Transfer-Encoding.',\
+    logdata:'%{matched_var}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
+    tag:'CAPEC-272',\
+    ver:'OWASP_CRS/3.1.0',\
+    rev:1,\
+    severity:'CRITICAL',\
+    chain"
+    SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
+        "t:none,\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
+
+
+#
 # Require Content-Length to be provided with every POST request.
 #
 # -=[ Rule Logic ]=-


### PR DESCRIPTION
Sibling of rule 920170.

Fixes #909.