### PR TITLE
REQUEST-901-INITIALIZATION.conf: add http PATCH verb to id 901160

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -152,7 +152,7 @@ SecRule &TX:allowed_methods "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
+    setvar:'tx.allowed_methods=GET HEAD POST OPTIONS PATCH'"
 
 # Default HTTP policy: allowed_request_content_type (rule 900220)
 SecRule &TX:allowed_request_content_type "@eq 0" \


### PR DESCRIPTION
The PATCH method is a request method supported by the HTTP protocol for making
partial changes to an existing resource (RFC5789)

Signed-off-by: Elia Pinto <pinto.elia@gmail.com>