### PR TITLE
for the serilize object injection, it should be 933170 instead of 933150

### DIFF
--- a/util/regression-tests/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933150.yaml
+++ b/util/regression-tests/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933150.yaml
@@ -218,7 +218,7 @@
           port: 80
           uri: /serialize0?foo=O%3A8%3A%22stdClass%22%3A0%3A%7B%7D
         output:
-          log_contains: id "933150"
+          log_contains: id "933170"
   - 
     test_title: 933150-16
     desc: PHP object injection
@@ -232,7 +232,7 @@
           port: 80
           uri: /serialize1?foo=O%3A8%3A%22stdClass%22%3A1%3A%7Bs%3A1%3A%22a%22%3Bi%3A2%3B%7D
         output:
-          log_contains: id "933150"
+          log_contains: id "933170"
   - 
     test_title: 933150-17
     desc: PHP object injection
@@ -248,7 +248,7 @@
           port: 80
           uri: /serialize2
         output:
-          log_contains: id "933150"
+          log_contains: id "933170"
   - 
     test_title: 933150-18
     desc: PHP object injection
@@ -264,7 +264,7 @@
           port: 80
           uri: /serialize3?foo=O%3A21%3A%22JDatabaseDriverMysqli%22%3A3%3A%7Bs%3A2%3A%22fc%22%3BO%3A17%3A%22JSimplepieFactory%22%3A0%3A%7B%7Ds%3A21%3A%22%5C0%5C0%5C0disconnectHandlers%22%3Ba%3A1%3A%7Bi%3A0%3Ba%3A2%3A%7Bi%3A0%3BO%3A9%3A%22SimplePie%22%3A5%3A%7Bs%3A8%3A%22sanitize%22%3BO%3A20%3A%22JDatabaseDriverMysql%22%3A0%3A%7B%7Ds%3A8%3A%22feed_url%22%3Bs%3A119%3A%22eval%28chr%28112%29.chr%28104%29.chr%28112%29.chr%28105%29.chr%28110%29.chr%28102%29.chr%28111%29.chr%2840%29.chr%2841%29.chr%2859%29%29%3BJFactory%3A%3AgetConfig%28%29%3Bexit%22%3Bs%3A19%3A%22cache_name_function%22%3Bs%3A6%3A%22assert%22%3Bs%3A5%3A%22cache%22%3Bb%3A1%3Bs%3A11%3A%22cache_class%22%3BO%3A20%3A%22JDatabaseDriverMysql%22%3A0%3A%7B%7D%7Di%3A1%3Bs%3A4%3A%22init%22%3B%7D%7Ds%3A13%3A%22%5C0%5C0%5C0connection%22%3Bb%3A1%3B%7D
         output:
-          log_contains: id "933150"
+          log_contains: id "933170"
   - 
     test_title: 933150-19
     desc: PHP object injection
@@ -280,7 +280,7 @@
           port: 80
           uri: /serialize4/ajax/api/hook/decodeArguments?arguments=O%3A12%3A%22vB_dB_Result%22%3A2%3A%7Bs%3A5%3A%22%00%2a%00db%22%3BO%3A11%3A%22vB_Database%22%3A1%3A%7Bs%3A9%3A%22functions%22%3Ba%3A1%3A%7Bs%3A11%3A%22free_result%22%3Bs%3A7%3A%22phpinfo%22%3B%7D%7Ds%3A12%3A%22%00%2a%00recordset%22%3Bi%3A1%3B%7D
         output:
-          log_contains: id "933150"
+          log_contains: id "933170"
   - 
     test_title: 933150-20
     desc: PHP object injection
@@ -296,7 +296,7 @@
           port: 80
           uri: /serialize5?O%3A8%3A%22stdClass%22%3A4%3A%7Bs%3A3%3A%22aaa%22%3Ba%3A5%3A%7Bi%3A0%3Bi%3A1%3Bi%3A1%3Bi%3A2%3Bi%3A2%3Ba%3A1%3A%7Bi%3A0%3Bi%3A1%3B%7Di%3A3%3Bi%3A4%3Bi%3A4%3Bi%3A5%3B%7Ds%3A3%3A%22aaa%22%3Bi%3A1%3Bs%3A3%3A%22ccc%22%3BR%3A5%3Bs%3A3%3A%22ddd%22%3Bs%3A4%3A%22AAAA%22%3B%7D
         output:
-          log_contains: id "933150"
+          log_contains: id "933170"
   - 
     test_title: 933150-21
     desc: PHP object injection
@@ -312,7 +312,7 @@
           port: 80
           uri: /serialize6
         output:
-          log_contains: id "933150"
+          log_contains: id "933170"
   - 
     test_title: 933150-22
     desc: PHP object injection
@@ -328,7 +328,7 @@
           port: 80
           uri: /serialize7
         output:
-          log_contains: id "933150"
+          log_contains: id "933170"
   - 
     test_title: 933150-23
     desc: PHP object injection
@@ -344,7 +344,7 @@
           port: 80
           uri: /serialize8
         output:
-          log_contains: id "933150"
+          log_contains: id "933170"
   - 
     test_title: 933150-24
     desc: PHP object injection
@@ -360,5 +360,5 @@
           port: 80
           uri: /serialize9
         output:
-          log_contains: id "933150"
+          log_contains: id "933170"
     


### PR DESCRIPTION
  After I debug one of the fail case, it seems to be there are some bug in the owasp regression
The test case is for php serialize object injection
   test_title: 933150-24
    desc: PHP object injection
    stages:
    - stage:
        input:
          data: foo=O%3A8%3A%22stdClass%22%3A1%3A%7Bs%3A1%3A%22a%22%3Bi%3A2%3B%7D
          dest_addr: 10.0.5.4
          headers:
            Host: localhost
            User-Agent: ModSecurity CRS 3 Tests
          method: POST
          port: 12801
          uri: /serialize9
        output:
          log_contains: id "933150"

it expects to trigger rule 933150, instead it triggered 933170, which is serialize object injection, while 933150 is for High-Risk PHP Function Name, so this is definitely a bug for owasp regression

[Wed Oct 25 00:20:47.723162 2017] [:error] [pid 2973:tid 140285283583744] [client 10.0.5.4:36508] [client 10.0.5.4] ModSecurity: Warning. Pattern match "[oOcC]:\\\\d+:\\".+?\\":\\\\d+:{.*}" at ARGS:foo. [file "/root/CP/Nginx/crs/crs-3.0/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf"] [line "396"] [id "933170"] [rev "1"] [msg "PHP Injection Attack: Serialized Object Injection"] [data "Matched Data: O:8:\\x22stdClass\\x22:1:{s:1:\\x22a\\x22;i:2;} found within ARGS:foo: O:8:\\x22stdClass\\x22:1:{s:1:\\x22a\\x22;i:2;}"] [severity "CRITICAL"] [ver "OWASP_CRS/3.0.0"] [maturity "1"] [accuracy "9"] [tag "application-multi"] [tag "language-php"] [tag "platform-multi"] [tag "attack-injection-php"] [tag "OWASP_CRS/WEB_ATTACK/PHP_INJECTION"] [tag "OWASP_TOP_10/A1"] [hostname "localhost"] [uri "/serialize9"] [unique_id "We-Y3woABQQAAAud4tMAAAAX"]

