### PR TITLE
Adding fgsch and spartantri as developers

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,8 @@
 - [Franziska Bühler](https://github.com/franbuehler)
 - [Christoph Hansen](https://github.com/emphazer)
 - [Victor Hora](https://github.com/victorhora)
+- [Federico G. Schwindt](https://github.com/fgsch)
+- [Manuel Spartan](https://github.com/spartantri)
 - [Felipe Zipitría](https://github.com/fzipi)
 
 ## Contributors:
@@ -32,7 +34,6 @@
 - [Christian Peron](https://github.com/csjperon)
 - [Elia Pinto](https://github.com/yersinia)
 - [Brian Rectanus](https://github.com/b1v1r)
-- [Federico G. Schwindt](https://github.com/fgsch)
 - Ofer Shezaf
 - Breno Silva
 - Marc Stern

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@
 - [Victor Hora](https://github.com/victorhora)
 - [Federico G. Schwindt](https://github.com/fgsch)
 - [Manuel Spartan](https://github.com/spartantri)
+- [Felipe Zimmerle](https://github.com/zimmerle)
 - [Felipe Zipitría](https://github.com/fzipi)
 
 ## Contributors:
@@ -36,12 +37,11 @@
 - [Brian Rectanus](https://github.com/b1v1r)
 - Ofer Shezaf
 - Breno Silva
-- Marc Stern
+- [Marc Stern](https://github.com/marcstern)
 - [Ben Williams](https://github.com/benwilliams)
 - [Greg Wroblewski](https://github.com/gwroblew)
 - [ygrek](https://github.com/ygrek)
 - [Zino](https://github.com/zinoe)
-- [Felipe Zimmerle](https://github.com/zimmerle)
 - Josh Zlatin
 - [Zou Guangxian](https://github.com/zouguangxian)
 - [4ft35t](https://github.com/4ft35t)


### PR DESCRIPTION
PR #922 only covered @fzipi.

This brings the same update for @fgsch and @spartantri.

This also means SpiderLabs (@victorhora / @zimmerle) has to enable the three new developers (@fzipi, @fgsch and @spartantri) on the repository.

Open question: @zimmerle promised to do the PR to shift him to developer level which has been agreed upon in June. But this never happened. We can include this into this PR if nobody minds.

Other open question: Backport to v3.0/dev?