### PR TITLE
Update ftw's CRS_Test.py mirroring ftw PR 14

### DIFF
--- a/util/regression-tests/CRS_Tests.py
+++ b/util/regression-tests/CRS_Tests.py
@@ -1,4 +1,4 @@
-from ftw import ruleset, logchecker, testrunner
+from ftw.ftw import ruleset, logchecker, testrunner
 import datetime
 import pytest
 import pdb


### PR DESCRIPTION
@zmallen fixed ftw import paths in FTW PR 14 (https://github.com/CRS-support/ftw/pull/14).

This mirrors that PR in our `CRS_Test.py`.

Not sure it is enough to make it work. It does work for me, though.