### PR TITLE
Add configurable timestamp format to our ftw integration

### DIFF
--- a/util/regression-tests/CRS_Tests.py
+++ b/util/regression-tests/CRS_Tests.py
@@ -32,15 +32,17 @@ class FooLogChecker(logchecker.LogChecker):
 
     def get_logs(self):
         log_location = config.log_location_linux
+        log_date_regex = config.log_date_regex
+        log_date_format = config.log_date_format
+        pattern = re.compile(r'%s' % log_date_regex)
         our_logs = []
-        pattern = re.compile(r"\[([A-Z][a-z]{2} [A-z][a-z]{2} \d{1,2} \d{1,2}\:\d{1,2}\:\d{1,2}\.\d+? \d{4})\]")
         for lline in self.reverse_readline(log_location):
             # Extract dates from each line
             match = re.match(pattern,lline)
             if match:
                 log_date = match.group(1)
                 # Convert our date
-                log_date = datetime.datetime.strptime(log_date, "%a %b %d %H:%M:%S.%f %Y")
+                log_date = datetime.datetime.strptime(log_date, log_date_format)
                 ftw_start = self.start
                 ftw_end = self.end
                 # If we have a log date in range

--- a/util/regression-tests/config.py
+++ b/util/regression-tests/config.py
@@ -1,5 +1,5 @@
 # Location of Apache Error Log
-log_location_linux = '/apache/logs/error.log'
+log_location_linux = '/var/log/httpd/error_log'
 log_location_windows = 'C:\Apache24\logs\error.log'
 
 # Regular expression to filter for timestamp in Apache Error Log

--- a/util/regression-tests/config.py
+++ b/util/regression-tests/config.py
@@ -1,2 +1,21 @@
-log_location_linux = '/var/log/httpd/error_log'
+# Location of Apache Error Log
+log_location_linux = '/apache/logs/error.log'
 log_location_windows = 'C:\Apache24\logs\error.log'
+
+# Regular expression to filter for timestamp in Apache Error Log
+#
+# Default timestamp format: (example: [Thu Nov 09 09:04:38.912314 2017])
+log_date_regex = "\[([A-Z][a-z]{2} [A-z][a-z]{2} \d{1,2} \d{1,2}\:\d{1,2}\:\d{1,2}\.\d+? \d{4})\]"
+#
+# Reverse format: (example: [2017-11-09 08:25:03.002312])
+#log_date_regex = "\[([0-9-]{10} [0-9:.]{15})\]"
+
+# Date format matching the timestamp format used by Apache 
+# in order to generate matching timestamp ourself
+#
+# Default timestamp format: (example: see above)
+log_date_format = "%a %b %d %H:%M:%S.%f %Y"
+#
+# Reverse format: (example: see above)
+#log_date_format = "%Y-%m-%d %H:%M:%S.%f"
+


### PR DESCRIPTION
FTW checks apache error logs to find out if ModSecurity / CRS triggered the right alerts. The matching is performed via timestamp match. First via a regex matching the logfile, then by generating a corresponding timestamp itself and the filtering of the loglines during the time delta.

This PR adds the option to define an alternative log timestamp format via `config.py`.

It also documents `config.py` a bit better and adds two additional values that are commented out (and match the reverse timestamp format used in the tutorials).

I just noted that the diff includes a change of the default value for `log_location_linux`. I am going to revert that immediately via a separate commit.