### PR TITLE
V3.1/dev marker

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -284,7 +284,7 @@ SecRule TX:sampling_percentage "@eq 100" \
     phase:1,\
     pass,\
     nolog,\
-    skipAfter:'END-SAMPLING'"
+    skipAfter:END-SAMPLING"
 
 SecRule UNIQUE_ID "@rx ^." \
     "id:901410,\

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -284,7 +284,7 @@ SecRule TX:sampling_percentage "@eq 100" \
     phase:1,\
     pass,\
     nolog,\
-    skipAfter:END-SAMPLING"
+    skipAfter:'END-SAMPLING'"
 
 SecRule UNIQUE_ID "@rx ^." \
     "id:901410,\
@@ -340,6 +340,6 @@ SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
     noauditlog,\
     msg:'Sampling: Disable the rule engine based on sampling_percentage \
 %{TX.sampling_percentage} and random number %{TX.sampling_rnd100}.',\
-    ctl:ruleEngine=off"
+    ctl:ruleEngine=Off"
 
 SecMarker "END-SAMPLING"

--- a/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
@@ -68,7 +68,7 @@ SecRule &TX:crs_exclusions_drupal|TX:crs_exclusions_drupal "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    skipAfter:'END-DRUPAL-RULE-EXCLUSIONS'"
+    skipAfter:END-DRUPAL-RULE-EXCLUSIONS"
 
 
 # [ Table of Contents ]

--- a/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
@@ -68,7 +68,7 @@ SecRule &TX:crs_exclusions_drupal|TX:crs_exclusions_drupal "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    skipAfter:END-DRUPAL-RULE-EXCLUSIONS"
+    skipAfter:'END-DRUPAL-RULE-EXCLUSIONS'"
 
 
 # [ Table of Contents ]
@@ -380,4 +380,4 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/services/rss-publishing" \
     ctl:ruleRemoveTargetByTag=CRS;ARGS:feed_description"
 
 
-SecMarker END-DRUPAL-RULE-EXCLUSIONS
+SecMarker "END-DRUPAL-RULE-EXCLUSIONS"

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -22,7 +22,7 @@ SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    skipAfter:'END-WORDPRESS'"
+    skipAfter:END-WORDPRESS"
 
 SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
     "id:9002001,\
@@ -30,7 +30,7 @@ SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    skipAfter:'END-WORDPRESS'"
+    skipAfter:END-WORDPRESS"
 
 
 #
@@ -193,7 +193,7 @@ SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     pass,\
     t:none,\
     nolog,\
-    skipAfter:'END-WORDPRESS-ADMIN'"
+    skipAfter:END-WORDPRESS-ADMIN"
 
 SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     "id:9002401,\
@@ -201,7 +201,7 @@ SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     pass,\
     t:none,\
     nolog,\
-    skipAfter:'END-WORDPRESS-ADMIN'"
+    skipAfter:END-WORDPRESS-ADMIN"
 
 
 #

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -22,7 +22,7 @@ SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    skipAfter:END-WORDPRESS"
+    skipAfter:'END-WORDPRESS'"
 
 SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
     "id:9002001,\
@@ -30,7 +30,7 @@ SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    skipAfter:END-WORDPRESS"
+    skipAfter:'END-WORDPRESS'"
 
 
 #
@@ -193,7 +193,7 @@ SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     pass,\
     t:none,\
     nolog,\
-    skipAfter:END-WORDPRESS-ADMIN"
+    skipAfter:'END-WORDPRESS-ADMIN'"
 
 SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     "id:9002401,\
@@ -201,7 +201,7 @@ SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     pass,\
     t:none,\
     nolog,\
-    skipAfter:END-WORDPRESS-ADMIN"
+    skipAfter:'END-WORDPRESS-ADMIN'"
 
 
 #
@@ -618,7 +618,7 @@ SecRule REQUEST_FILENAME "@rx /wp-admin/load-(?:scripts|styles)\.php$" \
     ctl:ruleRemoveTargetById=942432;ARGS:load[]"
 
 
-SecMarker END-WORDPRESS-ADMIN
+SecMarker "END-WORDPRESS-ADMIN"
 
 
-SecMarker END-WORDPRESS
+SecMarker "END-WORDPRESS"

--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -76,7 +76,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!@rx ^$" \
             setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
             setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var}',\
             setvar:'ip.reput_block_flag=1',\
-            setvar:'ip.reput_block_reason=%{rule.msg}'\
+            setvar:'ip.reput_block_reason=%{rule.msg}',\
             expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
 
 

--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -42,7 +42,7 @@ SecRule TX:DO_REPUT_BLOCK "@eq 1" \
     setvar:'tx.msg=%{rule.msg}',\
     severity:'CRITICAL',\
     chain,\
-    skipAfter:'BEGIN-REQUEST-BLOCKING-EVAL'"
+    skipAfter:BEGIN-REQUEST-BLOCKING-EVAL"
     SecRule IP:REPUT_BLOCK_FLAG "@eq 1" \
         "setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var}'"
@@ -122,7 +122,7 @@ SecRule IP:PREVIOUS_RBL_CHECK "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
-    skipAfter:'END-RBL-LOOKUP'"
+    skipAfter:END-RBL-LOOKUP"
 
 #
 # Check Client IP against ProjectHoneypot's HTTP Blacklist
@@ -144,7 +144,7 @@ SecRule &TX:block_suspicious_ip "@eq 0" \
     t:none,\
     nolog,\
     chain,\
-    skipAfter:'END-RBL-CHECK'"
+    skipAfter:END-RBL-CHECK"
     SecRule &TX:block_harvester_ip "@eq 0" \
         "chain"
         SecRule &TX:block_spammer_ip "@eq 0" \
@@ -182,7 +182,7 @@ SecRule TX:block_search_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     severity:'CRITICAL',\
     chain,\
-    skipAfter:'END-RBL-CHECK'"
+    skipAfter:END-RBL-CHECK"
     SecRule TX:httpbl_msg "@rx Search Engine" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
@@ -205,7 +205,7 @@ SecRule TX:block_spammer_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     severity:'CRITICAL',\
     chain,\
-    skipAfter:'END-RBL-CHECK'"
+    skipAfter:END-RBL-CHECK"
     SecRule TX:httpbl_msg "@rx (?i)^.*? spammer .*?$" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
@@ -228,7 +228,7 @@ SecRule TX:block_suspicious_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     severity:'CRITICAL',\
     chain,\
-    skipAfter:'END-RBL-CHECK'"
+    skipAfter:END-RBL-CHECK"
     SecRule TX:httpbl_msg "@rx (?i)^.*? suspicious .*?$" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
@@ -251,7 +251,7 @@ SecRule TX:block_harvester_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     severity:'CRITICAL',\
     chain,\
-    skipAfter:'END-RBL-CHECK'"
+    skipAfter:END-RBL-CHECK"
     SecRule TX:httpbl_msg "@rx (?i)^.*? harvester .*?$" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\

--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -42,7 +42,7 @@ SecRule TX:DO_REPUT_BLOCK "@eq 1" \
     setvar:'tx.msg=%{rule.msg}',\
     severity:'CRITICAL',\
     chain,\
-    skipAfter:BEGIN_REQUEST_BLOCKING_EVAL"
+    skipAfter:'BEGIN-REQUEST-BLOCKING-EVAL'"
     SecRule IP:REPUT_BLOCK_FLAG "@eq 1" \
         "setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var}'"
@@ -122,7 +122,7 @@ SecRule IP:PREVIOUS_RBL_CHECK "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
-    skipAfter:END_RBL_LOOKUP"
+    skipAfter:'END-RBL-LOOKUP'"
 
 #
 # Check Client IP against ProjectHoneypot's HTTP Blacklist
@@ -144,7 +144,7 @@ SecRule &TX:block_suspicious_ip "@eq 0" \
     t:none,\
     nolog,\
     chain,\
-    skipAfter:END_RBL_CHECK"
+    skipAfter:'END-RBL-CHECK'"
     SecRule &TX:block_harvester_ip "@eq 0" \
         "chain"
         SecRule &TX:block_spammer_ip "@eq 0" \
@@ -182,7 +182,7 @@ SecRule TX:block_search_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     severity:'CRITICAL',\
     chain,\
-    skipAfter:END_RBL_CHECK"
+    skipAfter:'END-RBL-CHECK'"
     SecRule TX:httpbl_msg "@rx Search Engine" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
@@ -205,7 +205,7 @@ SecRule TX:block_spammer_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     severity:'CRITICAL',\
     chain,\
-    skipAfter:END_RBL_CHECK"
+    skipAfter:'END-RBL-CHECK'"
     SecRule TX:httpbl_msg "@rx (?i)^.*? spammer .*?$" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
@@ -228,7 +228,7 @@ SecRule TX:block_suspicious_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     severity:'CRITICAL',\
     chain,\
-    skipAfter:END_RBL_CHECK"
+    skipAfter:'END-RBL-CHECK'"
     SecRule TX:httpbl_msg "@rx (?i)^.*? suspicious .*?$" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
@@ -251,7 +251,7 @@ SecRule TX:block_harvester_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     severity:'CRITICAL',\
     chain,\
-    skipAfter:END_RBL_CHECK"
+    skipAfter:'END-RBL-CHECK'"
     SecRule TX:httpbl_msg "@rx (?i)^.*? harvester .*?$" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
@@ -275,9 +275,9 @@ SecAction \
     setvar:'ip.previous_rbl_check=1',\
     expirevar:'ip.previous_rbl_check=86400'"
 
-SecMarker END_RBL_LOOKUP
+SecMarker "END-RBL-LOOKUP"
 
-SecMarker END_RBL_CHECK
+SecMarker "END-RBL-CHECK"
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:1,id:910013,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"

--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -70,7 +70,7 @@ SecRule &TX:dos_burst_time_slice "@eq 0" \
     t:none,\
     nolog,\
     chain,\
-    skipAfter:END_DOS_PROTECTION_CHECKS"
+    skipAfter:'END-DOS-PROTECTION-CHECKS'"
     SecRule &TX:dos_counter_threshold "@eq 0" \
         "chain"
         SecRule &TX:dos_block_timeout "@eq 0"
@@ -82,7 +82,7 @@ SecRule &TX:dos_burst_time_slice "@eq 0" \
     t:none,\
     nolog,\
     chain,\
-    skipAfter:END_DOS_PROTECTION_CHECKS"
+    skipAfter:'END-DOS-PROTECTION-CHECKS'"
     SecRule &TX:dos_counter_threshold "@eq 0" \
         "chain"
         SecRule &TX:dos_block_timeout "@eq 0"
@@ -152,7 +152,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-dos',\
-    skipAfter:END_DOS_PROTECTION_CHECKS"
+    skipAfter:'END-DOS-PROTECTION-CHECKS'"
 
 
 #
@@ -294,4 +294,4 @@ SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:2,id:912018,nolog,pass,skipAfter:END-RE
 #
 SecMarker "END-REQUEST-912-DOS-PROTECTION"
 
-SecMarker END_DOS_PROTECTION_CHECKS
+SecMarker "END-DOS-PROTECTION-CHECKS"

--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -70,7 +70,7 @@ SecRule &TX:dos_burst_time_slice "@eq 0" \
     t:none,\
     nolog,\
     chain,\
-    skipAfter:'END-DOS-PROTECTION-CHECKS'"
+    skipAfter:END-DOS-PROTECTION-CHECKS"
     SecRule &TX:dos_counter_threshold "@eq 0" \
         "chain"
         SecRule &TX:dos_block_timeout "@eq 0"
@@ -82,7 +82,7 @@ SecRule &TX:dos_burst_time_slice "@eq 0" \
     t:none,\
     nolog,\
     chain,\
-    skipAfter:'END-DOS-PROTECTION-CHECKS'"
+    skipAfter:END-DOS-PROTECTION-CHECKS"
     SecRule &TX:dos_counter_threshold "@eq 0" \
         "chain"
         SecRule &TX:dos_block_timeout "@eq 0"
@@ -152,7 +152,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-dos',\
-    skipAfter:'END-DOS-PROTECTION-CHECKS'"
+    skipAfter:END-DOS-PROTECTION-CHECKS"
 
 
 #

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -613,7 +613,7 @@ SecRule &REQUEST_HEADERS:Host "@eq 0" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}',\
-    skipAfter:END_HOST_CHECK"
+    skipAfter:'END-HOST-CHECK'"
 
 
 SecRule REQUEST_HEADERS:Host "@rx ^$" \
@@ -634,7 +634,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^$" \
     setvar:'tx.anomaly_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}'"
 
-SecMarker END_HOST_CHECK
+SecMarker "END-HOST-CHECK"
 
 
 #

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -613,7 +613,7 @@ SecRule &REQUEST_HEADERS:Host "@eq 0" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}',\
-    skipAfter:'END-HOST-CHECK'"
+    skipAfter:END-HOST-CHECK"
 
 
 SecRule REQUEST_HEADERS:Host "@rx ^$" \

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -31,7 +31,7 @@ SecRule &TX:'/LEAKAGE\\\/ERRORS/' "@ge 1" \
     tag:'event-correlation',\
     severity:'EMERGENCY',\
     chain,\
-    skipAfter:END_CORRELATION"
+    skipAfter:'END-CORRELATION'"
     SecRule &TX:'/WEB_ATTACK/' "@ge 1" "t:none"
 
 #
@@ -47,7 +47,7 @@ SecRule &TX:'/AVAILABILITY\\\/APP_NOT_AVAIL/' "@ge 1" \
     severity:'ALERT',\
     tag:'event-correlation',\
     chain,\
-    skipAfter:END_CORRELATION"
+    skipAfter:'END-CORRELATION'"
     SecRule &TX:'/WEB_ATTACK/' "@ge 1" "t:none"
 
 SecRule TX:INBOUND_ANOMALY_SCORE "@gt 0" \
@@ -60,7 +60,7 @@ SecRule TX:INBOUND_ANOMALY_SCORE "@gt 0" \
     msg:'Inbound Anomaly Score (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE}): %{tx.inbound_tx_msg}',\
     tag:'event-correlation',\
     chain,\
-    skipAfter:END_CORRELATION"
+    skipAfter:'END-CORRELATION'"
     SecRule TX:INBOUND_ANOMALY_SCORE "@lt %{tx.inbound_anomaly_score_threshold}"
 
 SecRule TX:INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
@@ -83,7 +83,7 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     msg:'Outbound Anomaly Score Exceeded (score %{TX.OUTBOUND_ANOMALY_SCORE}): %{tx.msg}',\
     tag:'event-correlation'"
 
-SecMarker END_CORRELATION
+SecMarker "END-CORRELATION"
 
 
 SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:1,id:980011,nolog,pass,skipAfter:END-RESPONSE-980-CORRELATION"

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -31,7 +31,7 @@ SecRule &TX:'/LEAKAGE\\\/ERRORS/' "@ge 1" \
     tag:'event-correlation',\
     severity:'EMERGENCY',\
     chain,\
-    skipAfter:'END-CORRELATION'"
+    skipAfter:END-CORRELATION"
     SecRule &TX:'/WEB_ATTACK/' "@ge 1" "t:none"
 
 #
@@ -47,7 +47,7 @@ SecRule &TX:'/AVAILABILITY\\\/APP_NOT_AVAIL/' "@ge 1" \
     severity:'ALERT',\
     tag:'event-correlation',\
     chain,\
-    skipAfter:'END-CORRELATION'"
+    skipAfter:END-CORRELATION"
     SecRule &TX:'/WEB_ATTACK/' "@ge 1" "t:none"
 
 SecRule TX:INBOUND_ANOMALY_SCORE "@gt 0" \
@@ -60,7 +60,7 @@ SecRule TX:INBOUND_ANOMALY_SCORE "@gt 0" \
     msg:'Inbound Anomaly Score (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE}): %{tx.inbound_tx_msg}',\
     tag:'event-correlation',\
     chain,\
-    skipAfter:'END-CORRELATION'"
+    skipAfter:END-CORRELATION"
     SecRule TX:INBOUND_ANOMALY_SCORE "@lt %{tx.inbound_anomaly_score_threshold}"
 
 SecRule TX:INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \


### PR DESCRIPTION
This is more cleaning up:

- fixing one typo
- changed underscore to dash in all SecMarker and skipAfter (from the contributing guidelines)

Part of #808. 