### PR TITLE
Make travis tests fail if Apache can't load rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ python:
   - 2.7
 before_install:
   - docker pull owasp/modsecurity-crs
-  - docker run -ti -e PARANOIA=5 -d --rm -p 80:80 -v /var/log/httpd:/var/log/httpd/ owasp/modsecurity-crs
+  - docker run -ti -e PARANOIA=5 -d --rm -p 80:80 -v $(pwd)/rules:/etc/httpd/modsecurity.d/owasp-crs/rules/ -v /var/log/httpd:/var/log/httpd/ owasp/modsecurity-crs
 install: 
   - pip install -r ./util/integration/requirements.txt
   - pip install -r ./util/regression-tests/requirements.txt
 script:
+  - docker ps | grep -q modsecurity-crs || exit 1
   - py.test -vs ./util/integration/format_tests.py
   - py.test -vs util/regression-tests/CRS_Tests.py --rule=util/regression-tests/tests/test.yaml
   - py.test -vs util/regression-tests/CRS_Tests.py --ruledir=util/regression-tests/tests/REQUEST-911-METHOD-ENFORCEMENT


### PR DESCRIPTION
I've added the 'docker ps' to the script so tests don't execute if apache isn't up.