### PR TITLE
Typo in comment

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -491,7 +491,7 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
 
 
 #
-# Disallow use of full-width unicode as decoding evasions my be possible.
+# Disallow use of full-width unicode as decoding evasions may be possible.
 #
 # -=[ Rule Logic ]=-
 # This rule looks for full-width encoding by looking for %u followed by 2 'f'


### PR DESCRIPTION
This is a port of #979 that was wrongly applied to `3.0/dev` first.

@Franbuehler, could you check and merge this please.