### PR TITLE
Rule 921160, removed unnecessary space match 

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -217,9 +217,9 @@ SecRule ARGS_NAMES "(\n|\r)" \
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}"
 
 
-SecRule ARGS_NAMES|ARGS|XML:/* "(?:\n|\r)+(?:location|refresh|(?:set-)?cookie|(X-)?(?:forwarded-(?:for|host|server)|host|via|remote-ip|remote-addr|originating-IP))\s*:" \
+SecRule ARGS_GET_NAMES|ARGS_GET "(?:\n|\r)+(?:\s|location|refresh|(?:set-)?cookie|(X-)?(?:forwarded-(?:for|host|server)|host|via|remote-ip|remote-addr|originating-IP))\s*:" \
 	"msg:'HTTP Header Injection Attack via payload (CR/LF and header-name detected)',\
-	phase:request,\
+	phase:1,\
 	id:921160,\
 	rev:'1',\
 	ver:'OWASP_CRS/3.0.0',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -217,7 +217,7 @@ SecRule ARGS_NAMES "(\n|\r)" \
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}"
 
 
-SecRule ARGS_NAMES|ARGS|XML:/* "(?:\n|\r)+(?:\s+|location|refresh|(?:set-)?cookie|(X-)?(?:forwarded-(?:for|host|server)|host|via|remote-ip|remote-addr|originating-IP))\s*:" \
+SecRule ARGS_NAMES|ARGS|XML:/* "(?:\n|\r)+(?:location|refresh|(?:set-)?cookie|(X-)?(?:forwarded-(?:for|host|server)|host|via|remote-ip|remote-addr|originating-IP))\s*:" \
 	"msg:'HTTP Header Injection Attack via payload (CR/LF and header-name detected)',\
 	phase:request,\
 	id:921160,\


### PR DESCRIPTION
Removed unnecessary space match that caused catastrophic backtracking ( https://www.regular-expressions.info/catastrophic.html ).

This fixes issue https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/999 .

I believe the first \s+ can be removed, because I cannot think of why we should be concerned with lines starting with a space followed by a colon.