### PR TITLE
Rule 921160, fixed runaway regex, v3.1/dev

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -205,9 +205,9 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}'"
 
 
-SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?:\n|\r)+(?:\s+|location|refresh|(?:set-)?cookie|(?:x-)?(?:forwarded-(?:for|host|server)|host|via|remote-ip|remote-addr|originating-IP))\s*:" \
+SecRule ARGS_GET_NAMES|ARGS_GET "@rx (?:\n|\r)+(?:\s|location|refresh|(?:set-)?cookie|(?:x-)?(?:forwarded-(?:for|host|server)|host|via|remote-ip|remote-addr|originating-IP))\s*:" \
     "id:921160,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:urlDecodeUni,t:htmlEntityDecode,t:lowercase,\

--- a/util/regression-tests/tests/REQUEST-921-PROTOCOL-ATTACK/921160.yaml
+++ b/util/regression-tests/tests/REQUEST-921-PROTOCOL-ATTACK/921160.yaml
@@ -7,6 +7,38 @@
   tests:
     -
       test_title: 921160-1
+      desc: "HTTP Header Injection Attack via payload: w/header, invalid line break, newlines after key"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  Host: "localhost"
+                  User-agent: "user agent"
+              uri: "/script_rule921160.jsp?variableX=bar&variable2=Y&%0d%0Remote-addr%0d%0d%0d:%20foo.bar.com"
+            output:
+              log_contains: id "921160"
+    -
+      test_title: 921160-2
+      desc: "HTTP Header Injection Attack via payload: w/header, correct line break, newlines after key"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  Host: "localhost"
+                  User-agent: "user agent"
+              uri: "/script_rule921160.jsp?variableX=bar&variable2=Y&%0d%0aRemote-addr%0d%0d%0d:%20foo.bar.com"
+            output:
+              log_contains: id "921160"
+    -
+      test_title: 921160-3
       desc: "HTTP Header Injection Attack via payload: w/header"
       stages:
         -
@@ -18,8 +50,38 @@
               headers:
                   Host: "localhost"
                   User-agent: "user agent"
-              # This trips 921160
-              #uri: "/script_rule921160.jsp?variableX=bar&variable2=Y&%0d%0X-Forwarded-Host:%20foo.bar.com
-              uri: "/script_rule921160.jsp?variableX=bar&variable2=Y&%0d%0Remote-addr%0d%0d%0d:%20foo.bar.com"
+              uri: "/script_rule921160.jsp?variableX=bar&variable2=Y&%0d%0aRemote-addr:%20foo.bar.com"
+            output:
+              log_contains: id "921160"
+    -
+      test_title: 921160-4
+      desc: "HTTP Header Injection Attack via payload: w/header, attack explicitly in value rather than key"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  Host: "localhost"
+                  User-agent: "user agent"
+              uri: "/script_rule921160.jsp?variableX=bar&variable2=%0d%0aRemote-addr:%20foo.bar.com"
+            output:
+              log_contains: id "921160"
+    -
+      test_title: 921160-5
+      desc: "HTTP Header Injection Attack via payload: w/header, attack explicitly in key rather than value"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  Host: "localhost"
+                  User-agent: "user agent"
+              uri: "/script_rule921160.jsp?variableX=bar&%0d%0aRemote-addr:%20foo.bar.com=Y"
             output:
               log_contains: id "921160"


### PR DESCRIPTION
Same as https://github.com/SpiderLabs/owasp-modsecurity-crs/pull/1000 , but based on v3.1/dev.

This fixes issue #999 .

Fixed space matching that caused catastrophic backtracking ( https://www.regular-expressions.info/catastrophic.html ).

Changing \s+ to just \s, as the following \s* will match the same thing, but without the catastrophic backtracking. Actually, I think the \s could be removed all together, because I cannot think of why we should be concerned with lines starting with a space followed by a colon. However, leaving it as per @dune73 's suggestion, as we don't understand why it's there in the first place.

Here's a good illustration of the [original regex](https://regexper.com/#(%3F%3A%5Cn%7C%5Cr)%2B(%3F%3A%5Cs%2B%7Clocation%7Crefresh%7C(%3F%3Aset-)%3Fcookie%7C(X-)%3F(%3F%3Aforwarded-(%3F%3Afor%7Chost%7Cserver)%7Chost%7Cvia%7Cremote-ip%7Cremote-addr%7Coriginating-IP))%5Cs*%3A) and the [updated regex](https://regexper.com/#(%3F%3A%5Cn%7C%5Cr)%2B(%3F%3A%5Cs%7Clocation%7Crefresh%7C(%3F%3Aset-)%3Fcookie%7C(X-)%3F(%3F%3Aforwarded-(%3F%3Afor%7Chost%7Cserver)%7Chost%7Cvia%7Cremote-ip%7Cremote-addr%7Coriginating-IP))%5Cs*%3A)

Updated the regression tests. I believe the original regression test had a bug, because it has %0d%0R, which is not even valid URL encoding. I think it was meant to say %0d%0a, which means \r\n. Leaving the old one in place just in case it was actually on purpose, and adding new ones with what I think was meant.
