### PR TITLE
942120: fix 'superlike' FP

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -540,7 +540,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (^\s*[\"'`;]+|[\"'`]+\s*$)" \
 # to the Regexp::Assemble output:
 #   (?i:ASSEMBLE_OUTPUT)
 #
-SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:r(?:like(?:\s+binary)?|egexp\s+binary)|(?:^|\W)in[+\s]*\([\s\d\"]+[^()]*\)|\b(?:r(?:egexp|like)|isnull|xor)\b|<(?:>(?:\s+binary)?|=>?|<)|not\s+between\s+0\s+and|(?:like|is)\s+null|>[=>]|\|\||!=|&&))" \
+SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:(?:^|\W)in[+\s]*\([\s\d\"]+[^()]*\)|\b(?:r(?:egexp|like)|isnull|xor)\b|<(?:>(?:\s+binary)?|=>?|<)|r(?:egexp|like)\s+binary|not\s+between\s+0\s+and|(?:like|is)\s+null|>[=>]|\|\||!=|&&))" \
     "id:942120,\
     phase:2,\
     block,\

--- a/util/regexp-assemble/regexp-942120.data
+++ b/util/regexp-assemble/regexp-942120.data
@@ -12,7 +12,6 @@
 regexp\s+binary
 \bisnull\b
 \brlike\b
-rlike
 rlike\s+binary
 not\s+between\s+0\s+and
 is\s+null


### PR DESCRIPTION
Rule 942120 triggers on the use of the word `superlike` (and other words containing the substring `rlike`) in paranoia level 2.

I think it's safe to trigger on `\brlike\b` instead of `rlike`.

In fact `\brlike\b` is already in `regexp-942120.data`, so I just removed the bare `rlike`.

I verified that the following strings are still triggering after the change:

```
foo rlike
rlike foo
foo rlike bar
```