### PR TITLE
Fix copyright2

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,8 @@
+Project Stewardship by Trustwave
+--------------------------------
+Over many years, Trustwave Holdings Inc. has contributed countless hours 
+to this project through their SpiderLabs security team.
+
 ## Project Lead:
 
 - [Chaim Sanders](https://github.com/csanders-git)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,4 +46,9 @@
 - [Zou Guangxian](https://github.com/zouguangxian)
 - [4ft35t](https://github.com/4ft35t)
 
+## Organizational Contributors:
+
+- Fastly
+- Trustwave
+
 *Note: Some contributors may have been working on behalf of organizations when they submitted code, As a result, in many cases these corperations control the copyright of the submitted work and it does not soley belong to the contributor listed.*

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -45,3 +45,5 @@
 - Josh Zlatin
 - [Zou Guangxian](https://github.com/zouguangxian)
 - [4ft35t](https://github.com/4ft35t)
+
+*Note: Some contributors may have been working on behalf of organizations when they submitted code, As a result, in many cases these corperations control the copyright of the submitted work and it does not soley belong to the contributor listed.*

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The OWASP ModSecurity Core Rule Set (CRS) is a set of generic attack detection r
 
 ## CRS Resources
 
-Please see the [OWASP ModSecurity Core Rule Set page](https://modsecurity.org/crs/) to get introduced to the CRS and view resources on installation, configuration, and working with the CRS.
+Please see the [OWASP ModSecurity Core Rule Set page](https://coreruleset.org/) to get introduced to the CRS and view resources on installation, configuration, and working with the CRS.
 
 ## Contributing to the CRS
 
@@ -25,3 +25,4 @@ Copyright (c) 2006-2018 Trustwave and contributors. All rights reserved.
 
 The OWASP ModSecurity Core Rule Set is distributed under Apache Software License (ASL) version 2. Please see the enclosed LICENSE file for full details.
 
+Copyright (c) 2006-2018 OWASP Core Rule Set [Contributors](CONTRIBUTORS.md). All rights reserved.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ We strive to make the OWASP ModSecurity CRS accessible to a wide audience of beg
 
 ## License
 
-Copyright (c) 2006-2018 Trustwave and contributors. All rights reserved.
-
 The OWASP ModSecurity Core Rule Set is distributed under Apache Software License (ASL) version 2. Please see the enclosed LICENSE file for full details.
 
 Copyright (c) 2006-2018 OWASP Core Rule Set [Contributors](CONTRIBUTORS.md). All rights reserved.


### PR DESCRIPTION
The copyright notice was not wrong, however it may lead contributors to assume that all CRS contributors were required, and had, assigned copyright to Trustwave. In reality, Trustwave maintains the copyright for works completed by employees while in their employment, in the same way that several other organizations hold copyright on CRS content. At the request of the organization we are willing to include their name in the contributors files if they can indicate specific commits their employees contributed.. 