### PR TITLE
Nextcloud/Owncloud patch for binary parsing via PUT

### DIFF
--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -72,7 +72,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
 
 # Skip PUT parsing for invalid encoding / protocol violations in binary files.
 
-SecRule REQUEST_METHOD "@pm PUT" \
+SecRule REQUEST_METHOD "@streq PUT" \
     "id:9003105,\
     phase:2,\
     t:none,\

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -70,6 +70,19 @@ SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
     ctl:ruleRemoveById=941000-942999,\
     ctl:ruleRemoveById=920420"
 
+# Skip PUT parsing for invalid encoding / protocol violations in binary files.
+
+SecRule REQUEST_METHOD "@pm PUT" \
+    "id:9003105,\
+    phase:2,\
+    t:none,\
+    nolog,\
+    pass,\
+    chain"
+    SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
+        "t:none,\
+        ctl:ruleRemoveById=920000-920999,\
+        ctl:ruleRemoveById=921150"
 
 # Allow the data type 'text/vcard'
 


### PR DESCRIPTION
tested with nextcloud 13.0 and owncloud 10.0.7

`````
Message: Warning. Found 3 byte(s) in ARGS:\xfd\xf1\xb5I\x82<\xc7\n\xb8:\xf2\xc6\x80A\x82y\xa9\t5\xb1\x15\x8a\xba\x92\xd4\xb0e\xa9\xa4h\x00`\x96c\xc1kE\xccT\x02\x02\x83\xaa\bb0\xa2\x92\x87\x07\x89\x1a\x85 outside range: 1-255. [file "/opt/rh/httpd24/root/etc/httpd/modsecurity.d/activated_rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "585"] [id "920270"] [rev "2"] [msg "Invalid character in request (null character)"] [data "ARGS:\x5cxfd\x5cxf1\x5cxb5I\x5cx82<\x5cxc7\x5cn\x5cxb8:\x5cxf2\x5cxc6\x5cx80A\x5cx82y\x5cxa9\x5ct5\x5cxb1\x5cx15\x5cx8a\x5cxba\x5cx92\x5cxd4\x5cxb0e\x5cxa9\x5cxa4h\x5cx00`\x5cx96c\x5cxc1kE\x5cxccT\x5cx02\x5cx02\x5cx83\x5cxaa\x5cbb0\x5cxa2\x5cx92\x5cx87\x5cx07\x5cx89\x5cx1a\x5cx85=\x05\x82Z\x1b^ \x93ZI\x8d\xed\x09\xb9\xdf\x5c\xf2a\x0cE{\xdd]\xf5\x1es\xc9mv6\x9d$\x03\xbe\x94=#\xfc\x05\xdf9\x86\x8c\xa3<\x84-\xd1\xc1D\x9e\xa8]\x93\x07^\x7f\x0b?\x8d\xe7\xed\x9f\x83l\xc8\xe1\xf3\xe6\x1f\xf9\x86oG\xec\xc7\x7f9\..."] [severity "CRITICAL"] [ver "OWASP_CRS/3.0.0"] [tag "application-multi"] [tag "languag
Message: Warning. Found 2 byte(s) in ARGS_NAMES:\x1f\x8b\b\b\xc7\x82\x04T\x00\x03xss.txt\x00\xcd\x94\xcf\n\xc20\x0c\xc6\xef\x82\xef\x10\xbc\x0c\x06}\x81\xed\xe8e\xe0E\xf0\xe0\xae]\x97i\xa5v\xb2f\xc8\xde\xdei\x1dNW\xc1Q\xff\x91\xdb\x97 outside range: 1-255. [file "/opt/rh/httpd24/root/etc/httpd/modsecurity.d/activated_rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "585"] [id "920270"] [rev "2"] [msg "Invalid character in request (null character)"] [data "ARGS_NAMES:\x5cx1f\x5cx8b\x5cb\x5cb\x5cxc7\x5cx82\x5cx04T\x5cx00\x5cx03xss.txt\x5cx00\x5cxcd\x5cx94\x5cxcf\x5cn\x5cxc20\x5cx0c\x5cxc6\x5cxef\x5cx82\x5cxef\x5cx10\x5cxbc\x5cx0c\x5cx06}\x5cx81\x5cxed\x5cxe8e\x5cxe0E\x5cxf0\x5cxe0\x5cxae]\x5cx97i\x5cxa5v\x5cxb2f\x5cxc8\x5cxde\x5cxdei\x5cx1dNW\x5cxc1Q\x5cxff\x5cx91\x5cxdb\x5cx97=\x1f\x8b\x08\x08\xc7\x82\x04T\x00\x03xss.txt\x00\xcd\x94\xcf\x0a\xc20\x0c\xc6\xef\x82\xef\x10\xbc\x0c\x06}\x81\xed\xe8e\xe0E\xf0\xe0\xae]\x97i\xa5v\xb2f\xc8\xde\xdei\x1dNW\xc1Q\xff\x..."] [severity "CRITICAL"] [ver "OWASP_CRS/3.0.0"] [tag "ap
Message: Warning. Found 1 byte(s) in ARGS_NAMES:\xfd\xf1\xb5I\x82<\xc7\n\xb8:\xf2\xc6\x80A\x82y\xa9\t5\xb1\x15\x8a\xba\x92\xd4\xb0e\xa9\xa4h\x00`\x96c\xc1kE\xccT\x02\x02\x83\xaa\bb0\xa2\x92\x87\x07\x89\x1a\x85 outside range: 1-255. [file "/opt/rh/httpd24/root/etc/httpd/modsecurity.d/activated_rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "585"] [id "920270"] [rev "2"] [msg "Invalid character in request (null character)"] [data "ARGS_NAMES:\x5cxfd\x5cxf1\x5cxb5I\x5cx82<\x5cxc7\x5cn\x5cxb8:\x5cxf2\x5cxc6\x5cx80A\x5cx82y\x5cxa9\x5ct5\x5cxb1\x5cx15\x5cx8a\x5cxba\x5cx92\x5cxd4\x5cxb0e\x5cxa9\x5cxa4h\x5cx00`\x5cx96c\x5cxc1kE\x5cxccT\x5cx02\x5cx02\x5cx83\x5cxaa\x5cbb0\x5cxa2\x5cx92\x5cx87\x5cx07\x5cx89\x5cx1a\x5cx85=\xfd\xf1\xb5I\x82<\xc7\x0a\xb8:\xf2\xc6\x80A\x82y\xa9\x095\xb1\x15\x8a\xba\x92\xd4\xb0e\xa9\xa4h\x00`\x96c\xc1kE\xccT\x02\x02\x83\xaa\x08b0\xa2\x92\x87\x07\x89\x1a\x85"] [severity "CRITICAL"] [ver "OWASP_CRS/3.0.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protoc
Message: Warning. Pattern match "[\\n\\r]" at ARGS_NAMES:\x1f\x8b\b\b\xc7\x82\x04T\x00\x03xss.txt\x00\xcd\x94\xcf\n\xc20\x0c\xc6\xef\x82\xef\x10\xbc\x0c\x06}\x81\xed\xe8e\xe0E\xf0\xe0\xae]\x97i\xa5v\xb2f\xc8\xde\xdei\x1dNW\xc1Q\xff\x91\xdb\x97. [file "/opt/rh/httpd24/root/etc/httpd/modsecurity.d/activated_rules/REQUEST-921-PROTOCOL-ATTACK.conf"] [line "205"] [id "921150"] [rev "1"] [msg "HTTP Header Injection Attack via payload (CR/LF detected)"] [data "Matched Data: \x0a found within ARGS_NAMES:\x5cx1f\x5cx8b\x5cb\x5cb\x5cxc7\x5cx82\x5cx04T\x5cx00\x5cx03xss.txt\x5cx00\x5cxcd\x5cx94\x5cxcf\x5cn\x5cxc20\x5cx0c\x5cxc6\x5cxef\x5cx82\x5cxef\x5cx10\x5cxbc\x5cx0c\x5cx06}\x5cx81\x5cxed\x5cxe8e\x5cxe0E\x5cxf0\x5cxe0\x5cxae]\x5cx97i\x5cxa5v\x5cxb2f\x5cxc8\x5cxde\x5cxdei\x5cx1dNW\x5cxc1Q\x5cxff\x5cx91\x5cxdb\x5cx97: \x1f\x8b\x08\x08\xc7\x82\x04T\x00\x03xss.txt\x00\xcd\x94\xcf\x0a\xc20\x0c\xc6\xef\x82\xef\x10\xbc\x0c\x06}\x81\xed\xe8e\xe0E\xf0\xe0\xae]\x97i\xa5v\x..."] [severity "CRITICAL"] [ver "OWASP_CRS/3.0.0"] 
Message: Warning. Pattern match "[\\n\\r]" at ARGS_NAMES:\xfd\xf1\xb5I\x82<\xc7\n\xb8:\xf2\xc6\x80A\x82y\xa9\t5\xb1\x15\x8a\xba\x92\xd4\xb0e\xa9\xa4h\x00`\x96c\xc1kE\xccT\x02\x02\x83\xaa\bb0\xa2\x92\x87\x07\x89\x1a\x85. [file "/opt/rh/httpd24/root/etc/httpd/modsecurity.d/activated_rules/REQUEST-921-PROTOCOL-ATTACK.conf"] [line "205"] [id "921150"] [rev "1"] [msg "HTTP Header Injection Attack via payload (CR/LF detected)"] [data "Matched Data: \x0a found within ARGS_NAMES:\x5cxfd\x5cxf1\x5cxb5I\x5cx82<\x5cxc7\x5cn\x5cxb8:\x5cxf2\x5cxc6\x5cx80A\x5cx82y\x5cxa9\x5ct5\x5cxb1\x5cx15\x5cx8a\x5cxba\x5cx92\x5cxd4\x5cxb0e\x5cxa9\x5cxa4h\x5cx00`\x5cx96c\x5cxc1kE\x5cxccT\x5cx02\x5cx02\x5cx83\x5cxaa\x5cbb0\x5cxa2\x5cx92\x5cx87\x5cx07\x5cx89\x5cx1a\x5cx85: \xfd\xf1\xb5I\x82<\xc7\x0a\xb8:\xf2\xc6\x80A\x82y\xa9\x095\xb1\x15\x8a\xba\x92\xd4\xb0e\xa9\xa4h\x00`\x96c\xc1kE\xccT\x02\x02\x83\xaa\x08b0\xa2\x92\x87\x07\x89\x1a\x85"] [severity "CRITICAL"] [ver "OWASP_CRS/3.0.0"] [tag "application-multi"] [tag "language-multi"]
`````