### PR TITLE
Set `monitoring_paranoia_level` to `paranoia_level` by default.

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -99,7 +99,7 @@ SecRule &TX:monitoring_paranoia_level "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    setvar:'tx.paranoia_level=%{TX.PARANOIA_LEVEL}'"
+    setvar:'tx.monitoring_paranoia_level=%{TX.PARANOIA_LEVEL}'"
 
 # Default Sampling Percentage (rule 900400 in setup.conf)
 SecRule &TX:sampling_percentage "@eq 0" \


### PR DESCRIPTION
It appears to me like a copy&paste error that `paranoia_level` is assigned to itself instead of being assigned to the `monitoring_paranoia_level`. Especially, because the rule is supposed to set the default `monitoring_paranoia_level`.