### PR TITLE
Remove duplicate apostrophe at the end.

### DIFF
--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -70,7 +70,7 @@ SecRule TX:INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     t:none,\
     log,\
     noauditlog,\
-    msg:'Inbound Anomaly Score Exceeded (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): %{tx.inbound_tx_msg}; individual paranoia level scores: %{TX.ANOMALY_SCORE_PL1}, %{TX.ANOMALY_SCORE_PL2}, %{TX.ANOMALY_SCORE_PL3}, %{TX.ANOMALY_SCORE_PL4}'',\
+    msg:'Inbound Anomaly Score Exceeded (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): %{tx.inbound_tx_msg}; individual paranoia level scores: %{TX.ANOMALY_SCORE_PL1}, %{TX.ANOMALY_SCORE_PL2}, %{TX.ANOMALY_SCORE_PL3}, %{TX.ANOMALY_SCORE_PL4}',\
     tag:'event-correlation'"
 
 SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \


### PR DESCRIPTION
This actually caused apache to exit with the error message:
```
AH00526: Syntax error on line 74 of /apache/conf/crs/rules/RESPONSE-980-CORRELATION.conf:
Error parsing actions: Unknown action: '
```

It was introduced in commit 65e7ccb.