### PR TITLE
Allow paranoia level to be 0.

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -86,12 +86,12 @@ SecRule &TX:outbound_anomaly_score_threshold "@eq 0" \
     setvar:'tx.outbound_anomaly_score_threshold=4'"
 
 # Default Paranoia Level (rule 900000 in setup.conf)
-SecRule &TX:paranoia_level "@eq 0" \
-    "id:901120,\
-    phase:1,\
-    pass,\
-    nolog,\
-    setvar:'tx.paranoia_level=1'"
+#SecRule &TX:paranoia_level "@eq 0" \
+#    "id:901120,\
+#    phase:1,\
+#    pass,\
+#    nolog,\
+#    setvar:'tx.paranoia_level=0'"
 
 # Default Monitoring Paranoia Level (rule 900000 in setup.conf)
 SecRule &TX:monitoring_paranoia_level "@eq 0" \

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -86,12 +86,12 @@ SecRule &TX:outbound_anomaly_score_threshold "@eq 0" \
     setvar:'tx.outbound_anomaly_score_threshold=4'"
 
 # Default Paranoia Level (rule 900000 in setup.conf)
-#SecRule &TX:paranoia_level "@eq 0" \
-#    "id:901120,\
-#    phase:1,\
-#    pass,\
-#    nolog,\
-#    setvar:'tx.paranoia_level=0'"
+SecRule &TX:paranoia_level "@eq 0" \
+    "id:901120,\
+    phase:1,\
+    pass,\
+    nolog,\
+    setvar:'tx.paranoia_level=1'"
 
 # Default Monitoring Paranoia Level (rule 900000 in setup.conf)
 SecRule &TX:monitoring_paranoia_level "@eq 0" \

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -15,7 +15,7 @@
 
 # NOTE: tx.anomaly_score should not be set initially, but masking would lead to difficult bugs.
 # So we add to it.
-SecAction \
+SecRule TX:PARANOIA_LEVEL "@ge 1" \
     "id:949060,\
     phase:2,\
     pass,\

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -25,7 +25,7 @@
 
 # NOTE: tx.anomaly_score should not be set initially, but masking would lead to difficult bugs.
 # So we add to it.
-SecAction \
+SecRule TX:PARANOIA_LEVEL "@ge 1" \
     "id:959060,\
     phase:2,\
     pass,\


### PR DESCRIPTION
This allows the Paranoia Level to be set to 0.

Paranoia Level 0 can be used in combination with a Monitoring Paranoia Level of 1 or higher when the CRS is first added to ModSecurity.