### PR TITLE
Adding logging for monitored PLs

### DIFF
--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -50,18 +50,30 @@ SecRule &TX:'/AVAILABILITY\\\/APP_NOT_AVAIL/' "@ge 1" \
     skipAfter:END-CORRELATION"
     SecRule &TX:'/WEB_ATTACK/' "@ge 1" "t:none"
 
-SecRule TX:INBOUND_ANOMALY_SCORE "@gt 0" \
+# Creating a total sum of all triggered inbound rules, including the ones only being monitored
+SecAction \
+    "id:980115,\
+    phase:5,\
+    pass,\
+    t:none,\
+    nolog,\
+    noauditlog,\
+    setvar:'tx.monitor_anomaly_score=%{tx.anomaly_score_pl1}',\
+    setvar:'tx.monitor_anomaly_score=+%{tx.anomaly_score_pl2}',\
+    setvar:'tx.monitor_anomaly_score=+%{tx.anomaly_score_pl3}',\
+    setvar:'tx.monitor_anomaly_score=+%{tx.anomaly_score_pl4}'"
+    
+SecRule TX:INBOUND_ANOMALY_SCORE "@lt %{tx.inbound_anomaly_score_threshold}" \
     "id:980120,\
     phase:5,\
     pass,\
     t:none,\
     log,\
     noauditlog,\
-    msg:'Inbound Anomaly Score (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE}): %{tx.inbound_tx_msg}; individual paranoia level scores: %{TX.ANOMALY_SCORE_PL1}, %{TX.ANOMALY_SCORE_PL2}, %{TX.ANOMALY_SCORE_PL3}, %{TX.ANOMALY_SCORE_PL4}',\
+    msg:'Inbound Anomaly Score (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): %{tx.inbound_tx_msg}; individual paranoia level scores: %{TX.ANOMALY_SCORE_PL1}, %{TX.ANOMALY_SCORE_PL2}, %{TX.ANOMALY_SCORE_PL3}, %{TX.ANOMALY_SCORE_PL4}',\
     tag:'event-correlation',\
-    chain,\
-    skipAfter:END-CORRELATION"
-    SecRule TX:INBOUND_ANOMALY_SCORE "@lt %{tx.inbound_anomaly_score_threshold}"
+    chain"
+    SecRule TX:MONITOR_ANOMALY_SCORE "@gt 1"
 
 SecRule TX:INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     "id:980130,\
@@ -82,6 +94,31 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     noauditlog,\
     msg:'Outbound Anomaly Score Exceeded (score %{TX.OUTBOUND_ANOMALY_SCORE}): %{tx.msg}; individual paranoia level scores: %{TX.OUTBOUND_ANOMALY_SCORE_PL1}, %{TX.OUTBOUND_ANOMALY_SCORE_PL2}, %{TX.OUTBOUND_ANOMALY_SCORE_PL3}, %{TX.OUTBOUND_ANOMALY_SCORE_PL4}',\
     tag:'event-correlation'"
+
+# Creating a total sum of all triggered outbound rules, including the ones only being monitored
+SecAction \
+    "id:980145,\
+    phase:5,\
+    pass,\
+    t:none,\
+    nolog,\
+    noauditlog,\
+    setvar:'tx.monitor_anomaly_score=%{tx.outbound_anomaly_score_pl1}',\
+    setvar:'tx.monitor_anomaly_score=+%{tx.outbound_anomaly_score_pl2}',\
+    setvar:'tx.monitor_anomaly_score=+%{tx.outbound_anomaly_score_pl3}',\
+    setvar:'tx.monitor_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
+
+SecRule TX:OUTBOUND_ANOMALY_SCORE "@lt %{tx.outbound_anomaly_score_threshold}" \
+    "id:980150,\
+    phase:5,\
+    pass,\
+    t:none,\
+    log,\
+    noauditlog,\
+    msg:'Outbound Anomaly Score (Total Outbound Score: %{TX.OUTBOUND_ANOMALY_SCORE}): %{tx.msg}; individual paranoia level scores: %{TX.OUTBOUND_ANOMALY_SCORE_PL1}, %{TX.OUTBOUND_ANOMALY_SCORE_PL2}, %{TX.OUTBOUND_ANOMALY_SCORE_PL3}, %{TX.OUTBOUND_ANOMALY_SCORE_PL4}',\
+    tag:'event-correlation',\
+    chain"
+    SecRule TX:MONITOR_ANOMALY_SCORE "@gt 1"
 
 SecMarker "END-CORRELATION"
 


### PR DESCRIPTION
The Total Score Message is now logged, even if the Anomaly Score is 0, so long as any Paranoia Level that is being monitored has produced a higher score.