### PR TITLE
2 missing important errors in php-errors.data

### DIFF
--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -215,4 +215,6 @@ You MUST load PDO before loading any PDO drivers
 [] operator not supported for strings
 and must therefore be declared abstract or implement the remaining methods
 namespace must not match the enclosing schema 'targetNamespace'
-requires PDO API version 
+requires PDO API version
+PDO Connection Error: SQLSTATE[HY000]
+(HY000/2002): Connection refused 

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -215,6 +215,6 @@ You MUST load PDO before loading any PDO drivers
 [] operator not supported for strings
 and must therefore be declared abstract or implement the remaining methods
 namespace must not match the enclosing schema 'targetNamespace'
-requires PDO API version
-PDO Connection Error: SQLSTATE[HY000]
-(HY000/2002): Connection refused 
+requires PDO API version 
+PDO Connection Error: SQLSTATE[HY000] 
+(HY000/2002): Connection refused  


### PR DESCRIPTION
added 2 important php sql connection errors for the outbound.
we had the situation that a mysql server crashed and modsecurity didn't detect the mysqli/pdo default connection error message.