### PR TITLE
bring back PHP closing tag '?>' detection

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -38,6 +38,11 @@ SecRule TX:PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,skipAfter:END-RE
 # Also detects "[php]", "[/php]" and "[\php]" tags used by some applications
 # to indicate PHP dynamic content.
 #
+# Previously, this rule also checked for the PHP close tag '?>', but
+# this resulted in false positives which were difficult to prevent.
+# Therefore, that pattern is now checked by rule 933190 in paranoia levels
+# 3 or higher.
+#
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:<\?(?!xml\s)|<\?php|\[(?:/|\\\\)?php\])" \
     "id:933100,\
     phase:2,\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -629,6 +629,38 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
 
 
+# [ PHP Closing Tag Found ]
+#
+# http://www.php.net/manual/en/language.basic-syntax.phptags.php
+#
+# This check was extracted from 933100 (paranoia level 1), since the
+# checked sequence '?>' commonly causes false positives.
+# See issue #654 for discussion.
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pm ?>" \
+    "msg:'PHP Injection Attack: PHP Closing Tag Found',\
+    phase:request,\
+    ver:'OWASP_CRS/3.0.0',\
+    t:none,t:urlDecodeUni,\
+    ctl:auditLogParts=+E,\
+    block,\
+    capture,\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    id:933101,\
+    severity:'CRITICAL',\
+    tag:'application-multi',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-injection-php',\
+    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
+    tag:'OWASP_TOP_10/A1',\
+    tag:'paranoia-level/3',\
+    setvar:'tx.msg=%{rule.msg}',\
+    setvar:tx.php_injection_score=+%{tx.critical_anomaly_score},\
+    setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+    setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}"
+
+
 SecRule TX:PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 SecRule TX:PARANOIA_LEVEL "@lt 4" "id:933018,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -651,7 +651,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     block,\
     capture,\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    id:933101,\
+    id:933190,\
     severity:'CRITICAL',\
     tag:'application-multi',\
     tag:'language-php',\


### PR DESCRIPTION
Resolves #766.

We removed `?>` detection in 3.0.1 because of FP reports, which couldn't be resolved in a reasonable way. Now, it's back as a separate rule in paranoia level 3.