### PR TITLE
WordPress: exclude Add Media, Insert Media, Insert into page

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -514,6 +514,21 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
             "t:none,\
             ctl:ruleRemoveTargetById=931130;ARGS:menu-item[-1][menu-item-url]"
 
+# Editor: Add Media, Insert Media, Insert into page
+SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
+    "id:9002770,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule ARGS:action "@streq send-attachment-to-editor" \
+        "t:none,\
+        chain"
+        SecRule &ARGS:action "@eq 1" \
+            "t:none,\
+            ctl:ruleRemoveTargetByTag=CRS;ARGS:html"
+
 
 #
 # [ Options and Settings ]


### PR DESCRIPTION
Resolve a false positive in the WordPress editor when doing Add Media -> Insert Media -> Insert into page.