### PR TITLE
Improve request Content-Type checks

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -976,7 +976,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 #
 # Restrict which content-types we accept.
 #
-SecRule REQUEST_METHOD "!@rx ^(?:GET|HEAD|PROPFIND|OPTIONS)$" \
+SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     "id:920420,\
     phase:2,\
     block,\
@@ -995,16 +995,14 @@ SecRule REQUEST_METHOD "!@rx ^(?:GET|HEAD|PROPFIND|OPTIONS)$" \
     rev:2,\
     ver:'OWASP_CRS/3.0.0',\
     severity:'CRITICAL',\
+    capture,\
     chain"
-    SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
-        "capture,\
-        chain"
-        SecRule TX:0 "!@rx ^%{tx.allowed_request_content_type}$" \
-            "t:none,\
-            ctl:forceRequestBodyVariable=On,\
-            setvar:'tx.msg=%{rule.msg}',\
-            setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
-            setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/CONTENT_TYPE_NOT_ALLOWED-%{matched_var_name}=%{matched_var}'"
+    SecRule TX:0 "!@rx ^%{tx.allowed_request_content_type}$" \
+        "t:none,\
+        ctl:forceRequestBodyVariable=On,\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
+        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/CONTENT_TYPE_NOT_ALLOWED-%{matched_var_name}=%{matched_var}'"
 
 #
 # Restrict protocol versions.

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -988,7 +988,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - multipart/form-data; boundary=----WebKitFormBoundary12345
 #
 SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w\d/\.\-\+]+(?:\s?;\s?(?:boundary|charset)\s?=\s?['\"\w\d_\-]+)?$" \
-    "id:920425,\
+    "id:920470,\
     phase:1,\
     block,\
     t:none,t:lowercase,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -976,6 +976,43 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 #
 # Restrict which content-types we accept.
 #
+
+# Restrict Content-Type header to established patterns.
+#
+# This provides generic whitelist protection against vulnerabilities like
+# Apache Struts Content-Type arbitrary command execution (CVE-2017-5638).
+#
+# Examples of allowed patterns:
+# - text/plain
+# - text/plain; charset="UTF-8"
+# - multipart/form-data; boundary=----WebKitFormBoundary12345
+#
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w\d/\.\-+]+(?:\s?;\s?(?:boundary|charset)\s?=\s?['\"\w\d_\-]+)?$" \
+    "id:920425,\
+    phase:1,\
+    block,\
+    t:none,t:lowercase,\
+    msg:'Illegal Content-Type header',\
+    logdata:'%{matched_var}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'OWASP_CRS/PROTOCOL_VIOLATION/CONTENT_TYPE',\
+    tag:'WASCTC/WASC-20',\
+    tag:'OWASP_TOP_10/A1',\
+    tag:'OWASP_AppSensor/EE2',\
+    tag:'PCI/12.1',\
+    rev:1,\
+    ver:'OWASP_CRS/3.0.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.msg=%{rule.msg}',\
+    setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/CONTENT_TYPE-%{matched_var_name}=%{matched_var}'"
+
+# In case Content-Type header can be parsed, check the mime-type against
+# the policy defined in the 'allowed_request_content_type' variable.
+# To change your policy, edit crs-setup.conf and activate rule 900220.
 SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     "id:920420,\
     phase:2,\
@@ -1003,6 +1040,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/CONTENT_TYPE_NOT_ALLOWED-%{matched_var_name}=%{matched_var}'"
+
 
 #
 # Restrict protocol versions.

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -987,7 +987,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS/POLICY/ENCODING_NOT_ALLOWED',\
+    tag:'OWASP_CRS/POLICY/CONTENT_TYPE_NOT_ALLOWED',\
     tag:'WASCTC/WASC-20',\
     tag:'OWASP_TOP_10/A1',\
     tag:'OWASP_AppSensor/EE2',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -987,7 +987,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - text/plain; charset="UTF-8"
 # - multipart/form-data; boundary=----WebKitFormBoundary12345
 #
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w\d/\.\-+]+(?:\s?;\s?(?:boundary|charset)\s?=\s?['\"\w\d_\-]+)?$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w\d/\.\-\+]+(?:\s?;\s?(?:boundary|charset)\s?=\s?['\"\w\d_\-]+)?$" \
     "id:920425,\
     phase:1,\
     block,\

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920420.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920420.yaml
@@ -1,15 +1,15 @@
 ---
-  meta: 
+  meta:
     author: "csanders-git"
     enabled: true
     name: "920420.yaml"
     description: "Description"
-  tests: 
-    - 
+  tests:
+    -
       test_title: 920420-1
-      stages: 
-        - 
-          stage: 
+      stages:
+        -
+          stage:
             input:
               dest_addr: "127.0.0.1"
               port: 80
@@ -19,13 +19,13 @@
                   Host: "localhost"
                   Content-Type: "application/x-www-form-urlencoded"
               data: "test=value"
-            output: 
+            output:
               no_log_contains: "id \"920420\""
-    - 
+    -
       test_title: 920420-2
-      stages: 
-        - 
-          stage: 
+      stages:
+        -
+          stage:
             input:
               dest_addr: "127.0.0.1"
               port: 80
@@ -35,13 +35,13 @@
                   Host: "localhost"
                   Content-Type: "my-new-content-type"
               data: "test"
-            output: 
+            output:
               log_contains: "id \"920420\""
-    - 
+    -
       test_title: 920420-3
-      stages: 
-        - 
-          stage: 
+      stages:
+        -
+          stage:
             input:
               dest_addr: "127.0.0.1"
               port: 80
@@ -51,13 +51,13 @@
                   Host: "localhost"
                   Content-Type: "my-new-content-type"
               data: "test"
-            output: 
-              no_log_contains: "id \"920420\""             
-    - 
+            output:
+              log_contains: "id \"920420\""
+    -
       test_title: 920420-4
-      stages: 
-        - 
-          stage: 
+      stages:
+        -
+          stage:
             input:
               dest_addr: "127.0.0.1"
               port: 80
@@ -67,13 +67,13 @@
                   Host: "localhost"
                   Content-Type: "my-new-content-type"
               data: "test"
-            output: 
-              no_log_contains: "id \"920420\""        
-    - 
+            output:
+              log_contains: "id \"920420\""
+    -
       test_title: 920420-5
       desc: Request content type is not allowed by policy (920420) from old modsec regressions
       stages:
-      - 
+      -
         stage:
           input:
             dest_addr: 127.0.0.1
@@ -108,11 +108,11 @@
             - --0000--
           output:
             log_contains: id "920420"
-    - 
+    -
       test_title: 920420-6
       desc: Request content type is not allowed by policy (920420) from old modsec regressions
       stages:
-      - 
+      -
         stage:
           input:
             dest_addr: 127.0.0.1
@@ -147,11 +147,11 @@
             - --0000--
           output:
             log_contains: id "920420"
-    - 
+    -
       test_title: 920420-7
       desc: Request content type is not allowed by policy (920420) from old modsec regressions
       stages:
-      - 
+      -
         stage:
           input:
             dest_addr: 127.0.0.1
@@ -186,5 +186,36 @@
             - --0000--
           output:
             log_contains: id "920420"
-                
+    -
+      test_title: 920420-8
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "HEAD"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "my-new-content-type"
+              data: "test"
+            output:
+              log_contains: "id \"920420\""
+    -
+      test_title: 920420-9
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "OPTIONS"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "application/json"
+              data: "test"
+            output:
+              no_log_contains: "id \"920420\""
 

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
@@ -1,0 +1,115 @@
+---
+  meta:
+    author: "lifeforms"
+    enabled: true
+    name: "920470.yaml"
+    description: "Content-Type header format checks"
+  tests:
+    - test_title: 920470-1
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "%{(#nike='multipart/form-data').(#dm=@ognl"
+                  Content-Length: 0
+            output:
+              log_contains: "id \"920470\""
+    - test_title: 920470-2
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'text/plain; charset="UTF-8"; garbage'
+                  Content-Length: 0
+            output:
+              log_contains: "id \"920470\""
+    - test_title: 920470-3
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'text/plain; charset=/gar/bage'
+                  Content-Length: 0
+            output:
+              log_contains: "id \"920470\""
+    - test_title: 920470-4
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              method: POST
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "text/plain"
+                  Content-Length: 0
+            output:
+              no_log_contains: "id \"920470\""
+    - test_title: 920470-5
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              method: POST
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'text/plain; charset=UTF-8'
+            output:
+              no_log_contains: "id \"920470\""
+    - test_title: 920470-6
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              method: POST
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'text/plain; charset="UTF-8"'
+                  Content-Length: 0
+            output:
+              no_log_contains: "id \"920470\""
+    - test_title: 920470-7
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              method: POST
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'multipart/form-data; boundary=----WebKitFormBoundary12345'
+                  Content-Length: 0
+            output:
+              no_log_contains: "id \"920470\""
+    - test_title: 920470-8
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              method: POST
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'application/json'
+                  Content-Length: 0
+            output:
+              no_log_contains: "id \"920470\""


### PR DESCRIPTION
This PR contains two changes to request Content-Type header checking:

## Changed: 920420 improve policy checks

Rule 920420 omitted to check the mime-type in the Content-Type request header in case of GET, HEAD, PROPFIND or OPTIONS requests.

These types of requests should not have a Content-Type header, since they have no body, but that is no reason to not check the mime-type, if one should be submitted.

Note that this rule only works on properly formatted Content-Type headers, from which a mime-type can be parsed.

## Added: 920470 whitelist header format

Since rule 920420 only works on well-behaved Content-Type headers, I've inserted a new rule above it, which first validates Content-Type against a regular expression.

This provides generic whitelist protection against vulnerabilities like Apache Struts Content-Type arbitrary command execution (CVE-2017-5638), which uses a Content-Type header like:

```
Content-Type: %{(#nike='multipart/form-data').(#dm=@ognl ...
```

For the Struts vuln, we have blacklisting in the 944xxx rules, but I feel the Content-Type header is a good candidate for whitelisting in addition to this.

The rule might be a little pedantic, but I've tried to be flexible towards possible practical uses. I've tested it out on some traffic. But it's possible that we'll discover from testing that we need to be a little more lax.