### PR TITLE
Move 944400 and create variable tx.enforce_bodyproc_urlencoded

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -166,6 +166,10 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # example: [tag "paranoia-level/2"]. This allows you to deduct from the
 # audit log how the WAF behavior is affected by paranoia level.
 #
+# For high security settings, it is important to also look into the variable
+# tx.enforce_bodyproc_urlencoded (Enforce Body Processor URLENCODED) defined
+# below.
+#
 # Uncomment this rule to change the default:
 #
 #SecAction \
@@ -175,6 +179,30 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #   pass,\
 #   t:none,\
 #   setvar:tx.paranoia_level=1"
+
+
+#
+# -- [[ Enforce Body Processor URLENCODED ]] -----------------------------------
+#
+# ModSecurity selects the body processor based on the Content-Type request
+# header. But clients are not always setting the Content-Type header for their
+# request body payloads. This will leave ModSecurity with limited vision into
+# the payload.  The variable tx.enforce_bodyproc_urlencoded lets you force the
+# URLENCODED body processor in these situations. This is off by default, as it
+# implies a change of the behaviour of ModSecurity beyond CRS (the body
+# processor applies to all rules, not only CRS) and because it may lead to
+# false positives already on paranoia level 1. However, in a high security
+# setting, we suggest to enable this variable.
+#
+# Uncomment this rule to change the default:
+#
+#SecAction \
+#  "id:900010,\
+#   phase:1,\
+#   nolog,\
+#   pass,\
+#   t:none,\
+#   setvar:tx.enforce_bodyproc_urlencoded=1"
 
 
 #

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -166,9 +166,9 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # example: [tag "paranoia-level/2"]. This allows you to deduct from the
 # audit log how the WAF behavior is affected by paranoia level.
 #
-# For high security settings, it is important to also look into the variable
-# tx.enforce_bodyproc_urlencoded (Enforce Body Processor URLENCODED) defined
-# below.
+# It is important to also look into the variable 
+# tx.enforce_bodyproc_urlencoded (Enforce Body Processor URLENCODED) 
+# defined below. Enabling it closes a possible bypass of CRS.
 #
 # Uncomment this rule to change the default:
 #
@@ -191,8 +191,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # URLENCODED body processor in these situations. This is off by default, as it
 # implies a change of the behaviour of ModSecurity beyond CRS (the body
 # processor applies to all rules, not only CRS) and because it may lead to
-# false positives already on paranoia level 1. However, in a high security
-# setting, we suggest to enable this variable.
+# false positives already on paranoia level 1. However, enabling this variable
+# closes a possible bypass of CRS so it should be considered.
 #
 # Uncomment this rule to change the default:
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -194,18 +194,13 @@ SecRule &TX:static_extensions "@eq 0" \
     nolog,\
     setvar:'tx.static_extensions=/.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/'"
 
-# Renamed 944000
-SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
-    "id:901170,\
+# Default enforcing of body processor URLENCODED
+SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
+    "id:901167,\
     phase:1,\
     pass,\
     nolog,\
-    noauditlog,\
-    msg:'Enabling body inspection',\
-    tag:'paranoia-level/1',\
-    ctl:forceRequestBodyVariable=On,\
-    rev:'1',\
-    ver:'OWASP_CRS/3.1.0'"
+    setvar:'tx.enforce_bodyproc_urlencoded=0'"
 
 SecAction \
     "id:901180,\
@@ -270,6 +265,40 @@ SecAction \
     initcol:global=global,\
     initcol:ip=%{remote_addr}_%{tx.ua_hash},\
     setvar:'tx.real_ip=%{remote_addr}'"
+
+#
+# -=[ Initialize Correct Body Processing ]=-
+#
+# Force request body variable and optionally request body processor
+#
+
+# Force body variable
+SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
+    "id:901340,\
+    phase:1,\
+    pass,\
+    nolog,\
+    noauditlog,\
+    msg:'Enabling body inspection',\
+    tag:'paranoia-level/1',\
+    ctl:forceRequestBodyVariable=On,\
+    rev:'1',\
+    ver:'OWASP_CRS/3.1.0'"
+
+# Force body processor URLENCODED
+SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
+    "id:944400,\
+    phase:1,\
+    pass,\
+    t:none,t:urlDecodeUni,\
+    nolog,\
+    noauditlog,\
+    msg:'Enabling forced body inspection for ASCII content',\
+    rev:'1',\
+    ver:'OWASP_CRS/3.1.0',\
+    chain"
+    SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
+        "ctl:requestBodyProcessor=URLENCODED"
 
 
 #

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -750,6 +750,9 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
 # Content-Type header. However, a request missing a Content-Header is a
 # strong indication of a non-compliant browser.
 #
+# Also, omitting the CT header allows to bypass the Request Body Processor
+# unless you set the optional tx.enforce_bodyproc_urlencoded variable.
+#
 # -=[ References ]=-
 # http://httpwg.org/specs/rfc7231.html#header.content-type
 

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -344,22 +344,6 @@ SecRule TX:PARANOIA_LEVEL "@lt 4" "phase:2,id:944018,nolog,pass,skipAfter:END-RE
 # -= Paranoia Level 4 =- (apply only when tx.paranoia_level is sufficiently high: 4 or higher)
 #
 
-# Renamed 944410 to 944400, to move to 901
-SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
-    "id:944400,\
-    phase:1,\
-    block,\
-    t:none,t:urlDecodeUni,\
-    nolog,\
-    noauditlog,\
-    msg:'Enabling forced body inspection for ASCII content',\
-    tag:'paranoia-level/4',\
-    ctl:requestBodyProcessor=URLENCODED,\
-    ctl:forceRequestBodyVariable=On,\
-    rev:'1',\
-    ver:'OWASP_CRS/3.1.0',\
-    chain"
-    SecRule STREAM_INPUT_BODY "@validateByteRange 1-255"
 
 #
 # -= Paranoia Levels Finished =-


### PR DESCRIPTION
This solves the problems referenced in issue #1076 and described in #1096 and follows the preferred solution as discussed in #1076.

We introduce a variable `tx.enforce_bodyproc_urlencoded` that is off by default. This variable can be enabled in the crs-setup.conf immediately after the PL. The PL description suggests to look into this variable too.

The refactoring of this body processor enforcing also removes the inspection of body payloads for NULL-Bytes that was present in the previous form. That form was incompatible to NGINX and meant to block non-ASCII payloads immediately. This constraint is now removed, means a change of behaviour though - but only if `tx.enforce_bodyproc_urlencoded` is enabled. As this is a manual setting in high security setups, people will be able to handle it themselves and we can gain experience too. Maybe this has to be adopted in the future.

Sorry this took so long. I'm mighty busy at the moment (and a recent flood cut me from the internet for a few days: https://www.facebook.com/christian.folini.5/media_set?set=a.10215175075917432.1073741832.1448781072&type=3&notif_id=1527586249036659&notif_t=feedback_reaction_generic)