### PR TITLE
Missing Content-Type: create critical sibling of 920340 in PL2

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1346,7 +1346,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     phase:2,\
     block,\
     t:none,\
-    msg:'Request Containing Content, but Missing Content-Type header',\
+    msg:'Request Containing Content Requires Content-Type header',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -763,7 +763,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
 SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     "id:920340,\
     phase:2,\
-    block,\
+    pass,\
     t:none,\
     msg:'Request Containing Content, but Missing Content-Type header',\
     tag:'application-multi',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1335,7 +1335,7 @@ SecRule FILES_NAMES|FILES "@rx ['\";=]" \
 
 
 #
-# PL2: block on Missing Content-Type Header with Request Body
+# PL2: Block on Missing Content-Type Header with Request Body
 # This is a stricter sibling of rule 920340.
 #
 # -=[ References ]=-

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -753,6 +753,10 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
 # Also, omitting the CT header allows to bypass the Request Body Processor
 # unless you set the optional tx.enforce_bodyproc_urlencoded variable.
 #
+# Note: in default settings, this behavior only provides a NOTICE and will
+# not cause a request to be blocked. However, in paranoia level 2 or
+# higher, we run sibling 920341, which DOES block these requests.
+#
 # -=[ References ]=-
 # http://httpwg.org/specs/rfc7231.html#header.content-type
 

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1334,6 +1334,34 @@ SecRule FILES_NAMES|FILES "@rx ['\";=]" \
     setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ-%{matched_var_name}=%{matched_var}'"
 
 
+#
+# PL2: block on Missing Content-Type Header with Request Body
+# This is a stricter sibling of rule 920340.
+#
+# -=[ References ]=-
+# http://httpwg.org/specs/rfc7231.html#header.content-type
+
+SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
+    "id:920341,\
+    phase:2,\
+    block,\
+    t:none,\
+    msg:'Request Containing Content, but Missing Content-Type header',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/2',\
+    ver:'OWASP_CRS/3.0.0',\
+    severity:'CRITICAL',\
+    chain"
+    SecRule &REQUEST_HEADERS:Content-Type "@eq 0" \
+        "t:none,\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}'"
+
+
 SecRule TX:PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #


### PR DESCRIPTION
As per discussion during the June IRC meet, we leave 920340 as a NOTICE (since it is technically allowed by the spec) but create a CRITICAL copy of the rule in paranoia level 2.