### PR TITLE
Added rule 932172: Prevent Bypass Rule 930120 on PL1 and PL2

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -520,7 +520,7 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "^\(\s*\)\s+{" \
 # by using wildcard characters. Example:
 # /index.php?cmd=cat+/et?/??ss??
 #
-# This could happend even setting Paranoia Level to 2 by using
+# This could happen even setting Paranoia Level to 2 by using
 # a lower number of consecutive wildcard char (<= 2). Example:
 # /index.php?cmd=cat+/et?/?asswd
 #

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -512,6 +512,48 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "^\(\s*\)\s+{" \
 	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}"
 
 
+#
+# -=[ Bypass Rule 930120 ]=-
+#
+# When Paranoia Level is set to 1, a Remote Command Execution
+# could be exploited bypassing rule 930120 (OS File Access Attempt)
+# by using wildcard characters. Example:
+# /index.php?cmd=cat+/et?/??ss??
+#
+# This could happend even setting Paranoia Level to 2 by using
+# a lower number of consecutive wildcard char (<= 2). Example:
+# /index.php?cmd=cat+/et?/?asswd
+#
+
+SecRule ARGS "@rx \/+\S+\/" "phase:request,id:932172,nolog,block,t:none,t:urlDecode,t:urlDecodeUni,chain"
+  SecRule ARGS "@rx (\?+\S+\?|\*+\S+\*)" \
+	"msg:'Remote Command Execution: Wildcard bypass technique attempt',\
+	phase:request,\
+	rev:'1',\
+	ver:'OWASP_CRS/3.0.0',\
+	maturity:'1',\
+	accuracy:'1',\
+	capture,\
+	t:none,t:urlDecode,t:urlDecodeUni,\
+	ctl:auditLogParts=+E,\
+	id:932172,\
+	tag:'application-multi',\
+	tag:'language-shell',\
+	tag:'platform-unix',\
+	tag:'attack-rce',\
+	tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
+	tag:'WASCTC/WASC-31',\
+	tag:'OWASP_TOP_10/A1',\
+	tag:'PCI/6.5.2',\
+	logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:tx.rce_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.anomaly_score=+%{tx.critical_anomaly_score},\
+	setvar:tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}"
+
+
+
 
 SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:1,id:932013,nolog,pass,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:932014,nolog,pass,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"


### PR DESCRIPTION
### Prevent bypass 930120 on PL1 and PL2
This rule, added on `owasp-modsecurity-crs/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf`, try to detects wildcard `?` and `*` usage in order to bypass rule **930120 (OS File Access Attempt)** on Paranoia Lvel 1 and 2.

In my test environment, it works fine! but I haven't tested it enough in order to know if it could lead to false positives. Could it be a good idea? Can someone test it and check for some FP? My only doubt is that the regex is very simple and I'm worried that it could match in other scenarios that I haven't test.

Chained rules using `@rx` on `ARGS`:
```perl
# detect /something/
SecRule ARGS "@rx \/+\S+\/" "...,block,chain"

# detect ?something?
SecRule ARGS "@rx (\?+\S+\?|\*+\S+\*)" "..."

# both chained will match on
/som?thin?/ or /som*thin*/
```

Example RCE bypassing  930120 with PL1 & PL2:
```bash
$ curl -v 'localhost/test.php?c=cat+/et?/?asswd'
$ curl -v 'localhost/test.php?c=cat+/et*/*asswd'
```

Log msg and details output:
```
Tue Jul  3 12:12:51 2018 [932172] Remote Command Execution: Wildcard bypass technique attempt
                          `- Matched Data: */* found within ARGS:c: cat /et*/*asswd
Tue Jul  3 12:13:09 2018 [932172] Remote Command Execution: Wildcard bypass technique attempt
                          `- Matched Data: ?/? found within ARGS:c: cat /et?/?asswd
```

Debug output:
```
[4] (Rule: 932172) Executing operator "Rx" with param "\/+\S+\/" against ARGS.
[9]  T (0) t:urlDecode: "cat /et?/?asswd"
[9]  T (1) t:urlDecodeUni: "cat /et?/?asswd"
[9] Target value: "cat /et?/?asswd" (Variable: ARGS:c)
[9] Matched vars updated.
[9] Rule contains a `block' action
[4] Rule returned 1.
[4] Executing chained rule.
[4] (Rule: 932172) Executing operator "Rx" with param "(\?+\S+\?|\*+\S+\*)" against ARGS.
[9]  T (0) t:urlDecode: "cat /et?/?asswd"
[9]  T (1) t:urlDecodeUni: "cat /et?/?asswd"
[9] Target value: "cat /et?/?asswd" (Variable: ARGS:c)
[7] Added regex subexpression TX.0: ?/?
[7] Added regex subexpression TX.1: ?/?
[9] Matched vars updated.
[4] Running [independent] (non-disruptive) action: msg
[9] Saving msg: Remote Command Execution: Wildcard bypass technique attempt
[4] Running [independent] (non-disruptive) action: setvar
[8] Saving variable: TX:msg with value: Remote Command Execution: Wildcard bypass technique attempt
[4] Running [independent] (non-disruptive) action: setvar
[8] Saving variable: TX:rce_score with value: 5
[4] Running [independent] (non-disruptive) action: setvar
[8] Saving variable: TX:anomaly_score with value: 5
[4] Running [independent] (non-disruptive) action: setvar
[8] Saving variable: TX:932172-OWASP_CRS/WEB_ATTACK/RCE-ARGS:c with value: ?/?
[4] Rule returned 1.
[9] (SecDefaultAction) Running action: log
[9] Saving transaction to logs
[9] (SecDefaultAction) Running action: auditlog
[4] (SecDefaultAction) ignoring action: deny (rule does not cotains block)
[9] (SecDefaultAction) Running action: status
[4] Running (non-disruptive) action: capture
[4] Running (non-disruptive) action: ctl
[4] Running (non-disruptive) action: tag
[9] Rule tag: application-multi
[4] Running (non-disruptive) action: tag
[9] Rule tag: language-shell
[4] Running (non-disruptive) action: tag
[9] Rule tag: platform-unix
[4] Running (non-disruptive) action: tag
[9] Rule tag: attack-rce
[4] Running (non-disruptive) action: tag
[9] Rule tag: OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION
[4] Running (non-disruptive) action: tag
[9] Rule tag: WASCTC/WASC-31
[4] Running (non-disruptive) action: tag
[9] Rule tag: OWASP_TOP_10/A1
[4] Running (non-disruptive) action: tag
[9] Rule tag: PCI/6.5.2
[4] Running (non-disruptive) action: logdata
[4] Running (non-disruptive) action: severity
[9] This rule severity is: 2 current transaction is: 255
[9] (SecDefaultAction) Running action: log
[9] Saving transaction to logs
[9] (SecDefaultAction) Running action: auditlog
[4] (SecDefaultAction) Running action: deny.
[8] Running action deny
[9] (SecDefaultAction) Running action: status
[4] Running (non-disruptive) action: nolog
[4] Running (disruptive)     action: block
[8] Marking request as disruptive.
[8] Running action deny
[8] Skipping this phase as this request was already intercepted.
```

thanks