### PR TITLE
Removing odd global variable set in IIS rules

### DIFF
--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -37,12 +37,9 @@ SecRule RESPONSE_BODY "@rx [a-z]:\\\\inetpub\b" \
     rev:3,\
     ver:'OWASP_CRS/3.0.0',\
     severity:'ERROR',\
-    chain"
-    SecRule &GLOBAL:alerted_970018_iisDefLoc "@eq 0" \
-        "setvar:'global.alerted_970018_iisDefLoc',\
-        setvar:'tx.msg=%{rule.msg}',\
-        setvar:'tx.outbound_anomaly_score=+%{tx.error_anomaly_score}',\
-        setvar:'tx.anomaly_score=+%{tx.error_anomaly_score}'"
+    setvar:'tx.msg=%{rule.msg}',\
+    setvar:'tx.outbound_anomaly_score=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score=+%{tx.error_anomaly_score}'"
 
 
 SecRule RESPONSE_BODY "@rx (?:Microsoft OLE DB Provider for SQL Server(?:<\/font>.{1,20}?error '800(?:04005|40e31)'.{1,40}?Timeout expired| \(0x80040e31\)<br>Timeout expired<br>)|<h1>internal server error<\/h1>.*?<h2>part of the server has crashed or it has a configuration error\.<\/h2>|cannot connect to the server: timed out)" \


### PR DESCRIPTION
This global. variable doesn't seem to be used and it is also not yet a supported syntax in libmodsecurity.