### PR TITLE
RCE: prevent bypass rule 930120 (PL3)

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -667,6 +667,39 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
 
+#
+# -=[ Bypass Rule 930120 (wildcard) ]=-
+#
+# When Paranoia Level is set to 1 and 2, a Remote Command Execution
+# could be exploited bypassing rule 930120 (OS File Access Attempt)
+# by using wildcard characters.
+#
+# In some other cases, it could be bypassed even if the Paranoia Level is set to 3.
+# Please, keep in mind that this rule could lead to many false positives.
+#
+SecRule ARGS|XML "@rx (?:/|\\\\)(?:[\?\*]+[a-z/\\\\]+|[a-z/\\\\]+[\?\*]+)" \
+    "id:932190,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:urlDecode,t:urlDecodeUni,t:normalizePath,t:cmdLine,\
+    msg:'Remote Command Execution: Wildcard bypass technique attempt',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-shell',\
+    tag:'platform-unix',\
+    tag:'attack-rce',\
+    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
+    tag:'WASCTC/WASC-31',\
+    tag:'OWASP_TOP_10/A1',\
+    tag:'PCI/6.5.2',\
+    tag:'paranoia-level/3',\
+    ctl:auditLogParts=+E,\
+    severity:'CRITICAL',\
+    setvar:'tx.msg=%{rule.msg}',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:932018,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"


### PR DESCRIPTION
Referencing to https://github.com/SpiderLabs/owasp-modsecurity-crs/pull/1131 this rule, added on `owasp-modsecurity-crs/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf`, tries to detect wildcard `?` and `*` usage in order to bypass rule `930120` (OS File Access Attempt) on Paranoia Lvel 3.

A POC was sent to security@coreruleset.org in order to not sharing on GitHub critical information about how to bypass the whole rule set to exploit a RCE.

At the time, I've placed this rule in PL3 because, unfortunately, it could lead to many false positives.

Thanks @lifeforms @spartantri @csanders-git and @fgsch for contributing.