### PR TITLE
Fixed "unknown option ff-only"

### DIFF
--- a/util/upgrade.py
+++ b/util/upgrade.py
@@ -33,7 +33,7 @@ def upgrade_crs(crs_directory, quiet):
 
     # Do a git 'git pull'
     os.chdir(crs_directory)
-    gitcmd = "git pull origin HEAD --ff-only"
+    gitcmd = "git pull --ff-only origin HEAD"
     try:
         git_output = check_output(gitcmd, stderr=STDOUT, shell=True)        
         returncode = 0


### PR DESCRIPTION
This commit fix this error:
crs: Git pull failed! Error: error: unknown option `ff-only'