### PR TITLE
Add self[ and document[ to rule 941180

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -251,7 +251,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 # [Blacklist Keywords from Node-Validator]
 # https://raw.github.com/chriso/node-validator/master/validator.js
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pm document.cookie document.write .parentnode .innerhtml window.location -moz-binding <!-- --> <![cdata[" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pm document.cookie document.write document[ self[ .parentnode .innerhtml window.location -moz-binding <!-- --> <![cdata[" \
     "id:941180,\
     phase:2,\
     block,\


### PR DESCRIPTION
It seems possible to bypass rule 941180 (on PL1) exploiting a "JavaScript Injection" by using `slef` or `document` JavaScript object. For example, `document.cookie` match this rule but `document['cookie']` or `self['document']['cookie']` not.

Furthermore, it's possible to bypass filters based on "JavaScript functions names" by replacing chars with respective hex. For example (ASCII to HEX: `a = 61`):

`alert("XSS")` == `self['\x61lert']("XSS")`

Or encoding the whole `document.cookie` variable:
`document.cookie` == `self['\x64\x6f\x63\x75\x6d\x65\x6e\x74']['\x63\x6f\x6f\x6b\x69\x65']`

Example payloads:
```
/test.php?a=';alert(document['cookie']);//
```
```
/test.php?a=';self['\x61lert'](self['\x64\x6f\x63\x75\x6d\x65\x6e\x74']['\x63\x6f\x6f\x6b\x69\x65']);//
```

Fixed by adding `document[` and `slef[` on the `@pm` strings list of rule 941180.