### PR TITLE
Add rule 933200 PHP Wrappers

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -207,9 +207,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # PHP comes with many built-in wrappers for various URL-style protocols for use with the filesystem
 # functions such as fopen(), copy(), file_exists() and filesize(). Abusing of PHP wrappers like phar://
-# could lead to RCE as describled by Sam Thomas at BlackHat USA 2018
+# could lead to RCE as describled by Sam Thomas at BlackHat USA 2018, even wrappers like zlib://,
+# glob://, rar://, zip://, etc... could lead to LFI and expect:// to RCE.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:zlib|data|glob|phar|ssh2|rar|ogg|expect)://[^/]+" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:zlib|glob|phar|ssh2|rar|ogg|expect|zip)://([^/]+|/[^/]+)" \
     "id:933200,\
     phase:2,\
     block,\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -203,6 +203,36 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 
 
 #
+# [ PHP Wrappers ]
+#
+# PHP comes with many built-in wrappers for various URL-style protocols for use with the filesystem 
+# functions such as fopen(), copy(), file_exists() and filesize(). Abusing of PHP wrappers like phar://
+# could lead to RCE as describled by Sam Thomas at BlackHat USA 2018
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:zlib|data|glob|phar|ssh2|rar|ogg|expect)://[^/]+" \
+    "id:933200,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'PHP Injection Attack: Wrapper scheme detected',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-injection-php',\
+    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
+    tag:'OWASP_TOP_10/A1',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.1.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.msg=%{rule.msg}',\
+    setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+
+
+#
 # [ PHP Functions ]
 #
 # Detecting PHP function names is useful to block PHP code injection attacks.

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -205,7 +205,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # [ PHP Wrappers ]
 #
-# PHP comes with many built-in wrappers for various URL-style protocols for use with the filesystem 
+# PHP comes with many built-in wrappers for various URL-style protocols for use with the filesystem
 # functions such as fopen(), copy(), file_exists() and filesize(). Abusing of PHP wrappers like phar://
 # could lead to RCE as describled by Sam Thomas at BlackHat USA 2018
 #

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -207,17 +207,16 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # PHP comes with many built-in wrappers for various URL-style protocols for use with the filesystem
 # functions such as fopen(), copy(), file_exists() and filesize(). Abusing of PHP wrappers like phar://
-# could lead to RCE as describled by Sam Thomas at BlackHat USA 2018, even wrappers like zlib://,
-# glob://, rar://, zip://, etc... could lead to LFI and expect:// to RCE.
+# could lead to RCE as describled by Sam Thomas at BlackHat USA 2018 (https://bit.ly/2yaKV5X), even
+# wrappers like zlib://, glob://, rar://, zip://, etc... could lead to LFI and expect:// to RCE.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:zlib|glob|phar|ssh2|rar|ogg|expect|zip)://([^/]+|/[^/]+)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:zlib|glob|phar|ssh2|rar|ogg|expect|zip)://(?:[^/]+|/[^/]+)" \
     "id:933200,\
     phase:2,\
     block,\
-    capture,\
-    t:none,\
+    t:none,t:utf8toUnicode,t:urlDecodeUni,t:removeNulls,t:cmdLine,\
     msg:'PHP Injection Attack: Wrapper scheme detected',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-php',\
     tag:'platform-multi',\
@@ -230,7 +229,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #


### PR DESCRIPTION
Referring to https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/1171 I'm testing this rule in production, and at the moment seems to works fine without FP in PL1. About the wrapper `phar://` please refer to: https://github.com/s-n-t/presentations/blob/master/us-18-Thomas-It's-A-PHP-Unserialization-Vulnerability-Jim-But-Not-As-We-Know-It.pdf