### PR TITLE
java-classes: add struts namespaces

### DIFF
--- a/rules/java-classes.data
+++ b/rules/java-classes.data
@@ -35,4 +35,6 @@ java.lang.StringBuilder
 java.lang.System
 javax.script.ScriptEngineManager
 org.apache.commons
+org.apache.struts
+org.apache.struts2
 org.omg.CORBA


### PR DESCRIPTION
Some new Struts payload was found to use a gadget under `org.apache.struts2` namespace, so include these Struts namespaces in the Java classes blacklist for good measure.

(We are already detecting this payload via other rules.)

See also: http://blog.atucom.net/2018/08/apache-struts-2-vulnerability-exploit.html