### PR TITLE
Fix duplicate .env reported in #1183

### DIFF
--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -107,7 +107,6 @@ wp-config.txt
 /packages.json
 # dotenv
 /.env
-/.env
 # OSX
 /.DS_Store
 # WS FTP


### PR DESCRIPTION
Multiple .env restrictions that did the same thing were in place in the file. Thanks to @jschleus for spotting the issue.