### PR TITLE
Fix small typo in variable

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -356,7 +356,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  setvar:tx.crs_exclusions_drupal=1,\
 #  setvar:tx.crs_exclusions_wordpress=1,\
 #  setvar:tx.crs_exclusions_nextcloud=1,\
-#  setvar:tx.crs_exclusions_dokuwik=1,\
+#  setvar:tx.crs_exclusions_dokuwiki=1,\
 #  setvar:tx.crs_exclusions_cpanel=1"
 
 #


### PR DESCRIPTION
The checked variable is `crs_exclusions_dokuwiki`. Do this need to be cherry picked for 3.1?