### PR TITLE
Drop the XML variable from rule 932190

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -665,7 +665,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # In some other cases, it could be bypassed even if the Paranoia Level is set to 3.
 # Please, keep in mind that this rule could lead to many false positives.
 #
-SecRule ARGS|XML "@rx (?:/|\\\\)(?:[\?\*]+[a-z/\\\\]+|[a-z/\\\\]+[\?\*]+)" \
+SecRule ARGS "@rx (?:/|\\\\)(?:[\?\*]+[a-z/\\\\]+|[a-z/\\\\]+[\?\*]+)" \
     "id:932190,\
     phase:2,\
     block,\


### PR DESCRIPTION
As discussed, as per docs having XML by itself seems to be invalid.