### PR TITLE
913100: remove lines with bare '#' comment char

### DIFF
--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -15,7 +15,6 @@ advanced email extractor
 # vuln scanner
 # http://www.arachni-scanner.com/
 arachni/
-#
 autogetcontent
 # nessus frontend
 # http://www.crossley-nilsen.com/Linux/Bilbo_-_Nessus_WEB/bilbo_-_nessus_web.html
@@ -55,21 +54,15 @@ domino hunter
 # vuln scanner - directory traversal fuzzer
 # https://github.com/wireghoul/dotdotpwn
 dotdotpwn
-#
-#
 email extractor
 # vuln scanner
 fhscan core 1.
-#
 floodgate
-#
 # "F-Secure Radar is a turnkey vulnerability scanning and management platform."
 F-Secure Radar
-#
 get-minimal
 # vuln scanner
 gootkit auto-rooter scanner
-#
 grabber
 # vuln scanner
 # https://sourceforge.net/projects/grendel/
@@ -79,7 +72,6 @@ havij
 # vuln scanner - path disclosure finder
 # http://seclists.org/fulldisclosure/2010/Sep/375
 inspath
-#
 internet ninja
 # vuln scanner
 jaascois
@@ -127,14 +119,11 @@ paros
 # phpmyadmin vuln scanner
 # dead 2005?
 pmafind
-#
 prog.customcrawler
 # vuln scanner
 # https://www.qualys.com/suite/web-application-scanning/
 qualys was
-# 
 s.t.a.l.k.e.r.
-#
 security scan
 # vuln scanner
 # https://sourceforge.net/projects/springenwerk/
@@ -151,7 +140,6 @@ sqlninja
 # password cracker
 # http://foofus.net/goons/jmk/medusa/medusa.html
 teh forest lobster
-# 
 this is an exploit
 # vuln scanner?
 toata dragostea


### PR DESCRIPTION
In CRS issue #1215, ModSec issue #1645, a problem with ModSec 3.0.2
was reported where the pmFromFile operator fails to ignore comment
lines that contain just '#' and no further text.
This caused CRS to block requests on the string '#' in User-Agent.

As a workaround, these entries are removed from our data files.