### PR TITLE
Backport 1187 - renaming matched_var/s

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -270,7 +270,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^.*$" \
     pass,\
     t:none,t:sha1,t:hexEncode,\
     nolog,\
-    setvar:'tx.ua_hash=%{matched_var}'"
+    setvar:'tx.ua_hash=%{MATCHED_VAR}'"
 
 SecAction \
     "id:901321,\

--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -45,7 +45,7 @@ SecRule TX:DO_REPUT_BLOCK "@eq 1" \
     skipAfter:BEGIN-REQUEST-BLOCKING-EVAL"
     SecRule IP:REPUT_BLOCK_FLAG "@eq 1" \
         "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -75,7 +75,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!@rx ^$" \
         SecRule GEO:COUNTRY_CODE "@within %{tx.high_risk_country_codes}" \
             "setvar:'tx.msg=%{rule.msg}',\
             setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-            setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var}',\
+            setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
             setvar:'ip.reput_block_flag=1',\
             setvar:'ip.reput_block_reason=%{rule.msg}',\
             expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
@@ -103,7 +103,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!@rx ^$" \
 #    severity:'CRITICAL',\
 #    setvar:'tx.msg=%{rule.msg}',\
 #    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-#    setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var}',\
+#    setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
 #    setvar:'ip.reput_block_flag=1',\
 #    setvar:'ip.reput_block_reason=%{rule.msg}',\
 #    expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
@@ -187,7 +187,7 @@ SecRule TX:block_search_ip "@eq 1" \
     SecRule TX:httpbl_msg "@rx Search Engine" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var}',\
+        setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
         setvar:'ip.reput_block_flag=1',\
         setvar:'ip.reput_block_reason=%{rule.msg}',\
         setvar:'ip.previous_rbl_check=1',\
@@ -210,7 +210,7 @@ SecRule TX:block_spammer_ip "@eq 1" \
     SecRule TX:httpbl_msg "@rx (?i)^.*? spammer .*?$" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var}',\
+        setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
         setvar:'ip.reput_block_flag=1',\
         setvar:'ip.reput_block_reason=%{rule.msg}',\
         setvar:'ip.previous_rbl_check=1',\
@@ -233,7 +233,7 @@ SecRule TX:block_suspicious_ip "@eq 1" \
     SecRule TX:httpbl_msg "@rx (?i)^.*? suspicious .*?$" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var}',\
+        setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
         setvar:'ip.reput_block_flag=1',\
         setvar:'ip.reput_block_reason=%{rule.msg}',\
         setvar:'ip.previous_rbl_check=1',\
@@ -256,7 +256,7 @@ SecRule TX:block_harvester_ip "@eq 1" \
     SecRule TX:httpbl_msg "@rx (?i)^.*? harvester .*?$" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{matched_var_name}=%{matched_var}',\
+        setvar:'tx.%{rule.id}-AUTOMATION/MALICIOUS-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
         setvar:'ip.reput_block_flag=1',\
         setvar:'ip.reput_block_reason=%{rule.msg}',\
         setvar:'ip.previous_rbl_check=1',\

--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -29,7 +29,7 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     phase:2,\
     block,\
     msg:'Method is not allowed by policy',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -43,7 +43,7 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     ver:'OWASP_CRS/3.1.0',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/METHOD_NOT_ALLOWED-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/METHOD_NOT_ALLOWED-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 

--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -50,7 +50,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/AUTOMATION/SECURITY_SCANNER-%{matched_var_name}=%{matched_var}',\
+    setvar:'tx.%{rule.id}-OWASP_CRS/AUTOMATION/SECURITY_SCANNER-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     setvar:'ip.reput_block_flag=1',\
     setvar:'ip.reput_block_reason=%{rule.msg}',\
     expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
@@ -75,7 +75,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmf scanners-headers.data" \
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/AUTOMATION/SECURITY_SCANNER-%{matched_var_name}=%{matched_var}',\
+    setvar:'tx.%{rule.id}-OWASP_CRS/AUTOMATION/SECURITY_SCANNER-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     setvar:'ip.reput_block_flag=1',\
     setvar:'ip.reput_block_reason=%{rule.msg}',\
     expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
@@ -102,7 +102,7 @@ SecRule REQUEST_FILENAME|ARGS "@pmf scanners-urls.data" \
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/AUTOMATION/SECURITY_SCANNER-%{matched_var_name}=%{matched_var}',\
+    setvar:'tx.%{rule.id}-OWASP_CRS/AUTOMATION/SECURITY_SCANNER-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     setvar:'ip.reput_block_flag=1',\
     setvar:'ip.reput_block_reason=%{rule.msg}',\
     expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
@@ -145,7 +145,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scripting-user-agents.data" \
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/AUTOMATION/SCRIPTING-%{matched_var_name}=%{matched_var}',\
+    setvar:'tx.%{rule.id}-OWASP_CRS/AUTOMATION/SCRIPTING-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     setvar:'ip.reput_block_flag=1',\
     setvar:'ip.reput_block_reason=%{rule.msg}',\
     expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
@@ -182,7 +182,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile crawlers-user-agents.data" \
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/AUTOMATION/CRAWLER-%{matched_var_name}=%{matched_var}',\
+    setvar:'tx.%{rule.id}-OWASP_CRS/AUTOMATION/CRAWLER-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     setvar:'ip.reput_block_flag=1',\
     setvar:'ip.reput_block_reason=%{rule.msg}',\
     expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -61,7 +61,7 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
     severity:'WARNING',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -100,7 +100,7 @@ SecRule FILES_NAMES|FILES "@rx (?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:
     block,\
     t:none,t:urlDecodeUni,\
     msg:'Attempted multipart/form-data bypass',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -111,7 +111,7 @@ SecRule FILES_NAMES|FILES "@rx (?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -145,7 +145,7 @@ SecRule REQBODY_ERROR "!@eq 0" \
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -187,7 +187,7 @@ SecRule MULTIPART_STRICT_ERROR "!@eq 0" \
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -206,7 +206,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
     block,\
     t:none,\
     msg:'Content-Length HTTP header is not numeric.',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -217,7 +217,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -241,7 +241,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     block,\
     t:none,\
     msg:'GET or HEAD Request with Body Content.',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -255,7 +255,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
         "t:none,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -267,7 +267,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     block,\
     t:none,\
     msg:'GET or HEAD Request with Transfer-Encoding.',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -281,7 +281,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
         "t:none,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -299,7 +299,7 @@ SecRule REQUEST_METHOD "@rx ^POST$" \
     block,\
     t:none,\
     msg:'POST without Content-Length or Transfer-Encoding headers.',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -314,7 +314,7 @@ SecRule REQUEST_METHOD "@rx ^POST$" \
         SecRule &REQUEST_HEADERS:Transfer-Encoding "@eq 0" \
             "setvar:'tx.msg=%{rule.msg}',\
             setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}',\
-            setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
+            setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -347,7 +347,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)\-(\d+)\,"
     capture,\
     t:none,\
     msg:'Range: Invalid Last Byte Value.',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -359,7 +359,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)\-(\d+)\,"
     SecRule TX:2 "!@ge %{tx.1}" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -380,7 +380,7 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
     block,\
     t:none,\
     msg:'Multiple/Conflicting Connection Header Data Found.',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -390,7 +390,7 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
     severity:'WARNING',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 #
 # Check URL encodings
@@ -413,7 +413,7 @@ SecRule REQUEST_URI "@rx \%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
     block,\
     t:none,\
     msg:'URL Encoding Abuse Attack Attempt',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -425,7 +425,7 @@ SecRule REQUEST_URI "@rx \%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
     SecRule REQUEST_URI "@validateUrlEncoding" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 SecRule REQUEST_HEADERS:Content-Type "@rx ^(?:application\/x-www-form-urlencoded|text\/xml)(?:;(?:\s?charset\s?=\s?[\w\d\-]{1,18})?)??$" \
     "id:920240,\
@@ -433,7 +433,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?:application\/x-www-form-urlencoded
     block,\
     t:none,\
     msg:'URL Encoding Abuse Attack Attempt',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -447,7 +447,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?:application\/x-www-form-urlencoded
         SecRule REQUEST_BODY|XML:/* "@validateUrlEncoding" \
             "setvar:'tx.msg=%{rule.msg}',\
             setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
-            setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}'"
+            setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -465,7 +465,7 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
     block,\
     t:none,\
     msg:'UTF8 Encoding Abuse Attack Attempt',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -477,7 +477,7 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
     SecRule REQUEST_FILENAME|ARGS|ARGS_NAMES "@validateUtf8Encoding" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -503,7 +503,7 @@ SecRule REQUEST_URI|REQUEST_BODY "@rx \%u[fF]{2}[0-9a-fA-F]{2}" \
     block,\
     t:none,\
     msg:'Unicode Full/Half Width Abuse Attack Attempt',\
-    logdata:'%{matched_var_name}=%{matched_var}',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-iis',\
@@ -513,7 +513,7 @@ SecRule REQUEST_URI|REQUEST_BODY "@rx \%u[fF]{2}[0-9a-fA-F]{2}" \
     severity:'WARNING',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -557,7 +557,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
     block,\
     t:none,t:urlDecodeUni,\
     msg:'Invalid character in request (null character)',\
-    logdata:'%{matched_var_name}=%{matched_var}',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -567,7 +567,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -601,7 +601,7 @@ SecRule &REQUEST_HEADERS:Host "@eq 0" \
     severity:'WARNING',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}',\
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     skipAfter:END-HOST-CHECK"
 
 
@@ -620,7 +620,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^$" \
     severity:'WARNING',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 SecMarker "END-HOST-CHECK"
 
@@ -665,7 +665,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
             "t:none,\
             setvar:'tx.msg=%{rule.msg}',\
             setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}',\
-            setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}'"
+            setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 #
 # This rule is a sibling of rule 920310.
@@ -690,7 +690,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
             "t:none,\
             setvar:'tx.msg=%{rule.msg}',\
             setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}',\
-            setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}'"
+            setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -718,7 +718,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
     severity:'NOTICE',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 #
 # Missing Content-Type Header with Request Body
@@ -757,7 +757,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
         "t:none,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 # Check that the host header is not an IP address
 # This is not an HTTP RFC violation but it is indicative of automated client access.
@@ -776,7 +776,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^[\d.:]+$" \
     block,\
     t:none,\
     msg:'Host header is a numeric IP address',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -789,7 +789,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^[\d.:]+$" \
     severity:'WARNING',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/IP_HOST-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/IP_HOST-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 # In most cases, you should expect a certain volume of each a request on your
@@ -811,7 +811,7 @@ SecRule &TX:MAX_NUM_ARGS "@eq 1" \
     block,\
     t:none,\
     msg:'Too many arguments in request',\
-    logdata:'%{matched_var_name}=%{matched_var}',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -824,7 +824,7 @@ SecRule &TX:MAX_NUM_ARGS "@eq 1" \
         "t:none,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 ## -- Arguments limits --
 #
@@ -836,7 +836,7 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
     block,\
     t:none,\
     msg:'Argument name too long',\
-    logdata:'%{matched_var_name}=%{matched_var}',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -849,7 +849,7 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
         "t:none,t:length,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 #
 # Limit argument value length
@@ -860,7 +860,7 @@ SecRule &TX:ARG_LENGTH "@eq 1" \
     block,\
     t:none,\
     msg:'Argument value too long',\
-    logdata:'%{matched_var_name}=%{matched_var}',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -873,7 +873,7 @@ SecRule &TX:ARG_LENGTH "@eq 1" \
         "t:none,t:length,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 #
 # Limit arguments total length
@@ -884,7 +884,7 @@ SecRule &TX:TOTAL_ARG_LENGTH "@eq 1" \
     block,\
     t:none,\
     msg:'Total arguments size exceeded',\
-    logdata:'%{matched_var_name}=%{matched_var}',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -897,7 +897,7 @@ SecRule &TX:TOTAL_ARG_LENGTH "@eq 1" \
         "t:none,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -924,7 +924,7 @@ SecRule &TX:MAX_FILE_SIZE "@eq 1" \
             "t:none,\
             setvar:'tx.msg=%{rule.msg}',\
             setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-            setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{matched_var_name}=%{matched_var}'"
+            setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 #
 # Combined file size is limited
@@ -935,7 +935,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
     block,\
     t:none,\
     msg:'Total uploaded files size too large',\
-    logdata:'%{matched_var_name}=%{matched_var}',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -948,7 +948,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
         "t:none,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/SIZE_LIMIT-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 
@@ -972,7 +972,7 @@ SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w\d/\.\-\+]+(?:\s?;\s?(?:boundary|
     block,\
     t:none,t:lowercase,\
     msg:'Illegal Content-Type header',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -986,7 +986,7 @@ SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w\d/\.\-\+]+(?:\s?;\s?(?:boundary|
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/CONTENT_TYPE-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/CONTENT_TYPE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 # In case Content-Type header can be parsed, check the mime-type against
 # the policy defined in the 'allowed_request_content_type' variable.
@@ -997,7 +997,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     block,\
     t:none,\
     msg:'Request content type is not allowed by policy',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1016,7 +1016,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
         ctl:forceRequestBodyVariable=On,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/CONTENT_TYPE_NOT_ALLOWED-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/CONTENT_TYPE_NOT_ALLOWED-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -1028,7 +1028,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*([^;\s]+)" \
     block,\
     t:none,t:lowercase,\
     msg:'Request content type charset is not allowed by policy',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1047,7 +1047,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*([^;\s]+)" \
         ctl:forceRequestBodyVariable=On,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/CONTENT_TYPE_CHARSET-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/CONTENT_TYPE_CHARSET-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -1059,7 +1059,7 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
     block,\
     t:none,\
     msg:'HTTP protocol version is not allowed by policy',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1072,7 +1072,7 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/PROTOCOL_NOT_ALLOWED-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/PROTOCOL_NOT_ALLOWED-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 #
 # Restrict file extension
@@ -1101,7 +1101,7 @@ SecRule REQUEST_BASENAME "@rx \.(.*)$" \
         "t:none,t:urlDecodeUni,t:lowercase,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/EXT_RESTRICTED-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/EXT_RESTRICTED-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 #
 # Restricted HTTP headers
@@ -1135,7 +1135,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     capture,\
     t:none,t:lowercase,\
     msg:'HTTP header is restricted by policy (%{MATCHED_VAR})',\
-    logdata:' Restricted header detected: %{matched_var}',\
+    logdata:' Restricted header detected: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1154,7 +1154,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     SecRule TX:/^HEADER_NAME_/ "@within %{tx.restricted_headers}" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/HEADERS_RESTRICTED-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/POLICY/HEADERS_RESTRICTED-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
@@ -1189,7 +1189,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d
     block,\
     t:none,\
     msg:'Range: Too many fields (6 or more)',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1202,7 +1202,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d
     SecRule REQUEST_BASENAME "!@endsWith .pdf" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 #
 # This is a sibling of rule 920200
@@ -1214,7 +1214,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     block,\
     t:none,\
     msg:'Range: Too many fields for pdf request (63 or more)',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1227,7 +1227,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?\-(?:\d+)?\s*,?\s*){63}" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 SecRule ARGS "@rx \%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
@@ -1236,7 +1236,7 @@ SecRule ARGS "@rx \%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
     block,\
     t:none,\
     msg:'Multiple URL Encoding Detected',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1247,7 +1247,7 @@ SecRule ARGS "@rx \%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
     severity:'WARNING',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -1280,7 +1280,7 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
             "t:none,\
             setvar:'tx.msg=%{rule.msg}',\
             setvar:'tx.anomaly_score_pl2=+%{tx.notice_anomaly_score}',\
-            setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}'"
+            setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 #
 # PL2: This is a stricter sibling of 920270.
@@ -1291,7 +1291,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,
     block,\
     t:none,t:urlDecodeUni,\
     msg:'Invalid character in request (non printable characters)',\
-    logdata:'%{matched_var_name}=%{matched_var}',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1302,7 +1302,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 
@@ -1332,7 +1332,7 @@ SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
     severity:'NOTICE',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.notice_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -1344,7 +1344,7 @@ SecRule FILES_NAMES|FILES "@rx ['\";=]" \
     block,\
     t:none,t:urlDecodeUni,\
     msg:'Attempted multipart/form-data bypass',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1356,7 +1356,7 @@ SecRule FILES_NAMES|FILES "@rx ['\";=]" \
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -1384,7 +1384,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
         "t:none,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
@@ -1402,7 +1402,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
     block,\
     t:none,t:urlDecodeUni,\
     msg:'Invalid character in request (outside of printable chars below ascii 127)',\
-    logdata:'%{matched_var_name}=%{matched_var}',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1413,7 +1413,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
@@ -1432,7 +1432,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     block,\
     t:none,\
     msg:'Range: Too many fields for pdf request (6 or more)',\
-    logdata:'%{matched_var}',\
+    logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1445,7 +1445,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?\-(?:\d+)?\s*,?\s*){6}" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -1457,7 +1457,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
     block,\
     t:none,t:urlDecodeUni,\
     msg:'Invalid character in request (outside of very strict set)',\
-    logdata:'%{matched_var_name}=%{matched_var}',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1468,7 +1468,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 #
 # This is a stricter sibling of 920270.
@@ -1479,7 +1479,7 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
     block,\
     t:none,t:urlDecodeUni,\
     msg:'Invalid character in request headers (outside of very strict set)',\
-    logdata:'%{matched_var_name}=%{matched_var}',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1490,7 +1490,7 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
     severity:'CRITICAL',\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 # -=[ Abnormal Character Escapes ]=-
@@ -1540,7 +1540,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?<!\Q\\\E)\Q\\\E[cdegh
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/ABNORMAL-ESCAPE-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/ABNORMAL-ESCAPE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -48,7 +48,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?:\n|\r)+(?:get|post|head|options|connect|p
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/REQUEST-SMUGGLING-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/REQUEST-SMUGGLING-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 #
 # -=[ HTTP Response Splitting ]=-
@@ -80,7 +80,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESPONSE_SPLITTING-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESPONSE_SPLITTING-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:\bhttp\/(?:0\.9|1\.[01])|<(?:html|meta)\b)" \
@@ -101,7 +101,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESPONSE_SPLITTING-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESPONSE_SPLITTING-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 #
 # -=[ HTTP Header Injection ]=-
@@ -135,7 +135,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 # Detect newlines in argument names.
@@ -160,7 +160,7 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule ARGS_GET_NAMES|ARGS_GET "@rx (?:\n|\r)+(?:\s|location|refresh|(?:set-)?cookie|(?:x-)?(?:forwarded-(?:for|host|server)|host|via|remote-ip|remote-addr|originating-IP))\s*:" \
@@ -181,7 +181,7 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx (?:\n|\r)+(?:\s|location|refresh|(?:set-)?c
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 
@@ -217,7 +217,7 @@ SecRule ARGS_GET "@rx [\n\r]" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HEADER_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:921015,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
@@ -279,7 +279,7 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HTTP_PARAMETER_POLLUTION-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/HTTP_PARAMETER_POLLUTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -44,7 +44,7 @@ SecRule REQUEST_URI_RAW|REQUEST_BODY|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XM
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 #
 # [ Decoded /../ Payloads ]
@@ -68,7 +68,7 @@ SecRule REQUEST_URI|REQUEST_BODY|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/*
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 #
 # -=[ OS File Access ]=-
@@ -96,7 +96,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 #
 # -=[ Restricted File Access ]=-
@@ -125,7 +125,7 @@ SecRule REQUEST_FILENAME "@pmf restricted-files.data" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 

--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -52,7 +52,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?):\/\/(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RFI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RFI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule QUERY_STRING|REQUEST_BODY "@rx (?i)(?:\binclude\s*\([^)]*|mosConfig_absolute_path|_CONF\[path\]|_SERVER\[DOCUMENT_ROOT\]|GALLERY_BASEDIR|path\[docroot\]|appserv_root|config\[root_dir\])=(?:file|ftps?|https?):\/\/" \
     "id:931110,\
@@ -73,7 +73,7 @@ SecRule QUERY_STRING|REQUEST_BODY "@rx (?i)(?:\binclude\s*\([^)]*|mosConfig_abso
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RFI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RFI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule ARGS "@rx ^(?i:file|ftps?|https?).*?\?+$" \
     "id:931120,\
@@ -94,7 +94,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?).*?\?+$" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RFI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RFI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 
@@ -121,13 +121,13 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?)://(.*)$" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
-    setvar:'tx.rfi_parameter_%{matched_var_name}=%{tx.1}',\
+    setvar:'tx.rfi_parameter_%{MATCHED_VAR_NAME}=%{tx.1}',\
     chain"
     SecRule TX:/rfi_parameter_.*/ "!@beginsWith %{request_headers.host}" \
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RFI-%{matched_var_name}=%{tx.1}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RFI-%{MATCHED_VAR_NAME}=%{tx.1}'"
 
 
 

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -118,7 +118,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Apache 2.2 requires configuration file lines to be under 8kB.
 # Therefore, some remaining commands have been split off to a separate rule.
@@ -156,7 +156,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 # [ Windows command injection ]
@@ -255,7 +255,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Apache 2.2 requires configuration file lines to be under 8kB.
 # Therefore, some remaining commands have been split off to a separate rule.
@@ -293,7 +293,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 # [ Windows PowerShell, cmdlets and options ]
@@ -330,7 +330,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 # [ Unix shell expressions ]
@@ -369,7 +369,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 # [ Windows FOR, IF commands ]
@@ -417,7 +417,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 # [ Unix direct remote command execution ]
@@ -467,7 +467,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 # [ Unix shell snippets ]
@@ -500,7 +500,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 # [ Shellshock vulnerability (CVE-2014-6271 and CVE-2014-7169) ]
@@ -534,7 +534,7 @@ SecRule REQUEST_HEADERS|REQUEST_LINE "@rx ^\(\s*\)\s+{" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
     "id:932171,\
@@ -558,7 +558,7 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -595,7 +595,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/FILE_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
@@ -653,7 +653,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 #
 # -=[ Bypass Rule 930120 (wildcard) ]=-
@@ -687,7 +687,7 @@ SecRule ARGS "@rx (?:/|\\\\)(?:[\?\*]+[a-z/\\\\]+|[a-z/\\\\]+[\?\*]+)" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:932018,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -63,7 +63,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 #
 # [ PHP Script Uploads ]
@@ -106,7 +106,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -135,7 +135,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -161,7 +161,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -199,7 +199,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -268,7 +268,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -317,7 +317,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -374,7 +374,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 
@@ -431,7 +431,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:933013,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
@@ -481,7 +481,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 
@@ -534,7 +534,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -577,7 +577,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -622,7 +622,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 # [ PHP Closing Tag Found ]
@@ -654,7 +654,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -57,7 +57,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -89,7 +89,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -120,7 +120,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -150,7 +150,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -181,7 +181,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -214,7 +214,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -244,7 +244,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -275,7 +275,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -307,7 +307,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:<.*[:]?vmlframe.*?[\s/+]*?src[\s/+]*=)" \
@@ -334,7 +334,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(j|(&#x?0*((74)|(4A)|(106)|(6A));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(a|(&#x?0*((65)|(41)|(97)|(61));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(v|(&#x?0*((86)|(56)|(118)|(76));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(a|(&#x?0*((65)|(41)|(97)|(61));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(s|(&#x?0*((83)|(53)|(115)|(73));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(c|(&#x?0*((67)|(43)|(99)|(63));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(r|(&#x?0*((82)|(52)|(114)|(72));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(i|(&#x?0*((73)|(49)|(105)|(69));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(p|(&#x?0*((80)|(50)|(112)|(70));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(t|(&#x?0*((84)|(54)|(116)|(74));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(:|(&((#x?0*((58)|(3A));?)|(colon;)))).)" \
@@ -361,7 +361,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(v|(&#x?0*((86)|(56)|(118)|(76));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(b|(&#x?0*((66)|(42)|(98)|(62));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(s|(&#x?0*((83)|(53)|(115)|(73));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(c|(&#x?0*((67)|(43)|(99)|(63));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(r|(&#x?0*((82)|(52)|(114)|(72));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(i|(&#x?0*((73)|(49)|(105)|(69));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(p|(&#x?0*((80)|(50)|(112)|(70));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(t|(&#x?0*((84)|(54)|(116)|(74));?))([\t]|(&((#x?0*(9|(13)|(10)|A|D);?)|(tab;)|(newline;))))*(:|(&((#x?0*((58)|(3A));?)|(colon;)))).)" \
@@ -388,7 +388,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<EMBED[\s/+].*?(?:src|type).*?=" \
@@ -415,7 +415,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx <[?]?import[\s\/+\S]*?implementation[\s\/+]*?=" \
@@ -442,7 +442,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:<META[\s/+].*?http-equiv[\s/+]*=[\s/+]*[\"\'`]?(((c|(&#x?0*((67)|(43)|(99)|(63));?)))|((r|(&#x?0*((82)|(52)|(114)|(72));?)))|((s|(&#x?0*((83)|(53)|(115)|(73));?)))))" \
@@ -469,7 +469,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:<META[\s/+].*?charset[\s/+]*=)" \
@@ -496,7 +496,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<LINK[\s/+].*?href[\s/+]*=" \
@@ -523,7 +523,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<BASE[\s/+].*?href[\s/+]*=" \
@@ -550,7 +550,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<APPLET[\s/+>]" \
@@ -577,7 +577,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<OBJECT[\s/+].*?(?:type|codetype|classid|code|data)[\s/+]*=" \
@@ -604,7 +604,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 #
 # https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet
@@ -636,7 +636,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 #
 # UTF-7 encoding XSS filter evasion for IE.
@@ -667,7 +667,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:941013,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
@@ -704,7 +704,7 @@ SecRule REQUEST_HEADERS:Referer "@detectXSS" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -736,7 +736,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 # Detect tags that are the most common direct HTML injection points.
@@ -821,7 +821,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\"\'][ ]*(([^a-z0-9~_:\' ])|(in)).*?(((l|(\\\\u006C))(o|(\\\\u006F))(c|(\\\\u0063))(a|(\\\\u0061))(t|(\\\\u0074))(i|(\\\\u0069))(o|(\\\\u006F))(n|(\\\\u006E)))|((n|(\\\\u006E))(a|(\\\\u0061))(m|(\\\\u006D))(e|(\\\\u0065)))|((o|(\\\\u006F))(n|(\\\\u006E))(e|(\\\\u0065))(r|(\\\\u0072))(r|(\\\\u0072))(o|(\\\\u006F))(r|(\\\\u0072)))|((v|(\\\\u0076))(a|(\\\\u0061))(l|(\\\\u006C))(u|(\\\\u0075))(e|(\\\\u0065))(O|(\\\\u004F))(f|(\\\\u0066)))).*?=)" \
     "id:941330,\
@@ -847,7 +847,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\"\'][ ]*(?:[^a-z0-9~_:\' ]|in).+?[.].+?=" \
     "id:941340,\
@@ -873,7 +873,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XSS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -63,7 +63,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.msg=%{rule.msg}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #
@@ -100,7 +100,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -126,7 +126,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942170.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -158,7 +158,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942190.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -190,7 +190,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ^(?i:-0000023456|4294967295|4294967296|2147483648|2147483647|0000012345|-2147483648|-2147483649|0000023456|3.0.00738585072007e-308|1e309)$" \
     "id:942220,\
@@ -214,7 +214,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:[\s()]case\s*?\()|(?:\)\s*?like\s*?\()|(?:having\s*?[^\s]+\s*?[^\w\s])|(?:if\s?\([\d\w]\s*?[=<>~]))" \
     "id:942230,\
@@ -238,7 +238,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942240.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -270,7 +270,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:merge.*?using\s*?\()|(execute\s*?immediate\s*?[\"'`])|(?:match\s*?[\w(),+-]+\s*?against\s*?\())" \
     "id:942250,\
@@ -294,7 +294,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:(union(.*?)select(.*?)from)))" \
     "id:942270,\
@@ -318,7 +318,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942280.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -350,7 +350,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:\[\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\]))" \
     "id:942290,\
@@ -374,7 +374,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942320.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -406,7 +406,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942350.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -438,7 +438,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # This rule has a stricter sibling: 942361.
 # The keywords 'alter' and 'union' led to false positives.
@@ -481,7 +481,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 
@@ -521,7 +521,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (^\s*[\"'`;]+|[\"'`]+\s*$)" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -558,7 +558,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:(?:^|\W)in[+\s]*\([\s\d\"]+[^()]*\)|\
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -596,7 +596,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i:([\s'\"`\(\)]*?)([\d\w]++)([\s'\"`\(\)]*
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -637,7 +637,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942180.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -670,7 +670,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942200.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -703,7 +703,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942210.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -736,7 +736,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942260.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -769,7 +769,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942300.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -802,7 +802,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942310.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -835,7 +835,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 #
 # -=[ SQL Injection Probings ]=-
@@ -876,7 +876,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942340.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -911,7 +911,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # This rule is a stricter sibling of 942360.
 # The keywords 'alter' and 'union' led to false positives.
@@ -948,7 +948,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # This rule is a sibling of 942330. See that rule for a description and overview.
 # Regexp generated from util/regexp-assemble/regexp-942370.data using Regexp::Assemble.
@@ -982,7 +982,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942380.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -1013,7 +1013,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942390.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -1044,7 +1044,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Regexp generated from util/regexp-assemble/regexp-942400.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -1078,7 +1078,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # The former rule id 942410 was split into three new rules: 942410, 942470, 942480
 #
@@ -1116,7 +1116,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 # The former rule id 942410 was split into three new rules: 942410, 942470, 942480
@@ -1153,7 +1153,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 # The former rule id 942410 was split into three new rules: 942410, 942470, 942480
@@ -1190,7 +1190,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -1232,7 +1232,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.msg=%{rule.msg}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -1280,7 +1280,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.msg=%{rule.msg}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -1309,7 +1309,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQL_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 
@@ -1353,7 +1353,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # This rule is a stricter sibling of 942330. See that rule for a description and overview.
 # Regexp generated from util/regexp-assemble/regexp-942490.data using Regexp::Assemble.
@@ -1387,7 +1387,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 #
 # [ SQL Injection Character Anomaly Usage ]
@@ -1431,7 +1431,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     setvar:'tx.anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.msg=%{rule.msg}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -1461,7 +1461,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     setvar:'tx.anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.msg=%{rule.msg}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -1494,7 +1494,7 @@ SecRule ARGS "@rx \W{4}" \
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
     setvar:'tx.msg=%{rule.msg}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:942017,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
@@ -1532,7 +1532,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     setvar:'tx.anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.msg=%{rule.msg}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #
@@ -1562,7 +1562,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     setvar:'tx.anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.msg=%{rule.msg}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RESTRICTED_SQLI_CHARS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 #

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -48,7 +48,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SESSION_FIXATION-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SESSION_FIXATION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsession|phpsessid|weblogicsession|session_id|session-id|cfid|cftoken|cfsid|jservsession|jwsession)$" \
@@ -77,7 +77,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
             "setvar:'tx.msg=%{rule.msg}',\
             setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
             setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-            setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SESSION_FIXATION-%{matched_var_name}=%{tx.0}'"
+            setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SESSION_FIXATION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp.net_sessionid|phpsession|phpsessid|weblogicsession|session_id|session-id|cfid|cftoken|cfsid|jservsession|jwsession)$" \
@@ -103,7 +103,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp.net_sessionid|phpsession
         "setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SESSION_FIXATION-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SESSION_FIXATION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -40,7 +40,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 # [ Java deserialization vulnerability/Apache Struts (CVE-2017-9805) ]
 # [ Java deserialization vulnerability/Oracle Weblogic (CVE-2017-10271) ]
@@ -70,11 +70,11 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
     chain"
-        SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* "@rx (?:unmarshaller|base64data|java\.)" \
-            "setvar:'tx.msg=%{rule.msg}',\
-            setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-            setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-            setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{matched_var}'"
+    SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* "@rx (?:unmarshaller|base64data|java\.)" \
+        "setvar:'tx.msg=%{rule.msg}',\
+        setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 # Magic bytes detected and payload included possibly RCE vulnerable classess detected and process execution methods detected
 # anomaly score set to critical as all conditions indicate the request try to perform RCE.
@@ -104,7 +104,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{matched_var}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@pmf java-classes.data" \
@@ -129,7 +129,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "phase:1,id:944013,nolog,pass,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
@@ -171,7 +171,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 # Detecting possibe base64 text to match encoded magic bytes \xac\xed\x00\x05 with padding encoded in base64 strings are rO0ABQ KztAAU Cs7QAF
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
@@ -196,7 +196,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)" \
@@ -221,7 +221,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@rx java\b.+(?:runtime|processbuilder)" \
@@ -246,7 +246,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 
@@ -285,7 +285,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{matched_var_name}=%{matched_var}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "phase:1,id:944017,nolog,pass,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -49,7 +49,7 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/INFO-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/INFO-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 
@@ -84,7 +84,7 @@ SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.error_anomaly_score}',\
-    setvar:'tx.%{rule.id}-AVAILABILITY/APP_NOT_AVAIL-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-AVAILABILITY/APP_NOT_AVAIL-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -62,7 +62,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951120,\
@@ -88,7 +88,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951130,\
@@ -114,7 +114,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951140,\
@@ -140,7 +140,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951150,\
@@ -166,7 +166,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule TX:sql_error_match "@eq 1" \
@@ -193,7 +193,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951170,\
@@ -219,7 +219,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951180,\
@@ -245,7 +245,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule TX:sql_error_match "@eq 1" \
@@ -272,7 +272,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule TX:sql_error_match "@eq 1" \
@@ -299,7 +299,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951210,\
@@ -325,7 +325,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951220,\
@@ -351,7 +351,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951230,\
@@ -377,7 +377,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951240,\
@@ -403,7 +403,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951250,\
@@ -429,7 +429,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951260,\
@@ -455,7 +455,7 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -44,7 +44,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-code-leakages.data" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/SOURCE_CODE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/SOURCE_CODE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 #
 # -=[ Java Errors ]=-
@@ -73,7 +73,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -44,7 +44,7 @@ SecRule RESPONSE_BODY "@pmf php-errors.data" \
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 #
 # -=[ PHP source code leakage ]=-
@@ -73,7 +73,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scan
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/SOURCE_CODE-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/SOURCE_CODE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 # Detect the presence of the PHP open tag "<?" or "<?php" in output.
 #
@@ -108,7 +108,7 @@ SecRule RESPONSE_BODY "@rx <\?(?!xml)" \
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/SOURCE_CODE-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/SOURCE_CODE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:953013,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -62,7 +62,7 @@ SecRule RESPONSE_BODY "@rx (?:Microsoft OLE DB Provider for SQL Server(?:<\/font
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.%{rule.id}-AVAILABILITY/APP_NOT_AVAIL-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-AVAILABILITY/APP_NOT_AVAIL-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 #
 # IIS Errors leakage
@@ -90,7 +90,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:A(?:DODB\.Command\b.{0,100}?\b(?:Application 
     setvar:'tx.msg=%{rule.msg}',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+    setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule RESPONSE_STATUS "!@rx ^404$" \
@@ -120,7 +120,7 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{matched_var_name}=%{tx.0}'"
+        setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/ERRORS-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 

--- a/util/debug/RESPONSE-981-DEBUG.conf
+++ b/util/debug/RESPONSE-981-DEBUG.conf
@@ -42,7 +42,7 @@ SecRule TX:/^\d*\-/ "." \
 	nolog,\
 	pass,\
 	setvar:tx.counter=+1,\
-	setenv:matched_rule-%{tx.counter}=%{matched_var_name},\
+	setenv:matched_rule-%{tx.counter}=%{MATCHED_VAR_NAME},\
 	setenv:anomaly_score=%{tx.anomaly_score},\
 	setenv:sql_injection_score=%{tx.sql_injection_score},\
 	setenv:xss_score=%{tx.xss_score},\

--- a/util/virtual-patching/arachni2modsec.pl
+++ b/util/virtual-patching/arachni2modsec.pl
@@ -1,11 +1,11 @@
 #!/opt/local/bin/perl -T
 
 #############################################
-# -=[ Virtual Patching Converter Script ]=- # 
+# -=[ Virtual Patching Converter Script ]=- #
 #       Converts arachni XML Ouput          #
-#    https://github.com/Zapotek/arachni     # 
+#    https://github.com/Zapotek/arachni     #
 #                                           #
-#           arachni2modsec.pl               # 
+#           arachni2modsec.pl               #
 #             Version: 1.0                  #
 #                                           #
 #            Copyright 2011                 #
@@ -26,7 +26,7 @@ use Acme::Comment type=>'C++', one_line=>1; #Block commenting, can be removed la
 
 #############
 # Variables #
-############# 
+#############
 
 # [Configuration Vars]
 my %param;
@@ -51,7 +51,7 @@ my $VULN_CLASS_LFI = "Path Traversal";
 my $VULN_CLASS_RFI = "Remote file inclusion";
 my $VULN_CLASS_HTTPRS = "Response splitting";
 
-# Only the vulnerabilities in this array will have 
+# Only the vulnerabilities in this array will have
 # rules generated for them.
 my @supported_vulns = ($VULN_CLASS_XSS, $VULN_CLASS_SQLI, $VULN_CLASS_BLIND_SQLI, $VULN_CLASS_LFI, $VULN_CLASS_RFI, $VULN_CLASS_HTTPRS);
 
@@ -74,7 +74,7 @@ my $num_attacks_noflag=0;
 
 #############
 #   Main    #
-############# 
+#############
 
 # Clean up env so perl doesn't complain
 # when trying to run the restart snort
@@ -95,7 +95,7 @@ $vuln_count = 0;
 foreach my $current_type (@type){
 	print "==================================================================================================\n";
 	print "Vulnerability[$vuln_count] -  Type: $current_type\n";
-	
+
 	if(exists {map { $_ => 1 } @supported_vulns}->{$current_type}){
 		parseData(to_string($current_type));
 	}else {
@@ -137,13 +137,13 @@ sub parseData
 	my $id = $vuln_count;
 
 	print "Found a $vuln_str vulnerability.\n";
-	
+
 	$current_vuln_xml = XML::Smart->new($all_vulnerabilities_filename);
 	$current_vuln_url = $url[$vuln_count];
 
 	print URL_LIST "$current_vuln_url\n";
 
-	# Validate url (need seperate sub?) 
+	# Validate url (need seperate sub?)
 	print "Validating URL: $current_vuln_url\n";
 	if(is_uri(to_string($current_vuln_url))){
 		print "URL is well-formed\n";
@@ -151,32 +151,32 @@ sub parseData
 	} else {
 		print "URL is NOT well-formed. Breaking Out of Rule Generation\n";
 		$num_bad_urls++;
-		
+
 		# Waits for keypress in test mode so you can
 		# see why the URL failed validation.
 		if($test_mode){
 			wait_for_keypress();
-		}	
+		}
 		return;
 	}
-	
+
 	$current_uricontent = get_uricontent($current_vuln_url);
-	
-	
+
+
 	# Only need param if XSS attack,SQLINJ,XPATH
 	# and maybe for HTTPRS, DT.
 	# NOT for PRL and DI
-	
+
 	if(($vuln_str ne $VULN_CLASS_PRL) && ($vuln_str ne $VULN_CLASS_DI)){
 		@current_params = $param[$vuln_count];
-		
+
 	}
-	if(($vuln_str ne $VULN_CLASS_PRL) && ($vuln_str ne $VULN_CLASS_DI)){	
+	if(($vuln_str ne $VULN_CLASS_PRL) && ($vuln_str ne $VULN_CLASS_DI)){
 			print "Current vulnerable Param(s): @current_params\n";
 	}
-	
-	generate_patch($vuln_str,$current_uricontent,@current_params);	
-	
+
+	generate_patch($vuln_str,$current_uricontent,@current_params);
+
 
 }
 
@@ -189,37 +189,37 @@ sub generate_patch
 
 	switch($type)
 	{
-		case ($VULN_CLASS_XSS) 
-		{	
+		case ($VULN_CLASS_XSS)
+		{
 			if($uricontent ne "" && @params){
 				foreach(@params){
 					if($_ ne ""){
 						# Check to see if each vulnerable parameter is valid
 						# then generate a rule using both uricontent and the
 						# parameter
-						$rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/XSS',tag:'WASCTC/WASC-8',tag:'WASCTC/WASC-22',tag:'OWASP_TOP_10/A2',tag:'OWASP_AppSensor/IE1',tag:'PCI/6.5.1',logdata:'%{matched_var_name}',severity:'2'\"\n\tSecRule \&TX:\'\/XSS.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.xss_score=+%{tx.critical_anomaly_score},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
-						
+						$rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/XSS',tag:'WASCTC/WASC-8',tag:'WASCTC/WASC-22',tag:'OWASP_TOP_10/A2',tag:'OWASP_AppSensor/IE1',tag:'PCI/6.5.1',logdata:'%{MATCHED_VAR_NAME}',severity:'2'\"\n\tSecRule \&TX:\'\/XSS.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.xss_score=+%{tx.critical_anomaly_score},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
+
 							print $MODSEC_RULES "#\n# Arachni Virtual Patch Details:\n# ID: $id\n# Type: $type\n# Vulnerable URL: $uricontent\n# Vulnerable Parameter: $_\n#\n".$rule."\n\n";
 							print "$VULN_CLASS_XSS (uricontent and param) rule successfully generated and saved in $modsec_rules_file.\n";
 							$num_rules_generated++;
 					}
 				}
-			} 
+			}
 		}
-		
+
 		case ($VULN_CLASS_SQLI)
 		{
-		
+
 			if($uricontent ne "" && @params){
 				foreach(@params){
 					if($_ ne ""){
-						$rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/SQL_INJECTION',tag:'WASCTC/WASC-19',tag:'OWASP_TOP_10/A1',tag:'OWASP_AppSensor/CIE1',tag:'PCI/6.5.2',logdata:'%{matched_var_name}',severity:'2'\"\n\tSecRule \&TX:\'\/SQL_INJECTION.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
-				
+						$rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/SQL_INJECTION',tag:'WASCTC/WASC-19',tag:'OWASP_TOP_10/A1',tag:'OWASP_AppSensor/CIE1',tag:'PCI/6.5.2',logdata:'%{MATCHED_VAR_NAME}',severity:'2'\"\n\tSecRule \&TX:\'\/SQL_INJECTION.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
+
 					print $MODSEC_RULES "#\n# Arachni Virtual Patch Details:\n# ID: $id\n# Type: $type\n# Vulnerable URL: $uricontent\n# Vulnerable Parameter: $_\n#\n".$rule."\n\n";
                                         print "$VULN_CLASS_SQLI (uricontent and param) rule successfully generated and saved in $modsec_rules_file.\n";
                                         $num_rules_generated++;
-		
-										
+
+
 					}
 				}
 			}
@@ -231,7 +231,7 @@ sub generate_patch
                         if($uricontent ne "" && @params){
                                 foreach(@params){
                                         if($_ ne ""){
-                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/SQL_INJECTION',tag:'WASCTC/WASC-19',tag:'OWASP_TOP_10/A1',tag:'OWASP_AppSensor/CIE1',tag:'PCI/6.5.2',logdata:'%{matched_var_name}',severity:'2'\"\n\tSecRule \&TX:\'\/SQL_INJECTION.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
+                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/SQL_INJECTION',tag:'WASCTC/WASC-19',tag:'OWASP_TOP_10/A1',tag:'OWASP_AppSensor/CIE1',tag:'PCI/6.5.2',logdata:'%{MATCHED_VAR_NAME}',severity:'2'\"\n\tSecRule \&TX:\'\/SQL_INJECTION.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
 
                                         print $MODSEC_RULES "#\n# Arachni Virtual Patch Details:\n# ID: $id\n# Type: $type\n# Vulnerable URL: $uricontent\n# Vulnerable Parameter: $_\n#\n".$rule."\n\n";
                                         print "$VULN_CLASS_SQLI (uricontent and param) rule successfully generated and saved in $modsec_rules_file.\n";
@@ -248,7 +248,7 @@ sub generate_patch
 			if($uricontent ne "" && @params){
 				foreach(@params){
 					if($_ ne ""){
-                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/LFI',tag:'WASCTC/WASC-33',logdata:'%{matched_var_name}',severity:'2'\"\n\tSecRule \&TX:\'\/LFI.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
+                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/LFI',tag:'WASCTC/WASC-33',logdata:'%{MATCHED_VAR_NAME}',severity:'2'\"\n\tSecRule \&TX:\'\/LFI.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
 
                                         print $MODSEC_RULES "#\n# Arachni Virtual Patch Details:\n# ID: $id\n# Type: $type\n# Vulnerable URL: $uricontent\n# Vulnerable Parameter: $_\n#\n".$rule."\n\n";
                                         print "$VULN_CLASS_LFI (uricontent and param) rule successfully generated and saved in $modsec_rules_file.\n";
@@ -265,7 +265,7 @@ sub generate_patch
                         if($uricontent ne "" && @params){
                                 foreach(@params){
                                         if($_ ne ""){
-                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/RFI',tag:'WASCTC/WASC-05',logdata:'%{matched_var_name}',severity:'2'\"\n\tSecRule \&TX:\'\/RFI.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
+                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/RFI',tag:'WASCTC/WASC-05',logdata:'%{MATCHED_VAR_NAME}',severity:'2'\"\n\tSecRule \&TX:\'\/RFI.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
 
                                         print $MODSEC_RULES "#\n# Arachni Virtual Patch Details:\n# ID: $id\n# Type: $type\n# Vulnerable URL: $uricontent\n# Vulnerable Parameter: $_\n#\n".$rule."\n\n";
                                         print "$VULN_CLASS_LFI (uricontent and param) rule successfully generated and saved in $modsec_rules_file.\n";
@@ -282,7 +282,7 @@ sub generate_patch
                         if($uricontent ne "" && @params){
                                 foreach(@params){
                                         if($_ ne ""){
-                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/RESPONSE_SPLITTING',tag:'WASCTC/WASC-25',logdata:'%{matched_var_name}',severity:'2'\"\n\tSecRule \&TX:\'\/RESPONSE_SPLITTING.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
+                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/RESPONSE_SPLITTING',tag:'WASCTC/WASC-25',logdata:'%{MATCHED_VAR_NAME}',severity:'2'\"\n\tSecRule \&TX:\'\/RESPONSE_SPLITTING.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
 
                                         print $MODSEC_RULES "#\n# Arachni Virtual Patch Details:\n# ID: $id\n# Type: $type\n# Vulnerable URL: $uricontent\n# Vulnerable Parameter: $_\n#\n".$rule."\n\n";
                                         print "$VULN_CLASS_RFI (uricontent and param) rule successfully generated and saved in $modsec_rules_file.\n";
@@ -306,8 +306,8 @@ sub get_uricontent
 	# http://.../
 	$url =~ /$regex/;
 	substr($url,index($url,$&),length($&)) = "";
-	
-	# If the URL contains a php or cgi query with 
+
+	# If the URL contains a php or cgi query with
 	# one or more params and values, trim those out.
 	# Trim from the question mark to the end.
 	if($url =~ /\?/){

--- a/util/virtual-patching/zap2modsec.pl
+++ b/util/virtual-patching/zap2modsec.pl
@@ -26,7 +26,7 @@ use Acme::Comment type=>'C++', one_line=>1; #Block commenting, can be removed la
 
 #############
 # Variables #
-############# 
+#############
 
 # [Configuration Vars]
 my %param;
@@ -51,7 +51,7 @@ my $VULN_CLASS_LFI = "Path Traversal";
 my $VULN_CLASS_RFI = "Remote File Inclusion";
 my $VULN_CLASS_HTTPRS = "HTTP Response Splitting";
 
-# Only the vulnerabilities in this array will have 
+# Only the vulnerabilities in this array will have
 # rules generated for them.
 my @supported_vulns = ($VULN_CLASS_XSS, $VULN_CLASS_SQLI, $VULN_CLASS_SQLI_FINGERPRINT, $VULN_CLASS_LFI, $VULN_CLASS_RFI, $VULN_CLASS_HTTPRS);
 
@@ -74,7 +74,7 @@ my $num_attacks_noflag=0;
 
 #############
 #   Main    #
-############# 
+#############
 
 # Clean up env so perl doesn't complain
 # when trying to run the restart snort
@@ -95,7 +95,7 @@ $vuln_count = 0;
 foreach my $current_type (@type){
 	print "==================================================================================================\n";
 	print "Vulnerability[$vuln_count] -  Type: $current_type\n";
-	
+
 	if(exists {map { $_ => 1 } @supported_vulns}->{$current_type}){
 		parseData(to_string($current_type));
 	}else {
@@ -137,13 +137,13 @@ sub parseData
 	my $id = $vuln_count;
 
 	print "Found a $vuln_str vulnerability.\n";
-	
+
 	$current_vuln_xml = XML::Smart->new($all_vulnerabilities_filename);
 	$current_vuln_url = $url[$vuln_count];
 
 	print URL_LIST "$current_vuln_url\n";
 
-	# Validate url (need seperate sub?) 
+	# Validate url (need seperate sub?)
 	print "Validating URL: $current_vuln_url\n";
 	if(is_uri(to_string($current_vuln_url))){
 		print "URL is well-formed\n";
@@ -151,32 +151,32 @@ sub parseData
 	} else {
 		print "URL is NOT well-formed. Breaking Out of Rule Generation\n";
 		$num_bad_urls++;
-		
+
 		# Waits for keypress in test mode so you can
 		# see why the URL failed validation.
 		if($test_mode){
 			wait_for_keypress();
-		}	
+		}
 		return;
 	}
-	
+
 	$current_uricontent = get_uricontent($current_vuln_url);
-	
-	
+
+
 	# Only need param if XSS attack,SQLINJ,XPATH
 	# and maybe for HTTPRS, DT.
 	# NOT for PRL and DI
-	
+
 	if(($vuln_str ne $VULN_CLASS_PRL) && ($vuln_str ne $VULN_CLASS_DI)){
 		@current_params = $param[$vuln_count];
-		
+
 	}
-	if(($vuln_str ne $VULN_CLASS_PRL) && ($vuln_str ne $VULN_CLASS_DI)){	
+	if(($vuln_str ne $VULN_CLASS_PRL) && ($vuln_str ne $VULN_CLASS_DI)){
 			print "Current vulnerable Param(s): @current_params\n";
 	}
-	
-	generate_patch($vuln_str,$current_uricontent,@current_params);	
-	
+
+	generate_patch($vuln_str,$current_uricontent,@current_params);
+
 
 }
 
@@ -189,37 +189,37 @@ sub generate_patch
 
 	switch($type)
 	{
-		case ($VULN_CLASS_XSS) 
-		{	
+		case ($VULN_CLASS_XSS)
+		{
 			if($uricontent ne "" && @params){
 				foreach(@params){
 					if($_ ne ""){
 						# Check to see if each vulnerable parameter is valid
 						# then generate a rule using both uricontent and the
 						# parameter
-						$rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/XSS',tag:'WASCTC/WASC-8',tag:'WASCTC/WASC-22',tag:'OWASP_TOP_10/A2',tag:'OWASP_AppSensor/IE1',tag:'PCI/6.5.1',logdata:'%{matched_var_name}',severity:'2'\"\n\tSecRule \&TX:\'\/XSS.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.xss_score=+%{tx.critical_anomaly_score},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
-						
+						$rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/XSS',tag:'WASCTC/WASC-8',tag:'WASCTC/WASC-22',tag:'OWASP_TOP_10/A2',tag:'OWASP_AppSensor/IE1',tag:'PCI/6.5.1',logdata:'%{MATCHED_VAR_NAME}',severity:'2'\"\n\tSecRule \&TX:\'\/XSS.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.xss_score=+%{tx.critical_anomaly_score},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
+
 							print $MODSEC_RULES "#\n# OWASP ZAP Virtual Patch Details:\n# ID: $id\n# Type: $type\n# Vulnerable URL: $uricontent\n# Vulnerable Parameter: $_\n#\n".$rule."\n\n";
 							print "$VULN_CLASS_XSS (uricontent and param) rule successfully generated and saved in $modsec_rules_file.\n";
 							$num_rules_generated++;
 					}
 				}
-			} 
+			}
 		}
-		
+
 		case ($VULN_CLASS_SQLI)
 		{
-		
+
 			if($uricontent ne "" && @params){
 				foreach(@params){
 					if($_ ne ""){
-						$rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/SQL_INJECTION',tag:'WASCTC/WASC-19',tag:'OWASP_TOP_10/A1',tag:'OWASP_AppSensor/CIE1',tag:'PCI/6.5.2',logdata:'%{matched_var_name}',severity:'2'\"\n\tSecRule \&TX:\'\/SQL_INJECTION.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
-				
+						$rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/SQL_INJECTION',tag:'WASCTC/WASC-19',tag:'OWASP_TOP_10/A1',tag:'OWASP_AppSensor/CIE1',tag:'PCI/6.5.2',logdata:'%{MATCHED_VAR_NAME}',severity:'2'\"\n\tSecRule \&TX:\'\/SQL_INJECTION.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
+
 					print $MODSEC_RULES "#\n# OWASP ZAP Virtual Patch Details:\n# ID: $id\n# Type: $type\n# Vulnerable URL: $uricontent\n# Vulnerable Parameter: $_\n#\n".$rule."\n\n";
                                         print "$VULN_CLASS_SQLI (uricontent and param) rule successfully generated and saved in $modsec_rules_file.\n";
                                         $num_rules_generated++;
-		
-										
+
+
 					}
 				}
 			}
@@ -231,7 +231,7 @@ sub generate_patch
                         if($uricontent ne "" && @params){
                                 foreach(@params){
                                         if($_ ne ""){
-                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/SQL_INJECTION',tag:'WASCTC/WASC-19',tag:'OWASP_TOP_10/A1',tag:'OWASP_AppSensor/CIE1',tag:'PCI/6.5.2',logdata:'%{matched_var_name}',severity:'2'\"\n\tSecRule \&TX:\'\/SQL_INJECTION.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
+                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/SQL_INJECTION',tag:'WASCTC/WASC-19',tag:'OWASP_TOP_10/A1',tag:'OWASP_AppSensor/CIE1',tag:'PCI/6.5.2',logdata:'%{MATCHED_VAR_NAME}',severity:'2'\"\n\tSecRule \&TX:\'\/SQL_INJECTION.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.sql_injection_score=+%{tx.critical_anomaly_score},setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
 
                                         print $MODSEC_RULES "#\n# OWASP ZAP Virtual Patch Details:\n# ID: $id\n# Type: $type\n# Vulnerable URL: $uricontent\n# Vulnerable Parameter: $_\n#\n".$rule."\n\n";
                                         print "$VULN_CLASS_SQLI (uricontent and param) rule successfully generated and saved in $modsec_rules_file.\n";
@@ -248,7 +248,7 @@ sub generate_patch
 			if($uricontent ne "" && @params){
 				foreach(@params){
 					if($_ ne ""){
-                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/LFI',tag:'WASCTC/WASC-33',logdata:'%{matched_var_name}',severity:'2'\"\n\tSecRule \&TX:\'\/LFI.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
+                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/LFI',tag:'WASCTC/WASC-33',logdata:'%{MATCHED_VAR_NAME}',severity:'2'\"\n\tSecRule \&TX:\'\/LFI.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
 
                                         print $MODSEC_RULES "#\n# OWASP ZAP Virtual Patch Details:\n# ID: $id\n# Type: $type\n# Vulnerable URL: $uricontent\n# Vulnerable Parameter: $_\n#\n".$rule."\n\n";
                                         print "$VULN_CLASS_LFI (uricontent and param) rule successfully generated and saved in $modsec_rules_file.\n";
@@ -265,7 +265,7 @@ sub generate_patch
                         if($uricontent ne "" && @params){
                                 foreach(@params){
                                         if($_ ne ""){
-                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/RFI',tag:'WASCTC/WASC-05',logdata:'%{matched_var_name}',severity:'2'\"\n\tSecRule \&TX:\'\/RFI.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
+                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/RFI',tag:'WASCTC/WASC-05',logdata:'%{MATCHED_VAR_NAME}',severity:'2'\"\n\tSecRule \&TX:\'\/RFI.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
 
                                         print $MODSEC_RULES "#\n# OWASP ZAP Virtual Patch Details:\n# ID: $id\n# Type: $type\n# Vulnerable URL: $uricontent\n# Vulnerable Parameter: $_\n#\n".$rule."\n\n";
                                         print "$VULN_CLASS_LFI (uricontent and param) rule successfully generated and saved in $modsec_rules_file.\n";
@@ -282,7 +282,7 @@ sub generate_patch
                         if($uricontent ne "" && @params){
                                 foreach(@params){
                                         if($_ ne ""){
-                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/RESPONSE_SPLITTING',tag:'WASCTC/WASC-25',logdata:'%{matched_var_name}',severity:'2'\"\n\tSecRule \&TX:\'\/RESPONSE_SPLITTING.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
+                                                $rule = "SecRule REQUEST_FILENAME \"$uricontent\" \"chain,phase:2,t:none,block,msg:'Virtual Patch for $type',id:'$id',tag:'WEB_ATTACK/RESPONSE_SPLITTING',tag:'WASCTC/WASC-25',logdata:'%{MATCHED_VAR_NAME}',severity:'2'\"\n\tSecRule \&TX:\'\/RESPONSE_SPLITTING.*ARGS:$_\/\' \"\@gt 0\" \"setvar:'tx.msg=%{rule.msg}',setvar:tx.anomaly_score=+%{tx.critical_anomaly_score}\"";
 
                                         print $MODSEC_RULES "#\n# OWASP ZAP Virtual Patch Details:\n# ID: $id\n# Type: $type\n# Vulnerable URL: $uricontent\n# Vulnerable Parameter: $_\n#\n".$rule."\n\n";
                                         print "$VULN_CLASS_RFI (uricontent and param) rule successfully generated and saved in $modsec_rules_file.\n";
@@ -306,8 +306,8 @@ sub get_uricontent
 	# http://.../
 	$url =~ /$regex/;
 	substr($url,index($url,$&),length($&)) = "";
-	
-	# If the URL contains a php or cgi query with 
+
+	# If the URL contains a php or cgi query with
 	# one or more params and values, trim those out.
 	# Trim from the question mark to the end.
 	if($url =~ /\?/){


### PR DESCRIPTION
This is PR 1187 from Victor, backported to 3.1/dev.

The process for generating was similar to the one for v3.2/dev. Applied patch with `--reject`, and solved the `*.rej` files.
