### PR TITLE
add content-type application/csp-report

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -397,7 +397,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|text/plain'"
+#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|text/plain'"
 
 # Content-Types charsets that a client is allowed to send in a request.
 # Default: utf-8|iso-8859-1|iso-8859-15|windows-1252

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -168,7 +168,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|text/plain'"
+    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|text/plain'"
 
 # Default HTTP policy: allowed_request_content_type_charset (rule 900270)
 SecRule &TX:allowed_request_content_type_charset "@eq 0" \


### PR DESCRIPTION
When `Content-Security-Policy` and `Content-Security-Policy-Report-Only` headers are configured with a self-referenced report URI (ex. `report-uri /csp-report.php`) the browser sends a POST request with `Content-Type`: `application/csp-report` that is blocked by CRS rule **920420: Request content type is not allowed by policy**.

I've added the `application/csp-report` in:
`crs-setup.conf.example` on rule **900200**
`rules/REQUEST-901-INITIALIZATION.conf` on rule **901162**

I'm writing a set of rules in order to parse the report-uri request and create a ModSecurity log when a CSP violation occurs. Let me know if this could be useful or not.