### PR TITLE
add content-type application/xss-auditor-report

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -397,7 +397,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|text/plain'"
+#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
 
 # Content-Types charsets that a client is allowed to send in a request.
 # Default: utf-8|iso-8859-1|iso-8859-15|windows-1252

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -168,7 +168,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|text/plain'"
+    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
 
 # Default HTTP policy: allowed_request_content_type_charset (rule 900270)
 SecRule &TX:allowed_request_content_type_charset "@eq 0" \


### PR DESCRIPTION
As done for CSP (https://github.com/SpiderLabs/owasp-modsecurity-crs/pull/1242) When `X-Xss-Protection` header is configured with a self-referenced report URI (ex. report-uri /xss-report.php) the browser sends a POST request with `Content-Type: application/xss-auditor-report` that is blocked by CRS rule **920420: Request content type is not allowed by policy**.

I've added the `application/xss-auditor-report` in:
*crs-setup.conf.example* on **rule 900200**
*rules/REQUEST-901-INITIALIZATION.conf* on **rule 901162**