### PR TITLE
Add CVE numbers for Apache Struts vulnerabilities to comments in rules

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -860,6 +860,9 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
 #
 # Limit argument value length
 #
+# This rule is also triggered by an Apache Struts Remote Code Execution exploit:
+# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324]
+#
 SecRule &TX:ARG_LENGTH "@eq 1" \
     "id:920370,\
     phase:2,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -861,7 +861,7 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
 # Limit argument value length
 #
 # This rule is also triggered by an Apache Struts Remote Code Execution exploit:
-# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324]
+# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324 ]
 #
 SecRule &TX:ARG_LENGTH "@eq 1" \
     "id:920370,\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -31,6 +31,9 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:932012,phase:2,pass,nolog,skipAf
 # The vulnerability exists when an application executes a shell command
 # without proper input escaping/validation.
 #
+# This rule is also triggered by an Oracle WebLogic Remote Command Execution exploit:
+# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
+#
 # To prevent false positives, we look for a 'starting sequence' that
 # precedes a command in shell syntax, such as: ; | & $( ` <( >(
 # Anatomy of the regexp with examples of patterns caught:
@@ -261,6 +264,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Therefore, some remaining commands have been split off to a separate rule.
 # For explanation of this rule, see rule 932110.
 #
+# This rule is also triggered by an Oracle WebLogic Remote Command Execution exploit:
+# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
+#
 # To rebuild the word list regexp:
 #   cd util/regexp-assemble
 #   cat regexp-932115.txt | ./regexp-cmdline.py windows | ./regexp-assemble.pl
@@ -429,6 +435,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # command string is appended (injected) to a regular parameter, and then
 # passed to a shell unescaped.
 #
+# This rule is also triggered by an Oracle WebLogic Remote Command Execution exploit:
+# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
+#
 # Due to a higher risk of false positives, the following changes have been
 # made relative to rule 932100:
 # 1) the set of commands is smaller
@@ -478,6 +487,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # have been added here with their full path, in order to catch some
 # cases where the full path is sent.
 #
+# This rule is also triggered by an Apache Struts Remote Code Execution exploit:
+# [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627]
+#
+# This rule is also triggered by an Oracle WebLogic Remote Command Execution exploit:
+# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
+
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmf unix-shell.data" \
     "id:932160,\
     phase:2,\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -32,7 +32,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:932012,phase:2,pass,nolog,skipAf
 # without proper input escaping/validation.
 #
 # This rule is also triggered by an Oracle WebLogic Remote Command Execution exploit:
-# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
+# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458 ]
 #
 # To prevent false positives, we look for a 'starting sequence' that
 # precedes a command in shell syntax, such as: ; | & $( ` <( >(
@@ -265,7 +265,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # For explanation of this rule, see rule 932110.
 #
 # This rule is also triggered by an Oracle WebLogic Remote Command Execution exploit:
-# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
+# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458 ]
 #
 # To rebuild the word list regexp:
 #   cd util/regexp-assemble
@@ -436,7 +436,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # passed to a shell unescaped.
 #
 # This rule is also triggered by an Oracle WebLogic Remote Command Execution exploit:
-# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
+# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458 ]
 #
 # Due to a higher risk of false positives, the following changes have been
 # made relative to rule 932100:
@@ -488,10 +488,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # cases where the full path is sent.
 #
 # This rule is also triggered by an Apache Struts Remote Code Execution exploit:
-# [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627]
+# [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627 ]
 #
 # This rule is also triggered by an Oracle WebLogic Remote Command Execution exploit:
-# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
+# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458 ]
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmf unix-shell.data" \
     "id:932160,\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -325,7 +325,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 #   system #comment \n (...)
 #
 # This rule is also triggered by an Apache Struts Remote Code Execution exploit:
-# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324]
+# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324 ]
 #
 # Regexp generated from util/regexp-assemble/regexp-933160.data using Regexp::Assemble.
 # See http://blog.modsecurity.org/2007/06/optimizing-regu.html for usage.

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -324,6 +324,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 #   system //comment \n (...)
 #   system #comment \n (...)
 #
+# This rule is also triggered by an Apache Struts Remote Code Execution exploit:
+# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324]
+#
 # Regexp generated from util/regexp-assemble/regexp-933160.data using Regexp::Assemble.
 # See http://blog.modsecurity.org/2007/06/optimizing-regu.html for usage.
 # Note that after assemble, PHP function syntax pre/postfix is added to the Regexp::Assemble

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -17,9 +17,16 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "phase:2,id:944012,nolog,pass,skipAf
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
 #
+# This rule is also triggered by an Apache Struts exploit:
 # [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638]
+#
+# This rule is also triggered by an Apache Struts Remote Code Execution exploit:
 # [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324]
+#
+# This rule is also triggered by an Apache Struts Remote Code Execution exploit:
 # [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627]
+#
+# This rule is also triggered by an Oracle WebLogic Remote Command Execution exploit:
 # [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
 #
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
@@ -47,8 +54,13 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
+# This rule is also triggered by an Apache Struts exploit:
 # [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638]
+#
+# This rule is also triggered by an Apache Struts Remote Code Execution exploit:
 # [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324]
+#
+# This rule is also triggered by an Apache Struts Remote Code Execution exploit:
 # [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627]
 #
 # [ Java deserialization vulnerability/Apache Struts (CVE-2017-9805) ]
@@ -115,12 +127,19 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
+# This rule is also triggered by an Apache Struts exploit:
 # [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/mazen160/struts-pwn]
 # [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638]
+#
+# This rule is also triggered by an Apache Struts Remote Code Execution exploit:
 # [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324]
+#
+# This rule is also triggered by an Apache Struts Remote Code Execution exploit:
 # [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627]
+#
+# This rule is also triggered by an Oracle WebLogic Remote Command Execution exploit:
 # [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
-
+#
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@pmf java-classes.data" \
     "id:944130,\

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -18,16 +18,16 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "phase:2,id:944012,nolog,pass,skipAf
 # -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
 #
 # This rule is also triggered by an Apache Struts exploit:
-# [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638]
+# [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638 ]
 #
 # This rule is also triggered by an Apache Struts Remote Code Execution exploit:
-# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324]
+# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324 ]
 #
 # This rule is also triggered by an Apache Struts Remote Code Execution exploit:
-# [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627]
+# [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627 ]
 #
 # This rule is also triggered by an Oracle WebLogic Remote Command Execution exploit:
-# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
+# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458 ]
 #
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@rx java\.lang\.(?:runtime|processbuilder)" \
@@ -55,13 +55,13 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 # This rule is also triggered by an Apache Struts exploit:
-# [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638]
+# [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638 ]
 #
 # This rule is also triggered by an Apache Struts Remote Code Execution exploit:
-# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324]
+# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324 ]
 #
 # This rule is also triggered by an Apache Struts Remote Code Execution exploit:
-# [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627]
+# [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627 ]
 #
 # [ Java deserialization vulnerability/Apache Struts (CVE-2017-9805) ]
 # [ Java deserialization vulnerability/Oracle Weblogic (CVE-2017-10271) ]
@@ -128,17 +128,17 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
         setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 # This rule is also triggered by an Apache Struts exploit:
-# [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/mazen160/struts-pwn]
-# [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638]
+# [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/mazen160/struts-pwn ]
+# [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638 ]
 #
 # This rule is also triggered by an Apache Struts Remote Code Execution exploit:
-# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324]
+# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324 ]
 #
 # This rule is also triggered by an Apache Struts Remote Code Execution exploit:
-# [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627]
+# [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627 ]
 #
 # This rule is also triggered by an Oracle WebLogic Remote Command Execution exploit:
-# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
+# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458 ]
 #
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@pmf java-classes.data" \

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -17,6 +17,11 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "phase:2,id:944012,nolog,pass,skipAf
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
 #
+# [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638]
+# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324]
+# [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627]
+# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
+#
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@rx java\.lang\.(?:runtime|processbuilder)" \
     "id:944100,\
@@ -42,6 +47,10 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
+# [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638]
+# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324]
+# [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627]
+#
 # [ Java deserialization vulnerability/Apache Struts (CVE-2017-9805) ]
 # [ Java deserialization vulnerability/Oracle Weblogic (CVE-2017-10271) ]
 #
@@ -105,6 +114,12 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
         setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/mazen160/struts-pwn]
+# [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638]
+# [ Apache Struts vulnerability CVE-2017-9791 - Exploit tested: https://www.exploit-db.com/exploits/42324]
+# [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627]
+# [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458]
 
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@pmf java-classes.data" \


### PR DESCRIPTION
This PR adds CVE numbers of Apache Struts and one WebLogic vulnerabilities to comments of rules in 
* REQUEST-920-PROTOCOL-ENFORCEMENT.conf
* REQUEST-932-APPLICATION-ATTACK-RCE.conf
* REQUEST-933-APPLICATION-ATTACK-PHP.conf
* REQUEST-944-APPLICATION-ATTACK-JAVA.conf

It's just comments, not a code change.

I have tested the available exploits and proposed this change in issue #1061.
Comments are now short. But they could be enhanced with "Matched data", for example. Let me know!