### PR TITLE
PHP: move get_defined_functions() and friends into PL1

### DIFF
--- a/rules/php-function-names-933150.data
+++ b/rules/php-function-names-933150.data
@@ -10,6 +10,11 @@ convert_uudecode
 file_get_contents
 file_put_contents
 fsockopen
+get_class_methods
+get_class_vars
+get_defined_constants
+get_defined_functions
+get_defined_vars
 gzdecode
 gzinflate
 gzuncompress

--- a/rules/php-function-names-933151.data
+++ b/rules/php-function-names-933151.data
@@ -218,14 +218,9 @@ gd_info
 get_browser
 get_called_class
 get_class
-get_class_methods
-get_class_vars
 get_declared_classes
 get_declared_interfaces
 get_declared_traits
-get_defined_constants
-get_defined_functions
-get_defined_vars
 get_extension_funcs
 get_headers
 get_html_translation_table

--- a/util/regression-tests/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933150.yaml
+++ b/util/regression-tests/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933150.yaml
@@ -5,7 +5,7 @@
     enabled: true
     name: 933150.yaml
   tests:
-  - 
+  -
     test_title: 933150-1
     desc: pmf
     stages:
@@ -19,7 +19,7 @@
           uri: /base64_decode
         output:
           log_contains: id "933150"
-  - 
+  -
     test_title: 933150-2
     desc: base64_decode
     stages:
@@ -33,7 +33,7 @@
           uri: /base64_decode
         output:
           log_contains: id "933150"
-  - 
+  -
     test_title: 933150-3
     desc: base64_decode
     stages:
@@ -47,7 +47,7 @@
           uri: /?base64_deCOde
         output:
           log_contains: id "933150"
-  - 
+  -
     test_title: 933150-4
     desc: base64_decode
     stages:
@@ -61,7 +61,7 @@
           uri: /?foo=bzdecomprEss
         output:
           log_contains: id "933150"
-  - 
+  -
     test_title: 933150-5
     desc: base64_decode
     stages:
@@ -75,7 +75,7 @@
           uri: /?foo=FOOcall_user_func
         output:
           log_contains: id "933150"
-  - 
+  -
     test_title: 933150-6
     desc: fsockopen
     stages:
@@ -89,7 +89,7 @@
           uri: /?foo=FOOcall_user_func
         output:
           log_contains: id "933150"
-  - 
+  -
     test_title: 933150-7
     desc: gzdecode
     stages:
@@ -103,7 +103,7 @@
           uri: /?foo=FOOcall_user_func
         output:
           log_contains: id "933150"
-  - 
+  -
     test_title: 933150-8
     desc: GzInFlAtE
     stages:
@@ -117,7 +117,7 @@
           uri: /?foo=FOOcall_user_func
         output:
           log_contains: id "933150"
-  - 
+  -
     test_title: 933150-9
     desc: GzInFlAtE
     stages:
@@ -131,7 +131,7 @@
           uri: /?foo=FOOcall_user_func
         output:
           log_contains: id "933150"
-  - 
+  -
     test_title: 933150-10
     desc: GzInFlAtE
     stages:
@@ -145,7 +145,7 @@
           uri: /?I%20don%27t%20like%20gzuncompress
         output:
           log_contains: id "933150"
-  - 
+  -
     test_title: 933150-11
     desc: GzInFlAtE
     stages:
@@ -159,7 +159,7 @@
           uri: /?bar=pfsockopen%28%27foo%27%2C%2025%29
         output:
           log_contains: id "933150"
-  - 
+  -
     test_title: 933150-12
     desc: posix_getpwuiD
     stages:
@@ -173,7 +173,7 @@
           uri: /?bar=pfsockopen%28%27foo%27%2C%2025%29
         output:
           log_contains: id "933150"
-  - 
+  -
     test_title: 933150-13
     desc: posix_getpwuiD
     stages:
@@ -189,13 +189,45 @@
           uri: /
         output:
           log_contains: id "933150"
-  - 
+  -
     test_title: 933150-14
     desc: ZlIb_DeCoDe
     stages:
     - stage:
         input:
           data: Shell%5fexec=bla
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          method: POST
+          port: 80
+          uri: /
+        output:
+          log_contains: id "933150"
+  -
+    test_title: 933150-15
+    desc: get_defined_functions
+    stages:
+    - stage:
+        input:
+          data: foo=get_defined_functions%28%29%5B0%5D
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          method: POST
+          port: 80
+          uri: /
+        output:
+          log_contains: id "933150"
+  -
+    test_title: 933150-16
+    desc: get_defined_vars
+    stages:
+    - stage:
+        input:
+          data: foo=get_defined_vars%28%29%5B0%5D
           dest_addr: 127.0.0.1
           headers:
             Host: localhost


### PR DESCRIPTION
An interesting PHP code injection WAF bypass was posted at: https://www.secjuice.com/php-rce-bypass-filters-sanitization-waf/

In this post, indexing into `get_defined_functions()` is used to access blacklisted PHP functions.

As `get_defined_functions` and related PHP function names should be highly uncommon in normal traffic, we will block their names by default in pmf rule 933150.