### PR TITLE
933180: fix tests which were doing nothing

### DIFF
--- a/util/regression-tests/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933180.yaml
+++ b/util/regression-tests/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933180.yaml
@@ -5,7 +5,7 @@
     enabled: true
     name: 933180.yaml
   tests:
-  - 
+  -
     test_title: 933180-1
     desc: PHP variable functions
     stages:
@@ -19,7 +19,7 @@
           uri: /?x=
         output:
           no_log_contains: id "933180"
-  - 
+  -
     test_title: 933180-2
     desc: $a(1)
     stages:
@@ -30,10 +30,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'foo=%24a%281%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-3
     desc: $$b(2)
     stages:
@@ -44,10 +45,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'foo=%24%24b%282%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-4
     desc: $_(3)
     stages:
@@ -58,10 +60,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'foo=%24_%283%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-5
     desc: '@$__[o](4)'
     stages:
@@ -72,10 +75,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'foo=%40%24__%5Bo%5D%284%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-6
     desc: $__['o'](5)
     stages:
@@ -86,10 +90,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'foo=%24__%5B%27o%27%5D%285%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-7
     desc: $__[@o](6)
     stages:
@@ -100,10 +105,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'foo=%24__%5B%40o%5D%286%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-8
     desc: $__[$_[1]](7)
     stages:
@@ -114,10 +120,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'foo=%24__%5B%24_%5B1%5D%5D%287%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-9
     desc: $__[@$c](8)
     stages:
@@ -128,10 +135,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'foo=%24__%5B%40%24c%5D%288%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-10
     desc: $d['o'](9)
     stages:
@@ -142,10 +150,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: '%24d%5B%27o%27%5D%289%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-11
     desc: ${@a}(10)
     stages:
@@ -156,10 +165,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'foo=%24%7B%40a%7D%2810%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-12
     desc: ${'a'}(11)
     stages:
@@ -170,10 +180,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: '/?foo=%24%7B%27a%27%7D%2811%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-13
     desc: ${@$b}(12)
     stages:
@@ -184,10 +194,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: '/?x=%24%7B%40%24b%7D%2812%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-14
     desc: ${$s20}['q53b3a6'](13)
     stages:
@@ -198,10 +208,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: '%24%7B%24s20%7D%5B%27q53b3a6%27%5D%2813%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-15
     desc: $GLOBALS['cf908275'](14)
     stages:
@@ -212,10 +223,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'foo=%24GLOBALS%5B%27cf908275%27%5D%2814%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-16
     desc: $OOO000000{0}(15)
     stages:
@@ -226,10 +238,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'c=%24OOO000000%7B0%7D%2815%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-17
     desc: $OOO0000O0 (16)
     stages:
@@ -240,10 +253,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: '/?x=%24OOO0000O0%20%2816%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-18
     desc: $_aB_4c[5]['d'] /*lol*/ (17)
     stages:
@@ -254,10 +267,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: '/?x=%24_aB_4c%5B5%5D%5B%27d%27%5D%20%2F%2Alol%2A%2F%20%2817%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-19
     desc: $_aB_4c[@5]/*wat*/[@d] (18)
     stages:
@@ -268,10 +281,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'x=%24_aB_4c%5B%405%5D%2F%2Awat%2A%2F%5B%40d%5D%20%28%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-20
     desc: $_aB_4c/*foo*/[@5]/*bar*/[@d]/*baz*/(19)
     stages:
@@ -282,10 +296,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'y=%24_aB_4c%2F%2Afoo%2A%2F%5B%405%5D%2F%2Abar%2A%2F%5B%40d%5D%2F%2Abaz%2A%2F%2819%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-21
     desc: $___[@-_](20)
     stages:
@@ -296,10 +311,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: '/?x=%24___%5B%40-_%5D%2820%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-22
     desc: '@$___[@!+_](21)'
     stages:
@@ -310,10 +325,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /?x=%40%24___%5B%40%21%2B_%5D%2821%29
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-23
     desc: $b374k=@$s_func(22)
     stages:
@@ -324,10 +339,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'foo=%24b374k%3D%40%24s_func%2822%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-24
     desc: $function\r\n (23)
     stages:
@@ -338,10 +354,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: /
+          data: 'foo=%24function%0D%0A%20%2823%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-25
     desc: $__[_](24)
     stages:
@@ -352,10 +369,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: '/?x=%24__%5B_%5D%2824%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-26
     desc: $____[_]{_}[@_](25)
     stages:
@@ -366,12 +383,12 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=
+          uri: '/?x=%24____%5B_%5D%7B_%7D%5B%40_%5D%2825%29'
         output:
-          no_log_contains: id "933180"
-  - 
+          log_contains: id "933180"
+  -
     test_title: 933180-27
-    desc: $____[_]{_}[@_](25)
+    desc: multiline with comments
     stages:
     - stage:
         input:
@@ -380,38 +397,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%24_aB_4c%20%23foo%0D%0A%09%5B5%5D%2F%2Fbar%0D%0A%09%5B%27d%27%5D%20%2F%2Afoo%2A%2F%20%2817%29
+          uri: /
+          data: x=%24_aB_4c%20%23foo%0D%0A%09%5B5%5D%2F%2Fbar%0D%0A%09%5B%27d%27%5D%20%2F%2Afoo%2A%2F%20%2817%29
         output:
           log_contains: id "933180"
-  - 
-    test_title: 933180-28
-    desc: $\x7f (27)
-    stages:
-    - stage:
-        input:
-          dest_addr: 127.0.0.1
-          headers:
-            Host: localhost
-            User-Agent: ModSecurity CRS 3 Tests
-          port: 80
-          uri: /?x=%24_aB_4c%20%23foo%0D%0A%09%5B5%5D%2F%2Fbar%0D%0A%09%5B%27d%27%5D%20%2F%2Afoo%2A%2F%20%2817%29
-        output:
-          log_contains: id "933180"
-  - 
-    test_title: 933180-29
-    desc: $\xff\t(28)
-    stages:
-    - stage:
-        input:
-          dest_addr: 127.0.0.1
-          headers:
-            Host: localhost
-            User-Agent: ModSecurity CRS 3 Tests
-          port: 80
-          uri: /?x=%24_aB_4c%20%23foo%0D%0A%09%5B5%5D%2F%2Fbar%0D%0A%09%5B%27d%27%5D%20%2F%2Afoo%2A%2F%20%2817%29
-        output:
-          log_contains: id "933180"
-  - 
+  -
     test_title: 933180-30
     desc: $$$z(29)
     stages:
@@ -422,10 +412,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%24_aB_4c%20%23foo%0D%0A%09%5B5%5D%2F%2Fbar%0D%0A%09%5B%27d%27%5D%20%2F%2Afoo%2A%2F%20%2817%29
+          uri: /?x=%24%24%24z%2829%29
         output:
           log_contains: id "933180"
-  - 
+  -
     test_title: 933180-31
     desc: ${_.__}(30);
     stages:
@@ -436,10 +426,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%24_aB_4c%20%23foo%0D%0A%09%5B5%5D%2F%2Fbar%0D%0A%09%5B%27d%27%5D%20%2F%2Afoo%2A%2F%20%2817%29
+          uri: /?x=%24%7B_.__%7D%2830%29%3B
         output:
           log_contains: id "933180"
-  - 
+  -
     test_title: 933180-32
     desc: $ {@_.__}(31);
     stages:
@@ -450,10 +440,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%24_aB_4c%20%23foo%0D%0A%09%5B5%5D%2F%2Fbar%0D%0A%09%5B%27d%27%5D%20%2F%2Afoo%2A%2F%20%2817%29
+          uri: /?x=%24%20%7B%40_.__%7D%2831%29%3B
         output:
           log_contains: id "933180"
-  - 
+  -
     test_title: 933180-33
     desc: $_[@-_]($_[@!+_] )
     stages:
@@ -464,10 +454,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%24_aB_4c%20%23foo%0D%0A%09%5B5%5D%2F%2Fbar%0D%0A%09%5B%27d%27%5D%20%2F%2Afoo%2A%2F%20%2817%29
+          uri: /?x=%24_%5B%40-_%5D%28%24_%5B%40%21%2B_%5D%20%29
         output:
           log_contains: id "933180"
-  - 
+  -
     test_title: 933180-34
     desc: $f(101).$f(120)
     stages:
@@ -478,10 +468,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%24_aB_4c%20%23foo%0D%0A%09%5B5%5D%2F%2Fbar%0D%0A%09%5B%27d%27%5D%20%2F%2Afoo%2A%2F%20%2817%29
+          uri: /?x=%24f%28101%29.%24f%28120%29
         output:
           log_contains: id "933180"
-  - 
+  -
     test_title: 933180-35
     desc: '@$b374k("foo")'
     stages:
@@ -492,10 +482,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%24_aB_4c%20%23foo%0D%0A%09%5B5%5D%2F%2Fbar%0D%0A%09%5B%27d%27%5D%20%2F%2Afoo%2A%2F%20%2817%29
+          uri: /?x=%40%24b374k%28%22foo%22%29
         output:
           log_contains: id "933180"
-  - 
+  -
     test_title: 933180-36
     desc: ${$foo->bar}(200)
     stages:
@@ -506,10 +496,10 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%24_aB_4c%20%23foo%0D%0A%09%5B5%5D%2F%2Fbar%0D%0A%09%5B%27d%27%5D%20%2F%2Afoo%2A%2F%20%2817%29
+          uri: /?x=%24%7B%24foo-%3Ebar%7D%28200%29
         output:
           log_contains: id "933180"
-  - 
+  -
     test_title: 933180-37
     desc: $foo->$funcname()
     stages:
@@ -520,10 +510,11 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%24_aB_4c%20%23foo%0D%0A%09%5B5%5D%2F%2Fbar%0D%0A%09%5B%27d%27%5D%20%2F%2Afoo%2A%2F%20%2817%29
+          uri: /
+          data: '%24foo-%3E%24funcname%28%29'
         output:
           log_contains: id "933180"
-  - 
+  -
     test_title: 933180-38
     desc: Foo::$variable()
     stages:
@@ -534,6 +525,6 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%24_aB_4c%20%23foo%0D%0A%09%5B5%5D%2F%2Fbar%0D%0A%09%5B%27d%27%5D%20%2F%2Afoo%2A%2F%20%2817%29
+          uri: /?x=Foo%3A%3A%24variable%28%29
         output:
           log_contains: id "933180"


### PR DESCRIPTION
During routine investigation of rule 933180 I stumbled on some tests which did not test anything, due to the PHP payloads only being in the test description and not in the input data.