### PR TITLE
Update dockerfile to always use 3.2/dev

### DIFF
--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM owasp/modsecurity:v2-ubuntu-apache
 MAINTAINER Chaim Sanders chaim.sanders@gmail.com
 
-ARG COMMIT=v3.1/dev
+ARG COMMIT=v3.2/dev
 ARG REPO=SpiderLabs/owasp-modsecurity-crs
 ENV PARANOIA=1
 
@@ -9,12 +9,12 @@ RUN apt-get update && \
     apt-get -y install python git ca-certificates iproute2
 
 RUN cd /opt && \
-  git clone https://github.com/${REPO}.git owasp-modsecurity-crs-3.1 && \
-  cd owasp-modsecurity-crs-3.1 && \
+  git clone https://github.com/${REPO}.git owasp-modsecurity-crs-3.2 && \
+  cd owasp-modsecurity-crs-3.2 && \
   git checkout -qf ${COMMIT} 
 
 RUN cd /opt && \
-  cp -R /opt/owasp-modsecurity-crs-3.1/ /etc/apache2/modsecurity.d/owasp-crs/ && \
+  cp -R /opt/owasp-modsecurity-crs-3.2/ /etc/apache2/modsecurity.d/owasp-crs/ && \
   mv /etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf.example /etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf && \
   cd /etc/apache2/modsecurity.d && \
   printf "include modsecurity.d/owasp-crs/crs-setup.conf\ninclude modsecurity.d/owasp-crs/rules/*.conf" > include.conf && \


### PR DESCRIPTION
This should fix the travis-ci tests for non-PRs.