### PR TITLE
New rule 950140 to detect CGI source code leakages

### DIFF
--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -51,7 +51,6 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/INFO-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
-
 #
 # -=[ CGI Source Code Leakage ]=-
 #
@@ -92,7 +91,6 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:950014,phase:4,pass,nolog,skipAf
 #
 # -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
 #
-
 
 #
 # -=[ The application is not available - 5xx level status code ]=-

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -56,7 +56,7 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
 # -=[ CGI Source Code Leakage ]=-
 #
 # a CGI script begins normally with #!/
-# for example: 
+# for example:
 #!/usr/bin/perl
 #!/usr/bin/python
 #!/usr/bin/ruby
@@ -92,6 +92,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:950014,phase:4,pass,nolog,skipAf
 #
 # -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
 #
+
 
 #
 # -=[ The application is not available - 5xx level status code ]=-

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -61,7 +61,7 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
 #!/usr/bin/ruby
 # If the CGI-Script processors or MIME type handlers are misconfigured,
 # the source code can be displayed in plain text.
-SecRule RESPONSE_BODY "@rx ^#\!/" \
+SecRule RESPONSE_BODY "@rx ^#\!\s*/" \
     "id:950140,\
     phase:4,\
     block,\

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -63,7 +63,7 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
 #
 # If the CGI script processors or MIME type handlers are misconfigured,
 # the script's source code could be erroneously returned to the client.
-SecRule RESPONSE_BODY "@rx ^#\!\s*/" \
+SecRule RESPONSE_BODY "@rx ^#\!\s?/" \
     "id:950140,\
     phase:4,\
     block,\

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -52,6 +52,40 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
     setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/INFO-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
+#
+# -=[ CGI Source Code Leakage ]=-
+#
+# a CGI script begins normally with #!/
+# for example: 
+#!/usr/bin/perl
+#!/usr/bin/python
+#!/usr/bin/ruby
+# If the CGI-Script processors or MIME type handlers are misconfigured,
+# the source code can be displayed in plain text.
+SecRule RESPONSE_BODY "@rx ^#\!/" \
+    "id:950140,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'CGI source code leakage',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-disclosure',\
+    tag:'OWASP_CRS/LEAKAGE/SOURCE_CODE_CGI',\
+    tag:'WASCTC/WASC-13',\
+    tag:'OWASP_TOP_10/A6',\
+    tag:'PCI/6.5.6',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.2.0',\
+    severity:'ERROR',\
+    setvar:'tx.msg=%{rule.msg}',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.%{rule.id}-OWASP_CRS/LEAKAGE/SOURCE_CODE-%{MATCHED_VAR_NAME}=%{tx.0}'"
+
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:950013,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:950014,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -54,13 +54,15 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
 #
 # -=[ CGI Source Code Leakage ]=-
 #
-# a CGI script begins normally with #!/
+# A CGI script begins normally with #! and the interpreter,
 # for example:
-#!/usr/bin/perl
-#!/usr/bin/python
-#!/usr/bin/ruby
-# If the CGI-Script processors or MIME type handlers are misconfigured,
-# the source code can be displayed in plain text.
+#
+# #!/usr/bin/perl
+# #!/usr/bin/python
+# #!/usr/bin/ruby
+#
+# If the CGI script processors or MIME type handlers are misconfigured,
+# the script's source code could be erroneously returned to the client.
 SecRule RESPONSE_BODY "@rx ^#\!\s*/" \
     "id:950140,\
     phase:4,\


### PR DESCRIPTION
If the CGI-Script processors or MIME type handlers are missconfigured,
the source code can be displayed in plain text.


for example: 
`````
#!/usr/bin/perl
#!/usr/bin/python
#!/usr/bin/ruby
`````