### PR TITLE
Jwall AuditConsole Outbound Anomaly Scoring Requirements

### DIFF
--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -31,7 +31,6 @@ SecRule TX:PARANOIA_LEVEL "@ge 1" \
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score_pl1}',\
     setvar:'tx.outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 
 SecRule TX:PARANOIA_LEVEL "@ge 2" \
@@ -40,7 +39,6 @@ SecRule TX:PARANOIA_LEVEL "@ge 2" \
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score_pl2}',\
     setvar:'tx.outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 
 SecRule TX:PARANOIA_LEVEL "@ge 3" \
@@ -49,7 +47,6 @@ SecRule TX:PARANOIA_LEVEL "@ge 3" \
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score_pl3}',\
     setvar:'tx.outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 
 SecRule TX:PARANOIA_LEVEL "@ge 4" \
@@ -58,7 +55,6 @@ SecRule TX:PARANOIA_LEVEL "@ge 4" \
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score_pl4}',\
     setvar:'tx.outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 
 
@@ -70,7 +66,8 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     deny,\
     t:none,\
     msg:'Outbound Anomaly Score Exceeded (Total Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
-    tag:'anomaly-evaluation'"
+    tag:'anomaly-evaluation',\
+    setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score}'"
 
 
 

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -31,6 +31,7 @@ SecRule TX:PARANOIA_LEVEL "@ge 1" \
     pass,\
     t:none,\
     nolog,\
+    setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score_pl1}',\
     setvar:'tx.outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 
 SecRule TX:PARANOIA_LEVEL "@ge 2" \
@@ -39,6 +40,7 @@ SecRule TX:PARANOIA_LEVEL "@ge 2" \
     pass,\
     t:none,\
     nolog,\
+    setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score_pl2}',\
     setvar:'tx.outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 
 SecRule TX:PARANOIA_LEVEL "@ge 3" \
@@ -47,6 +49,7 @@ SecRule TX:PARANOIA_LEVEL "@ge 3" \
     pass,\
     t:none,\
     nolog,\
+    setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score_pl3}',\
     setvar:'tx.outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 
 SecRule TX:PARANOIA_LEVEL "@ge 4" \
@@ -55,6 +58,7 @@ SecRule TX:PARANOIA_LEVEL "@ge 4" \
     pass,\
     t:none,\
     nolog,\
+    setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score_pl4}',\
     setvar:'tx.outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 
 

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -60,6 +60,11 @@ SecRule TX:PARANOIA_LEVEL "@ge 4" \
 
 # Alert and Block on High Anomaly Scores - this would block outbound data leakages
 #
+# Note: This rule also sets the 'tx.anomaly_score' variable.
+# That variable name was formerly used in CRS, but not any longer.
+# However, Jwall AuditConsole depends on this exact variable name.
+# Without setting it, the 'Outbound Score' in the AuditConsole GUI would always be 0.
+
 SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     "id:959100,\
     phase:4,\


### PR DESCRIPTION
here is a PR to keep Jwall AuditConsole compatible with CRS.

Without this PR the Outbound Score in the AC GUI will be always 0.