### PR TITLE
XML Soap Encoding 920240

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -448,9 +448,9 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^application\/x-www-form-urlencoded(?:
     ver:'OWASP_CRS/3.1.0',\
     severity:'WARNING',\
     chain"
-    SecRule REQUEST_BODY|XML:/* "@rx \%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
+    SecRule REQUEST_BODY "@rx \%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
         "chain"
-        SecRule REQUEST_BODY|XML:/* "@validateUrlEncoding" \
+        SecRule REQUEST_BODY "@validateUrlEncoding" \
             "setvar:'tx.msg=%{rule.msg}',\
             setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
             setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -433,7 +433,7 @@ SecRule REQUEST_URI "@rx \%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
 
 # Not supported by re2 (?!re).
 #
-SecRule REQUEST_HEADERS:Content-Type "@rx ^(?:application\/x-www-form-urlencoded|text\/xml)(?:;(?:\s?charset\s?=\s?[\w\d\-]{1,18})?)??$" \
+SecRule REQUEST_HEADERS:Content-Type "@rx ^application\/x-www-form-urlencoded(?:;(?:\s?charset\s?=\s?[\w\d\-]{1,18})?)??$" \
     "id:920240,\
     phase:2,\
     block,\
@@ -448,14 +448,12 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?:application\/x-www-form-urlencoded
     ver:'OWASP_CRS/3.1.0',\
     severity:'WARNING',\
     chain"
-    SecRule &REQUEST_HEADERS:Soapaction "@eq 0" \
+    SecRule REQUEST_BODY|XML:/* "@rx \%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
         "chain"
-        SecRule REQUEST_BODY|XML:/* "@rx \%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
-            "chain"
-            SecRule REQUEST_BODY|XML:/* "@validateUrlEncoding" \
-                "setvar:'tx.msg=%{rule.msg}',\
-                setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
-                setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+        SecRule REQUEST_BODY|XML:/* "@validateUrlEncoding" \
+            "setvar:'tx.msg=%{rule.msg}',\
+            setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
+            setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -448,12 +448,14 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?:application\/x-www-form-urlencoded
     ver:'OWASP_CRS/3.1.0',\
     severity:'WARNING',\
     chain"
-    SecRule REQUEST_BODY|XML:/* "@rx \%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
+    SecRule &REQUEST_HEADERS:Soapaction "@eq 0" \
         "chain"
-        SecRule REQUEST_BODY|XML:/* "@validateUrlEncoding" \
-            "setvar:'tx.msg=%{rule.msg}',\
-            setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
-            setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+        SecRule REQUEST_BODY|XML:/* "@rx \%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
+            "chain"
+            SecRule REQUEST_BODY|XML:/* "@validateUrlEncoding" \
+                "setvar:'tx.msg=%{rule.msg}',\
+                setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
+                setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
 #

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920240.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920240.yaml
@@ -133,4 +133,4 @@
                   Content-Type: "application/x-www-form-urlencoded"
               data: "param=%7%6F%6D%65%74%65%78%74%5F%31%32%33%"
             output: 
-              log_contains: "id \"920240\""                
+              log_contains: "id \"920240\""

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920240.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920240.yaml
@@ -59,7 +59,7 @@
               no_log_contains: "id \"920240\""                   
                              
     - 
-      # Test URL Encoding Abuse Attack Attempt/XML from orig modsec regression
+      # We have a valid percent encoding here
       test_title: 920240-4
       stages: 
         - 
@@ -87,7 +87,7 @@
                 - "  </SOAP-ENV:Body>"
                 - "</SOAP-ENV:Envelope>"
             output: 
-              log_contains: "id \"920240\""
+              no_log_contains: "id \"920240\""
     - 
       # test URL Encoding Abuse Attack Attempt from old regression tests
       test_title: 920240-5


### PR DESCRIPTION
% characters should be always allowed

https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references

`````
[14/Jan/2019:14:16:07 +0100] XDyLlwVeGKmHjNcA7bxy1wAAAww 127.0.0.1 58782 127.0.0.1 443
--0bd85403-B--
POST /?wsdl HTTP/1.1
Host: localhost
User-Agent: curl/7.63.0
Accept: */*
Content-Type: text/xml;charset=UTF-8
SOAPAAction: "daten"
Content-Length: 761

<?xml version="1.0" encoding="UTF-8"?>
<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns0="http://de.webservice/xsd" xmlns:ns1="http://de.webservice" xmlns:ns2="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <SOAP-ENV:Header />
   <ns2:Body>
      <ns1:anfrage>
         <ns1:parameter>
            <ns0:bearbeiter>
               <ns0:anwenderkennwort>%asdf</ns0:anwenderkennwort>
               <ns0:anwendername>adminasdf</ns0:anwendername>
               <ns0:wskennwort>7Aasdf%</ns0:wskennwort>
            </ns0:bearbeiter>
            <ns0:parameter>
               <ns0:anfrageparameter1>PXB_HRGE_1</ns0:anfrageparameter1>
               <ns0:anfrageparameter2>MHZasdfb</ns0:anfrageparameter2>
               <ns0:anfragetyp>AUTH</ns0:anfragetyp>
            </ns0:parameter>
         </ns1:parameter>
      </ns1:anfrage>
   </ns2:Body>
</SOAP-ENV:Envelope>
`````
`````
Message: Warning. Invalid URL Encoding: Non-hexadecimal digits used at XML. [file "/etc/httpd/modsecurity.d/activated_rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "450"] [id "920240"] [msg "URL Encoding Abuse Attack Attempt"] [data "%asdfadminasdf7Aasdf%PXB_HRGE_1MHZasdfbAUTH"] [severity "WARNING"] [ver "OWASP_CRS/3.1.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "OWASP_CRS/PROTOCOL_VIOLATION/EVASION"]
`````