### PR TITLE
Prevent bypass 933180 PHP Variable Function on PL1

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -470,6 +470,48 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
+# [ PHP Functions: Variable Function Prevent Bypass ]
+#
+# Referring to https://www.secjuice.com/php-rce-bypass-filters-sanitization-waf/
+# the rule 933180 could be bypassed by using the following payloads:
+#
+# - (system)('uname')
+# - (sy.(st).em)('uname')
+# - (string)"system"('uname')
+# - define('x', 'sys' . 'tem');(x)/* comment */('uname')
+# - $y = 'sys'.'tem';($y)('uname')
+# - define('z', [['sys' .'tem']]);(z)[0][0]('uname');
+# - (system)(ls)
+# - (/**/system)(ls/**/);
+# - (['system'])[0]('uname');
+# - (++[++system++][++0++])++{/*dsasd*/0}++(++ls++);
+#
+# This rule blocks all payloads above and avoids to block values like:
+#
+# - [ACME] this is a test (just a test)
+# - Test (with two) rounded (brackets)
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?:(?:\(|\[)[a-zA-Z0-9_.$\"'\[\](){}/*\s]+(?:\)|\])[0-9_.$\"'\[\](){}/*\s]*\([a-zA-Z0-9_.$\"'\[\](){}/*\s].*\)|\([\s]*string[\s]*\)[\s]*(?:\"|'))" \
+    "id:933210,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:urlDecode,t:replaceComments,t:compressWhitespace,\
+    msg:'PHP Injection Attack: Variable Function Call Found',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-injection-php',\
+    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
+    tag:'OWASP_TOP_10/A1',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.1.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.msg=%{rule.msg}',\
+    setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/PHP_INJECTION-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:933013,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:933014,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"

--- a/util/regression-tests/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933210.yaml
+++ b/util/regression-tests/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933210.yaml
@@ -1,0 +1,245 @@
+---
+  meta:
+    author: theMiddle
+    description: Test for "933210" PHP Variable Function bypass
+    enabled: true
+    name: 933210.yaml
+  tests:
+  - 
+    test_title: 933210-1
+    desc: Check for false positive 1
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=%5bACME%5d%3a+this+is%2c+%28another%29+test+%28foo%29bar+or+foo%28bar%29.
+        output:
+          no_log_contains: id "933210"
+  - 
+    test_title: 933210-2
+    desc: Check for false positive 2
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=%28foo%29bar+or+foo%28bar%29+or+%5bfoo%5dbar+or+foo%5bbar%5d
+        output:
+          no_log_contains: id "933210"
+
+  - 
+    test_title: 933210-3
+    desc: PHP Variable Function bypass "(system)('uname')"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=%28system%29%28%27uname%27%29
+        output:
+          log_contains: id "933210"
+
+  - 
+    test_title: 933210-4
+    desc: PHP Variable Function bypass "(sy.(st).em)('uname')"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=%28sy.%28st%29.em%29%28%27uname%27%29
+        output:
+          log_contains: id "933210"
+
+  - 
+    test_title: 933210-5
+    desc: PHP Variable Function bypass "(string)'system'('uname')"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=%28string%29%22system%22%28%27uname%27%29
+        output:
+          log_contains: id "933210"
+
+  - 
+    test_title: 933210-6
+    desc: PHP Variable Function bypass "( string ) 'sys'.'t'.'em' ('uname')"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=%28+string+%29+%22sys%22.%22t%22.%22em%22+%28%27uname%27%29
+        output:
+          log_contains: id "933210"
+
+  - 
+    test_title: 933210-7
+    desc: PHP Variable Function bypass "(string) {[system][0]} ('uname')"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=%28string%29+%7b%5bsystem%5d%5b0%5d%7d+%28%27uname%27%29
+        output:
+          log_contains: id "933210"
+
+  - 
+    test_title: 933210-8
+    desc: PHP Variable Function bypass "define('x', 'sys' . 'tem');(x)/* comment */('uname')"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=define%28%27x%27,+%27sys%27+.+%27tem%27%29%3b%28x%29%2f*+comment+*%2f%28%27uname%27%29
+        output:
+          log_contains: id "933210"
+
+  - 
+    test_title: 933210-9
+    desc: PHP Variable Function bypass "$y = 'sys'.'tem';($y)('uname')"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=$y+=+%27sys%27.%27tem%27%3b%28$y%29%28%27uname%27%29
+        output:
+          log_contains: id "933210"
+
+  - 
+    test_title: 933210-10
+    desc: PHP Variable Function bypass "define('z', [['sys' .'tem']]);(z)[0][0]('uname')"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=define%28%27z%27,+%5b%5b%27sys%27+.%27tem%27%5d%5d%29%3b%28z%29%5b0%5d%5b0%5d%28%27uname%27%29
+        output:
+          log_contains: id "933210"
+
+  - 
+    test_title: 933210-11
+    desc: PHP Variable Function bypass "(system)(ls)"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=%28system%29%28ls%29
+        output:
+          log_contains: id "933210"
+
+  - 
+    test_title: 933210-12
+    desc: PHP Variable Function bypass "(/* comment */system)(ls/* comment */)"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=%28%2f*+comment+*%2fsystem%29%28ls%2f*+comment+*%2f%29
+        output:
+          log_contains: id "933210"
+
+  - 
+    test_title: 933210-13
+    desc: PHP Variable Function bypass "[system][0](ls)"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=%5bsystem%5d%5b0%5d%28ls%29
+        output:
+          log_contains: id "933210"
+
+  - 
+    test_title: 933210-14
+    desc: PHP Variable Function bypass "[ system ] [ 0 ] ( ls )"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=%5b+system+%5d+%5b+0+%5d+%28+ls+%29
+        output:
+          log_contains: id "933210"
+
+  - 
+    test_title: 933210-15
+    desc: PHP Variable Function bypass "(['system'])[0]('uname')"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=%28%5b%27system%27%5d%29%5b0%5d%28%27uname%27%29
+        output:
+          log_contains: id "933210"
+
+  - 
+    test_title: 933210-16
+    desc: PHP Variable Function bypass "(  [  system  ][  0  ])  {/* comment */0}  (  ls  )"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?x=%28++%5b++system++%5d%5b++0++%5d%29++%7b%2f*+comment+*%2f0%7d++%28++ls++%29
+        output:
+          log_contains: id "933210"


### PR DESCRIPTION
Referring to #1274 this new rule (933210) prevents to bypass rule 933180 using PHP syntax like the following:

```php
- (system)(ls)
- (/**/system)(ls/**/);
- (['system'])[0]('uname');
- (++[++system++][++0++])++{/*dsasd*/0}++(++ls++);
- (sy.(st).em)('uname')
- (string)"system"('uname')
- define('x', 'sys' . 'tem');(x)/* comment */('uname');
- $y = 'sys'.'tem';($y)('uname')
- define('z', [['sys' .'tem']]);(z)[0][0]('uname');
etc...
```

I propose to put this rule in PL1 because I think it shouldn't be prone to many FPs. I've created a script that try to catch some FPs and this is the result:

![image](https://user-images.githubusercontent.com/4454961/51780014-6850e680-210b-11e9-972d-d190f9a1f07b.png)

As you can see, this regex avoids to block values like:

```
- [ACME] this is a test (just a test)
- [ACME]: this is, a test. (just a test)!
- [ACME]: this is, (another) test (foo)bar or foo(bar).
- (foo)bar or foo(bar) !or! [foo]bar or foo[bar]
- Test (with two) rounded (brackets)
```

I've used the following transformation functions:
- urlDecode (obviously)
- compressWhitespace (useful for something like `(+++system+++)`)
- replaceComments (remove C-like comments `(system/*foo*/)(/*bar*/ls)`)

Questions:
- What do you think about? 
- Is there anyone who wants to test others payloads or FPs? 
- Is 933210 good for the CRS rule numbering policy?