### PR TITLE
Fix 920440 "URL file extension is restricted by policy" regex

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1086,7 +1086,7 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
 #
 # Restrict file extension
 #
-SecRule REQUEST_BASENAME "@rx \.(.*)$" \
+SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
     "id:920440,\
     phase:2,\
     block,\

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920440.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920440.yaml
@@ -75,3 +75,26 @@
           version: HTTP/1.1
         output:
           log_contains: id "920440"
+  -
+    test_title: 920440-4
+    desc: URL file extension is restricted by policy (920440) - GH issue 1296
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+            Accept-Encoding: gzip,deflate
+            Accept-Language: en-us,en;q=0.5
+            Host: localhost
+            Keep-Alive: '300'
+            Proxy-Connection: keep-alive
+            User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
+          method: GET
+          port: 80
+          uri: /foo.bar.sql
+          version: HTTP/1.1
+        output:
+          log_contains: id "920440"


### PR DESCRIPTION
Referring to #1296 this fix the 920440 regex to `\.[^\.]+$` preventing to make it match something like `.com.sql` instead of `.sql`.