### PR TITLE
wordpress: gutenberg support

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -95,6 +95,7 @@ SecRule REQUEST_FILENAME "@rx ^(/wp\-json/wp/v[0-9]+/(posts|pages))" \
     pass,\
     t:none,\
     nolog,\
+    ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
     ctl:ruleRemoveTargetByTag=CRS;ARGS:json.content"
 
 

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -95,14 +95,7 @@ SecRule REQUEST_FILENAME "@rx ^(/wp\-json/wp/v[0-9]+/(posts|pages))" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetById=941180;ARGS:json.content,\
-    ctl:ruleRemoveTargetById=941320;ARGS:json.content,\
-    ctl:ruleRemoveTargetById=942200;ARGS:json.content,\
-    ctl:ruleRemoveTargetById=942260;ARGS:json.content,\
-    ctl:ruleRemoveTargetById=942340;ARGS:json.content,\
-    ctl:ruleRemoveTargetById=942370;ARGS:json.content,\
-    ctl:ruleRemoveTargetById=942430;ARGS:json.content,\
-    ctl:ruleRemoveTargetById=942440;ARGS:json.content"
+    ctl:ruleRemoveTargetByTag=CRS;ARGS:json.content"
 
 
 #

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -84,6 +84,28 @@ SecRule REQUEST_FILENAME "@endsWith /wp-comments-post.php" \
 
 
 #
+# [ Gutenberg Editor ]
+# Used when a user (auto)saves a post/page with Gutenberg.
+#
+
+# Gutenberg
+SecRule REQUEST_FILENAME "@rx ^(/wp\-json/wp/v[0-9]+/(posts|pages))" \
+    "id:9002140,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=941180;ARGS:json.content,\
+    ctl:ruleRemoveTargetById=941320;ARGS:json.content,\
+    ctl:ruleRemoveTargetById=942200;ARGS:json.content,\
+    ctl:ruleRemoveTargetById=942260;ARGS:json.content,\
+    ctl:ruleRemoveTargetById=942340;ARGS:json.content,\
+    ctl:ruleRemoveTargetById=942370;ARGS:json.content,\
+    ctl:ruleRemoveTargetById=942430;ARGS:json.content,\
+    ctl:ruleRemoveTargetById=942440;ARGS:json.content"
+
+
+#
 # [ Live preview ]
 # Used when an administrator customizes the site and previews the result
 # as a normal user.

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -89,7 +89,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-comments-post.php" \
 #
 
 # Gutenberg
-SecRule REQUEST_FILENAME "@rx ^(/wp\-json/wp/v[0-9]+/(posts|pages))" \
+SecRule REQUEST_FILENAME "@rx ^/wp\-json/wp/v[0-9]+/(?:posts|pages)" \
     "id:9002140,\
     phase:1,\
     pass,\


### PR DESCRIPTION
This adds support for the new Gutenberg editor in Wordpress. #1232 