### PR TITLE
scanners: add Jorgee

### DIFF
--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -77,6 +77,8 @@ internet ninja
 jaascois
 # vuln scanner
 zmeu
+# "Mozilla/5.0 Jorgee", vuln scanner
+Jorgee
 # port scanner
 # https://github.com/robertdavidgraham/masscan
 masscan


### PR DESCRIPTION
Jorgee turns up in logs and appears to look for phpMyAdmin installs in well known locations.

There are various places mentioning it:

- http://sipadcg.org/jorgee/
- https://blog.paranoidpenguin.net/2017/04/jorgee-goes-on-a-rampage/
- https://www.symantec.com/security_response/attacksignatures/detail.jsp?asid=30164 (Symantec: Jorgee Vulnerability Scanner)
- https://fortiguard.com/encyclopedia/ips/44308 (Fortigate: Jorgee.Web.Scanner)