### PR TITLE
Using and defining better TX:REAL_IP variable

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -233,6 +233,42 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 
 #
+# -- [[ Remote IP Address ]] ---------------------------------------------------
+#
+# If your web server is behind a reverse proxy (like a load balancer),
+# all connections will come from the same IP address. CRS need to know
+# the real IP address of clients for working with RBL and for DoS rules.
+# Usually, a reverse proxy set the user's real IP address in a request header
+# like X-Forwarded-For or True-Client-IP. CRS uses the tx.real_ip variable
+# to store the user's IP address, that can be set with a rule like the following: 
+#
+#SecRule REMOTE_ADDR "@ipMatch 127.0.0.1" \
+#	"id:900020,\
+#	phase:1,\
+#	nolog,\
+#	pass,\
+#	t:none,\
+#	setvar:tx.real_ip=%{REQUEST_HEADERS:X-Forwarded-For}"
+#
+# Before setting the tx.real_ip variable it's absolutely necessary to check first
+# if the request comes from the reverse proxy IP address. This because a user could
+# send the X-Forwarded-For header in order to act as the reverse proxy and hide its
+# real IP address.
+#
+# For example, if your web server is behind CloudFlare load balancer, you should
+# uncomment the following rule that check if the request come from one of CloudFlare
+# IP addresses (https://www.cloudflare.com/ips/) and then set the tx.real_ip variable:
+#
+#SecRule REMOTE_ADDR "@ipMatch 103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,104.16.0.0/12,108.162.192.0/18,131.0.72.0/22,141.101.64.0/18,162.158.0.0/15,172.64.0.0/13,173.245.48.0/20,188.114.96.0/20,190.93.240.0/20,197.234.240.0/22,198.41.128.0/17,2400:cb00::/32,2405:b500::/32,2606:4700::/32,2803:f800::/32,2c0f:f248::/32,2a06:98c0::/29" \
+#	"id:900020,\
+#	phase:1,\
+#	nolog,\
+#	pass,\
+#	t:none,\
+#	setvar:tx.real_ip=%{REQUEST_HEADERS:CF-Connecting-IP}"
+
+
+#
 # -- [[ Anomaly Mode Severity Levels ]] ----------------------------------------
 #
 # Each rule in the CRS has an associated severity level.

--- a/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
+++ b/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
@@ -87,7 +87,7 @@
 # IP network block as appropriate for your AVS traffic
 #
 # ModSec Rule Exclusion: Disable Rule Engine for known ASV IP
-# SecRule REMOTE_ADDR "@ipMatch 192.168.1.100" \
+# SecRule TX:REAL_IP "@ipMatch 192.168.1.100" \
 #     "id:1000,\
 #     phase:1,\
 #     pass,\

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -282,6 +282,14 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^.*$" \
     nolog,\
     setvar:'tx.ua_hash=%{MATCHED_VAR}'"
 
+SecRule &TX:REAL_IP "@eq 0" \
+    "id:901320,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.real_ip=%{remote_addr}'"
+
 SecAction \
     "id:901321,\
     phase:1,\
@@ -289,8 +297,7 @@ SecAction \
     t:none,\
     nolog,\
     initcol:global=global,\
-    initcol:ip=%{remote_addr}_%{tx.ua_hash},\
-    setvar:'tx.real_ip=%{remote_addr}'"
+    initcol:ip=%{tx.real_ip}_%{tx.ua_hash}"
 
 #
 # -=[ Initialize Correct Body Processing ]=-

--- a/rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf
@@ -51,7 +51,7 @@ SecRule REQUEST_LINE "@rx ^GET /whm-server-status(?:/|/\?auto)? HTTP/[12]\.[01]$
     tag:'platform-apache',\
     tag:'attack-generic',\
     chain"
-    SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
+    SecRule TX:REAL_IP "@ipMatch 127.0.0.1,::1" \
         "t:none,\
         ctl:ruleRemoveById=920280,\
         ctl:ruleRemoveById=920350"

--- a/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+++ b/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
@@ -24,7 +24,7 @@ SecRule REQUEST_LINE "@streq GET /" \
     tag:'platform-apache',\
     tag:'attack-generic',\
     chain"
-    SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
+    SecRule TX:REAL_IP "@ipMatch 127.0.0.1,::1" \
         "t:none,\
         ctl:ruleEngine=Off,\
         ctl:auditEngine=Off"
@@ -43,7 +43,7 @@ SecRule REQUEST_LINE "@rx ^(?:GET /|OPTIONS \*) HTTP/[12]\.[01]$" \
     tag:'platform-apache',\
     tag:'attack-generic',\
     chain"
-    SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
+    SecRule TX:REAL_IP "@ipMatch 127.0.0.1,::1" \
         "t:none,\
         chain"
         SecRule REQUEST_HEADERS:User-Agent "@rx ^.*\(internal dummy connection\)$" \


### PR DESCRIPTION
The rule `901321` set `tx.real_ip` variable to `REMOTE_ADDR` and it could be a problem when CRS is behind a reverse proxy, especially for rules included in `REQUEST-910-IP-REPUTATION.conf` and `REQUEST-912-DOS-PROTECTION.conf`.

This PR adds `901320` that set `tx.real_ip` to `REMOTE_ADDR` if it doesn't already exist. Moreover, with this PR, I would like to propose a new rule (`900020`) that should help users to set the correct real IP address to `tx.real_ip` even with an example on how to do it using CloudFlare.

I've also replaced all rules that use `REMOTE_ADDR` variable with `TX:REAL_IP`:
```bash
# egrep -i '(remote_addr|real_ip)' rules/*
rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example:# SecRule REMOTE_ADDR "@ipMatch 192.168.1.100" \
rules/REQUEST-901-INITIALIZATION.conf:    initcol:ip=%{remote_addr}_%{tx.ua_hash},\
rules/REQUEST-901-INITIALIZATION.conf:    setvar:'tx.real_ip=%{remote_addr}'"
rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf:    SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
rules/REQUEST-905-COMMON-EXCEPTIONS.conf:    SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
rules/REQUEST-905-COMMON-EXCEPTIONS.conf:    SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
rules/REQUEST-910-IP-REPUTATION.conf:    SecRule TX:REAL_IP "@geoLookup" \
rules/REQUEST-910-IP-REPUTATION.conf:#SecRule TX:REAL_IP "@ipMatchFromFile ip_blacklist.data" \
rules/REQUEST-910-IP-REPUTATION.conf:SecRule TX:REAL_IP "@rbl dnsbl.httpbl.org" \
rules/REQUEST-912-DOS-PROTECTION.conf:    msg:'Denial of Service (DoS) attack identified from %{tx.real_ip} (%{tx.dos_block_counter} hits since last alert)',\
rules/REQUEST-912-DOS-PROTECTION.conf:    msg:'Potential Denial of Service (DoS) Attack from %{tx.real_ip} - # of Request Bursts: %{ip.dos_burst_counter}',\
rules/REQUEST-912-DOS-PROTECTION.conf:    msg:'Potential Denial of Service (DoS) Attack from %{tx.real_ip} - # of Request Bursts: %{ip.dos_burst_counter}',\
``` 

Even if it could be useful for many users, maybe the "CloudFlare example" is too much for the `crs-setup.conf`, what do you think about it? Feel free to change/edit/fix the `900020` comment. Anyway, in my opinion, to use a single variable for the client IP instead `REMOTE_ADDR` should be a good thing.