### PR TITLE
Fix 920460 test

### DIFF
--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920460.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920460.yaml
@@ -1,8 +1,7 @@
 ---
   meta: 
     author: "csanders-git"
-    # Not triggering (unsure why)
-    enabled: false
+    enabled: true
     name: "920460.yaml"
     description: "Description"
   tests: 
@@ -12,7 +11,17 @@
         - 
           stage: 
             input:
-              encoded_request: "UE9TVCAvIEhUVFAvMS4xCkhvc3Q6IGxvY2FsaG9zdApVc2VyLUFnZW50OiBNb2RTZWN1cml0eSBDUlMgMyBUZXN0cwpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL3gtd3d3LWZvcm0tdXJsZW5jb2RlZApDb250ZW50LUxlbmd0aDogMjIKCmZpbGU9Y2F0Ky9ldGMvXHBhc3N3XGQ="
-
-            output: 
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "POST"
+              uri: "/"
+              headers:
+                Host: "localhost"
+                Accept: "*/*"
+                Content-Length: 22
+                Content-Type: "application/x-www-form-urlencoded"
+                User-Agent: "ModSecurity CRS 3 Tests"
+              data: 'file=cat+/etc/\passw\d'
+              stop_magic: true
+            output:
               log_contains: "id \"920460\""


### PR DESCRIPTION
The base64 encoded payload was not correct and is no needed.