### PR TITLE
adding rule for Drupal CVE-2019-6340

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -168,7 +168,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
+    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain|application/hal\+json'"
 
 # Default HTTP policy: allowed_request_content_type_charset (rule 900270)
 SecRule &TX:allowed_request_content_type_charset "@eq 0" \

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -575,6 +575,30 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
+# CVE-2019-6340
+SecRule REQUEST_URI "@rx ^/node/\d+\?_format=hal_json"  \
+    "id:932180,\
+    phase:2,\
+    block,\
+    deny,\
+    msg:'CVE-2019-6340 Drupal Restful module RCE',\
+    logdata:'Matched Data: CVE-2019-6340 Drupal Restful module RCE found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-php',\
+    tag:'attack-rce',\
+    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
+    tag:'WASCTC/WASC-31',\
+    tag:'OWASP_TOP_10/A1',\
+    tag:'PCI/6.5.2',\
+    severity:'CRITICAL',\
+    chain"
+    SecRule REQUEST_BODY "GuzzleHttp\\\\HandlerStack" \
+	"capture,\
+    	setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}',\
+    	setvar:'tx.msg=%{rule.msg}'"
+
 
 #
 # -=[ Restricted File Upload ]=-

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -577,10 +577,12 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
 
 # CVE-2019-6340
 SecRule REQUEST_URI "@rx ^/node/\d+\?_format=hal_json"  \
-    "id:932180,\
+    "id:932220,\
     phase:2,\
     block,\
     deny,\
+    t:lowercase, \
+    ctl:requestBodyProcessor=JSON, \ 
     msg:'CVE-2019-6340 Drupal Restful module RCE',\
     logdata:'Matched Data: CVE-2019-6340 Drupal Restful module RCE found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -597,6 +599,7 @@ SecRule REQUEST_URI "@rx ^/node/\d+\?_format=hal_json"  \
     	setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{tx.0}',\
+    	setvar:'tx.crs_exclusions_drupal=1', \
     	setvar:'tx.msg=%{rule.msg}'"
 
 
@@ -614,7 +617,7 @@ SecRule REQUEST_URI "@rx ^/node/\d+\?_format=hal_json"  \
 #
 SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X-File-Name \
         "@pmf restricted-upload.data" \
-    "id:932180,\
+    "id:932210,\
     phase:2,\
     block,\
     capture,\


### PR DESCRIPTION
Used the following modified POC tool to test it https://gist.github.com/d1vious/9d798d4f50d6d887f1babcb82f5e3559 still need to build a unit test for it. Here an example payload from the attack 
```
GET /node/3?_format=hal_json HTTP/1.1
Host: 192.168.86.76
User-Agent: python-requests/2.18.4
Accept-Encoding: gzip, deflate
Accept: */*
Connection: keep-alive
Content-Type: application/hal+json
Content-Length: 583


20:18:28.762332 IP 192.168.86.77.37584 > 192.168.86.76.80: Flags [P.], seq 225:808, ack 1, win 229, options [nop,nop,TS val 615012830 ecr 1128184318], length 583: HTTP
E..{ev@.@.....VM..VL...PO.. ..rB....N>.....
$.Y.C>..{"link": [{"value": "link", "options": "O:24:\"GuzzleHttp\\Psr7\\FnStream\":2:{s:33:\"\u0000GuzzleHttp\\Psr7\\FnStream\u0000methods\";a:1:{s:5:\"close\";a:2:{i:0;O:23:\"GuzzleHttp\\HandlerStack\":3:{s:32:\"\u0000GuzzleHttp\\HandlerStack\u0000handler\";s:18:\"echo ---- & whoami\";s:30:\"\u0000GuzzleHttp\\HandlerStack\u0000stack\";a:1:{i:0;a:1:{i:0;s:6:\"system\";}}s:31:\"\u0000GuzzleHttp\\HandlerStack\u0000cached\";b:0;}i:1;s:7:\"resolve\";}}s:9:\"_fn_close\";a:2:{i:0;r:4;i:1;s:7:\"resolve\";}}"}], "_links": {"type": {"href": "http://192.168.86.76/rest/type/shortcut/default"}}}
```

And the matching logs in JSON https://jsoneditoronline.org/?id=8e756fa3f4e34b20b13756d04df78690