### PR TITLE
Minor improvement on the rule for HTTP request smuggling attack

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -30,7 +30,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,skipAf
 # [ References ]
 # http://projects.webappsec.org/HTTP-Request-Smuggling
 #
-SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?:\n|\r)+(?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+.+http" \
+SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?:\n|\r)+(?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+[^\s]+\s+http" \
     "id:921110,\
     phase:2,\
     block,\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -30,7 +30,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,skipAf
 # [ References ]
 # http://projects.webappsec.org/HTTP-Request-Smuggling
 #
-SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?:\n|\r)+(?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+" \
+SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?:\n|\r)+(?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+.+http" \
     "id:921110,\
     phase:2,\
     block,\

--- a/util/regression-tests/tests/REQUEST-921-PROTOCOL-ATTACK/921110.yaml
+++ b/util/regression-tests/tests/REQUEST-921-PROTOCOL-ATTACK/921110.yaml
@@ -22,3 +22,37 @@
           version: HTTP/1.0
         output:
           log_contains: id "921110"
+  -
+    test_title: 921110-2
+    desc: "HTTP Response Splitting"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: "localhost"
+            Cache-Control: "no-cache, no-store, must-revalidate"
+          method: POST
+          port: 80
+          data: "var=aaa%0aGET+/+HTTP/1.1"
+          version: HTTP/1.0
+        output:
+          log_contains: id "921110"
+  -
+    test_title: 921110-3
+    desc: "HTTP Response Splitting"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: "localhost"
+            Cache-Control: "no-cache, no-store, must-revalidate"
+          method: POST
+          port: 80
+          data: "var=aaa%0dHEAD+http://example.com/+HTTP/1.1"
+          version: HTTP/1.0
+        output:
+          log_contains: id "921110"

--- a/util/regression-tests/tests/REQUEST-921-PROTOCOL-ATTACK/921110.yaml
+++ b/util/regression-tests/tests/REQUEST-921-PROTOCOL-ATTACK/921110.yaml
@@ -5,11 +5,11 @@
     enabled: true
     name: 921110.yaml
   tests:
-  - 
+  -
     test_title: 921110-1
     desc: "HTTP Response Splitting"
     stages:
-    - 
+    -
       stage:
         input:
           dest_addr: 127.0.0.1
@@ -18,7 +18,7 @@
             Cache-Control: "no-cache, no-store, must-revalidate"
           method: POST
           port: 80
-          data: "var=%0aPOST /"
+          data: "var=%0aPOST / HTTP/1.0"
           version: HTTP/1.0
         output:
           log_contains: id "921110"

--- a/util/regression-tests/tests/REQUEST-921-PROTOCOL-ATTACK/921110.yaml
+++ b/util/regression-tests/tests/REQUEST-921-PROTOCOL-ATTACK/921110.yaml
@@ -56,3 +56,20 @@
           version: HTTP/1.0
         output:
           log_contains: id "921110"
+  -
+    test_title: 921110-4
+    desc: "HTTP Response Splitting"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: "localhost"
+            Cache-Control: "no-cache, no-store, must-revalidate"
+          method: POST
+          port: 80
+          data: "var=aaa%0d%0aGet+foo+bar"
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "921110"


### PR DESCRIPTION
The rule 921110 covers too much of free-form text and causes many false-positives.
I believe the rule should check if 'HTTP' exists after request verb and request path in the payload for HTTP request smuggling.
Although it won't get rid of all false-positives, it will decrease the number of them for sure.

I'm not used to contribute to open source project, if my conducts are against to any rules, please point it out. Thank you.