### PR TITLE
XML attack rules file 945000

### DIFF
--- a/rules/REQUEST-945-APPLICATION-ATTACK-XML.conf
+++ b/rules/REQUEST-945-APPLICATION-ATTACK-XML.conf
@@ -1,0 +1,146 @@
+# ------------------------------------------------------------------------
+# OWASP ModSecurity Core Rule Set ver.3.1.0
+# Copyright (c) 2006-2017 Trustwave and contributors. All rights reserved.
+#
+# The OWASP ModSecurity Core Rule Set is distributed under
+# Apache Software License (ASL) version 2
+# Please see the enclosed LICENSE file for full details.
+# ------------------------------------------------------------------------
+
+#
+# -= Paranoia Level 0 (empty) =- (apply unconditionally)
+#
+# This rule skip all XML attacks rules if Content-Type is not
+# one of the following:
+#
+#  - text/xml
+#  - application/xml
+#
+# Keep in mind that an application may parses XML input
+# even if the Content-Type is not one of them listed above.
+# Uncomment this rule only if you're confident about what's
+# the application behavior with different content-types.
+#
+#SecRule !REQUEST_HEADERS:Content-Type "@rx (?:application(?:/soap\+|/)|text/)xml" \
+#	"id:945000,\
+#	phase:1,\
+#	t:none,\
+#	t:lowercase,\
+#	pass,\
+#	nolog,\
+#	skipAfter:END-REQUEST-945-XML"
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:945011,phase:1,pass,nolog,skipAfter:END-REQUEST-945-XML"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:945012,phase:2,pass,nolog,skipAfter:END-REQUEST-945-XML"
+#
+# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+#
+SecRule REQUEST_BODY "@rx <!ENTITY\s+[^\s]+\s+(?:SYSTEM|PUBLIC)\s+['\"](?i:file|http|https|ftp|php|zlib|data|glob|phar|ssh2|rar|ogg|expect|zip|jdbc)://" \
+	"id:945100,\
+	phase:2,\
+	t:none,t:compressWhitespace,t:urlDecode,\
+	log,\
+	msg:'XML eXternal Entity: LFI/RFI using wrapper',\
+	logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',\
+	tag:'application-multi',\
+	tag:'platform-multi',\
+	tag:'attack-xxe',\
+	tag:'OWASP_CRS/WEB_ATTACK/XXE',\
+	tag:'WASCTC/WASC-43',\
+	tag:'OWASP_TOP_10/A4',\
+	tag:'paranoia-level/1',\
+	ver:'OWASP_CRS/3.2.0',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XXE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+SecRule REQUEST_BODY "@rx <!ENTITY\s+[^\s]+\s+(?:SYSTEM|PUBLIC)\s+['\"][^:]+" \
+	"id:945110,\
+	phase:2,\
+	t:none,t:compressWhitespace,t:urlDecode,\
+	log,\
+	msg:'XML eXternal Entity: Local File Inclusion attempt',\
+	logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',\
+	tag:'application-multi',\
+	tag:'platform-multi',\
+	tag:'attack-xxe',\
+	tag:'OWASP_CRS/WEB_ATTACK/XXE',\
+	tag:'WASCTC/WASC-43',\
+	tag:'OWASP_TOP_10/A4',\
+	tag:'paranoia-level/1',\
+	ver:'OWASP_CRS/3.2.0',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XXE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:945013,phase:1,pass,nolog,skipAfter:END-REQUEST-945-XML"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:945014,phase:2,pass,nolog,skipAfter:END-REQUEST-945-XML"
+#
+# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+#
+SecRule REQUEST_BODY "@rx <!ENTITY\s+[^\s]+\s+(?!:SYSTEM|PUBLIC)" \
+	"id:945200,\
+	phase:2,\
+	t:none,t:compressWhitespace,t:urlDecode,\
+	log,\
+	msg:'XML eXternal Entity: Replace values attempt',\
+	logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',\
+	tag:'application-multi',\
+	tag:'platform-multi',\
+	tag:'attack-xxe',\
+	tag:'OWASP_CRS/WEB_ATTACK/XXE',\
+	tag:'WASCTC/WASC-43',\
+	tag:'OWASP_TOP_10/A4',\
+	tag:'paranoia-level/2',\
+	ver:'OWASP_CRS/3.2.0',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XXE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:945015,phase:1,pass,nolog,skipAfter:END-REQUEST-945-XML"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:945016,phase:2,pass,nolog,skipAfter:END-REQUEST-945-XML"
+#
+# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+#
+SecRule REQUEST_BODY "@rx <!ENTITY\s+" \
+	"id:945300,\
+	phase:2,\
+	t:none,t:compressWhitespace,t:urlDecode,\
+	log,\
+	msg:'XML eXternal Entity: ENTITY tag in request',\
+	logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',\
+	tag:'application-multi',\
+	tag:'platform-multi',\
+	tag:'attack-xxe',\
+	tag:'OWASP_CRS/WEB_ATTACK/XXE',\
+	tag:'WASCTC/WASC-43',\
+	tag:'OWASP_TOP_10/A4',\
+	tag:'paranoia-level/3',\
+	ver:'OWASP_CRS/3.2.0',\
+	severity:'CRITICAL',\
+	setvar:'tx.msg=%{rule.msg}',\
+	setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+	setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/XXE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:945017,phase:1,pass,nolog,skipAfter:END-REQUEST-945-XML"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:945018,phase:2,pass,nolog,skipAfter:END-REQUEST-945-XML"
+#
+# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+#
+# -= Paranoia Levels Finished =-
+#
+SecMarker "END-REQUEST-945-XML"

--- a/util/regression-tests/tests/REQUEST-945-APPLICATION-ATTACK-XML/945100.yaml
+++ b/util/regression-tests/tests/REQUEST-945-APPLICATION-ATTACK-XML/945100.yaml
@@ -1,0 +1,48 @@
+---
+  meta: 
+    author: "theMiddle"
+    enabled: true
+    name: "945000.yaml"
+    description: "XXE PL1"
+  tests: 
+    - 
+      test_title: 945100-1
+      desc: XXE LFI/RFI using wrapper
+      stages: 
+        - 
+          stage: 
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              headers:
+                Host: "localhost"
+                Accept: "*/*"
+                User-Agent: "ModSecurity CRS 3 Tests"
+                Content-Type: "text/html"
+              method: POST
+              version: HTTP/1.0
+              uri: /
+              data: "<?xml version=\"1.0\" encoding=\"utf-8\"?><!DOCTYPE xxe [<!ELEMENT name ANY ><!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]><root><name>&xxe;</name></root>"
+            output: 
+              log_contains: "id \"945100\""
+
+    - 
+      test_title: 945000-2
+      desc: XXE Local File Inclusion
+      stages: 
+        - 
+          stage: 
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              headers:
+                Host: "localhost"
+                Accept: "*/*"
+                User-Agent: "ModSecurity CRS 3 Tests"
+                Content-Type: "text/html"
+              method: POST
+              version: HTTP/1.0
+              uri: /
+              data: "<?xml version=\"1.0\" ?><!DOCTYPE replace [<!ENTITY example SYSTEM \"/foo/bar/xyz.txt\"> ]><root><name>&example;</name></root>"
+            output: 
+              log_contains: "id \"945110\""

--- a/util/regression-tests/tests/REQUEST-945-APPLICATION-ATTACK-XML/945200.yaml
+++ b/util/regression-tests/tests/REQUEST-945-APPLICATION-ATTACK-XML/945200.yaml
@@ -1,0 +1,28 @@
+---
+  meta: 
+    author: "theMiddle"
+    enabled: true
+    name: "945200.yaml"
+    description: "XXE Regression Test PL2"
+  tests: 
+    - 
+      test_title: 945200-1
+      desc: XXE test replace response values
+      stages: 
+        - 
+          stage: 
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              headers:
+                Host: "localhost"
+                Accept: "*/*"
+                User-Agent: "ModSecurity CRS 3 Tests"
+                Content-Type: "text/html"
+              method: POST
+              version: HTTP/1.1
+              uri: /
+              data: "<!--?xml version=\"1.0\" ?--><!DOCTYPE replace [<!ENTITY example \"foobar\"> ]><root><name>&example;</name></root>"
+            output: 
+              log_contains: "id \"945200\""
+

--- a/util/regression-tests/tests/REQUEST-945-APPLICATION-ATTACK-XML/945300.yaml
+++ b/util/regression-tests/tests/REQUEST-945-APPLICATION-ATTACK-XML/945300.yaml
@@ -1,0 +1,28 @@
+---
+  meta: 
+    author: "theMiddle"
+    enabled: true
+    name: "945300.yaml"
+    description: "XXE Regression Test PL3"
+  tests: 
+    - 
+      test_title: 945200-1
+      desc: XXE ENTITY tag
+      stages: 
+        - 
+          stage: 
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              headers:
+                Host: "localhost"
+                Accept: "*/*"
+                User-Agent: "ModSecurity CRS 3 Tests"
+                Content-Type: "text/html"
+              method: POST
+              version: HTTP/1.1
+              uri: /
+              data: "<?xml version=\"1.0\" ?><!DOCTYPE replace [<!ENTITY example \"foo\"> ]>"
+            output: 
+              log_contains: "id \"945300\""
+


### PR DESCRIPTION
related to #1319 this PR adds a new rule file for XXE attacks. This file adds 2 rules in PL1, 1 rule in PL2 and 1 rule in PL3:

I'm trying to define something like this:
- PL1: block XXE attacks that uses `SYSTEM` or `PUBLIC` to exploit a LFI/RFI
- PL2: block any kind of requests that includes the `<!ENTITY` tag using `SYSTEM` or `PUBLIC`
- PL3: block any requests with `<!ENTITY` in the body

It would be nice If someone can run and check all regression tests. Any help/comments is really appreciated.

thanks!