### PR TITLE
Add SQLi bypass detection: MySQL comments

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -483,6 +483,44 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
+#
+# -=[ Detect MySQL in-line comments ]=-
+#
+# MySQL in-line comments can be used to bypass SQLi detection.
+#
+# Ref: https://dev.mysql.com/doc/refman/8.0/en/comments.html:
+# SELECT /*! STRAIGHT_JOIN */ col1 FROM table1,table2 WHERE ...
+# CREATE TABLE t1(a INT, KEY (a)) /*!50110 KEY_BLOCK_SIZE=1024 */;
+# SELECT /*+ BKA(t1) */ FROM ... ;
+#
+# http://localhost/test.php?id=9999+or+{if+length((/*!5000select+username/*!50000from*/user+where+id=1))>0}
+#
+# The minimal string that triggers this regexp is: /*!*/ or /*+*/.
+# The rule 942500 is related to 942440 which catches both /*! and */ independently.
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:/\*[!+](?:[\w\s=_\-()]+)?\*/)" \
+    "id:942500,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:urlDecodeUni,\
+    msg:'MySQL in-line comment detected.',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-sqli',\
+    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
+    tag:'WASCTC/WASC-19',\
+    tag:'OWASP_TOP_10/A1',\
+    tag:'OWASP_AppSensor/CIE1',\
+    tag:'PCI/6.5.2',\
+    ver:'OWASP_CRS/3.2.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.msg=%{rule.msg}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/SQLI-%{MATCHED_VAR_NAME}=%{tx.0}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:942013,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"

--- a/util/regression-tests/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942500.yaml
+++ b/util/regression-tests/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942500.yaml
@@ -1,0 +1,23 @@
+---
+  meta:
+    author: "Franziska Buehler"
+    description: None
+    enabled: true
+    name: 942500.yaml
+  tests:
+  - 
+    test_title: 942500-1
+    desc: "MySQL in-line comment detection"
+    stages:
+    - 
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: POST
+          port: 80
+          uri: "?id=9999+or+{if+length((/*!5000select+username/*!50000from*/user+where+id=1))>0}"
+          version: HTTP/1.0
+        output:
+          log_contains: id "942500"


### PR DESCRIPTION
This PR partially resolves issue #1167.
The new SQLi rule 942500 detects in-line MySQL comments, that can be used to bypass SQLi detection.
I have placed the new rule at PL1, because it will come with a new release 3.2.
I can also move this rule to PL2. But then we would still have no detection at PL1.