### PR TITLE
WordPress: exclude Gutenberg via rest_route

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -110,10 +110,10 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
         "t:none,\
         nolog,\
         chain"
-    SecRule ARGS:rest_route "@rx ^/wp/v[0-9]+/(?:posts|pages)" \
-        "t:none,\
-        ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
-        ctl:ruleRemoveTargetByTag=CRS;ARGS:json.content"
+        SecRule ARGS:rest_route "@rx ^/wp/v[0-9]+/(?:posts|pages)" \
+            "t:none,\
+            ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
+            ctl:ruleRemoveTargetByTag=CRS;ARGS:json.content"
 
 #
 # [ Live preview ]

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -98,6 +98,22 @@ SecRule REQUEST_FILENAME "@rx ^/wp\-json/wp/v[0-9]+/(?:posts|pages)" \
     ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
     ctl:ruleRemoveTargetByTag=CRS;ARGS:json.content"
 
+# Gutenberg via rest_route for sites without pretty permalinks
+SecRule REQUEST_FILENAME "@endsWith /index.php" \
+    "id:9002141,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &ARGS:rest_route "@eq 1" \
+        "t:none,\
+        nolog,\
+        chain"
+    SecRule ARGS:rest_route "@rx ^/wp/v[0-9]+/(?:posts|pages)" \
+        "t:none,\
+        ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
+        ctl:ruleRemoveTargetByTag=CRS;ARGS:json.content"
 
 #
 # [ Live preview ]


### PR DESCRIPTION
In WordPress 5.x, the Gutenberg editor uses WordPress REST API to store the content, therefore we have excluded the URI pattern `/wp-json/wp/v2/posts/1234` to solve false positives in posted HTML.

However, on sites without pretty permalinks setting (and also sometimes in other situations), WordPress posts to the following endpoint instead `/index.php?rest_route=/wp/v2/posts/1234`.

So, we also have to make an exclusion on `index.php` if the `rest_route` parameter is matching.

Fixes #1309 .
