### PR TITLE
WordPress: exclude SQL comment rule from _wp_http_referer

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -337,6 +337,7 @@ SecAction \
     ctl:ruleRemoveTargetById=942200;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=942260;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=942431;ARGS:_wp_http_referer,\
+    ctl:ruleRemoveTargetById=942440;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=920230;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=931130;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=932150;ARGS:wp_http_referer,\


### PR DESCRIPTION
Found a false positive on rule 942440 in `_wp_http_referer`. As this parameter is passed around constantly in the WordPress admin panel, it ended up blocking the user's session entirely. Oops!