### PR TITLE
add missing OWASP_CRS tags to 921xxx rules

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -42,6 +42,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx [\n\r]+(?:get|post|head|options|connect|put|
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS/WEB_ATTACK/REQUEST_SMUGGLING',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -74,6 +75,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS/WEB_ATTACK/RESPONSE_SPLITTING',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -95,6 +97,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS/WEB_ATTACK/RESPONSE_SPLITTING',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -129,6 +132,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS/WEB_ATTACK/HEADER_INJECTION',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -157,6 +161,7 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS/WEB_ATTACK/HEADER_INJECTION',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -178,6 +183,7 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx (?:\n|\r)+(?:\s|location|refresh|(?:set-)?c
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS/WEB_ATTACK/HEADER_INJECTION',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -214,6 +220,7 @@ SecRule ARGS_GET "@rx [\n\r]" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/2',\
+    tag:'OWASP_CRS/WEB_ATTACK/HEADER_INJECTION',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -272,6 +279,7 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS/WEB_ATTACK/HTTP_PARAMETER_POLLUTION',\
     tag:'paranoia-level/3',\
     tag:'CAPEC-460',\
     ver:'OWASP_CRS/3.1.0',\


### PR DESCRIPTION
It's nice to have the `OWASP_CRS/FOO/BAR` tags on every rule. It helps to distinguish in log analysis that the alert came from a CRS rule. The tag is also used in exclusions, to disable all the CRS rules on a certain target.

I just noticed from a FP report, that file 921xxx doesn't contain this tag, so adding them quickly. (Haven't done a complete review of all our files.)