### PR TITLE
remove WARNING from php-errors.data

### DIFF
--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -1,4 +1,3 @@
-<b>Warning</b>:
 No row with the given identifier
 open_basedir restriction in effect
 eval()'d code</b> on line <b>


### PR DESCRIPTION
referring to #1182 this PR removes `<b>Warning</b>:` from `php-errors.data`. All PHP warning messages already match 953100.