### PR TITLE
Purge Git history in Docker image (saves > 3 MiB)

### DIFF
--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -1,23 +1,21 @@
 FROM owasp/modsecurity:2.9-apache-ubuntu
-MAINTAINER Chaim Sanders chaim.sanders@gmail.com
+LABEL maintainer="Chaim Sanders <chaim.sanders@gmail.com>"
 
 ARG COMMIT=v3.2/dev
 ARG REPO=SpiderLabs/owasp-modsecurity-crs
 ENV PARANOIA=1
 
 RUN apt-get update && \
-    apt-get -y install python git ca-certificates iproute2
-
-RUN cd /opt && \
-  git clone https://github.com/${REPO}.git owasp-modsecurity-crs-3.2 && \
-  cd owasp-modsecurity-crs-3.2 && \
-  git checkout -qf ${COMMIT} 
-
-RUN cd /opt && \
-  cp -R /opt/owasp-modsecurity-crs-3.2/ /etc/apache2/modsecurity.d/owasp-crs/ && \
-  mv /etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf.example /etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf && \
-  cd /etc/apache2/modsecurity.d && \
-  printf "include modsecurity.d/owasp-crs/crs-setup.conf\ninclude modsecurity.d/owasp-crs/rules/*.conf" > include.conf && \
+  apt-get -y install python git ca-certificates iproute2 && \
+  mkdir /opt/owasp-modsecurity-crs-3.2 && \
+  cd /opt/owasp-modsecurity-crs-3.2 && \
+  git init && \
+  git remote add origin https://github.com/${REPO}.git && \
+  git fetch --depth 1 origin ${COMMIT} && \
+  git checkout FETCH_HEAD && \
+  mv crs-setup.conf.example crs-setup.conf && \
+  ln -sv /opt/owasp-modsecurity-crs-3.2 /etc/apache2/modsecurity.d/owasp-crs && \
+  printf "include modsecurity.d/owasp-crs/crs-setup.conf\ninclude modsecurity.d/owasp-crs/rules/*.conf" > /etc/apache2/modsecurity.d/include.conf && \
   sed -i -e 's/SecRuleEngine DetectionOnly/SecRuleEngine On/g' /etc/apache2/modsecurity.d/modsecurity.conf && \
   a2enmod proxy proxy_http
 


### PR DESCRIPTION
This change:

- reduces the Docker image size by more than 3 MiB using a [shallow Git clone](https://stackoverflow.com/questions/21833870/how-do-i-shallow-clone-a-repo-on-a-specific-branch) of the CRS repository,
- which also speeds up the Docker build significantly.
- removes one image layer and the software installed only for cloning the repo with Git,
- replaces the deprecated `MAINTAINER` directive by the [suggested](https://docs.docker.com/engine/reference/builder/#maintainer) `LABEL`