### PR TITLE
Also handle dot variant of X_Filename

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -88,7 +88,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # X_Filename, or X-File-Name to transmit the file name to the server;
 # scan these request headers as well as multipart/form-data file names.
 #
-SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X-File-Name "@rx .*\.(?:php\d*|phtml)\.*$" \
+SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X.Filename|REQUEST_HEADERS:X-File-Name "@rx .*\.(?:php\d*|phtml)\.*$" \
     "id:933110,\
     phase:2,\
     block,\
@@ -684,7 +684,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 #
 # This rule is a stricter sibling of rule 933110.
 #
-SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X-File-Name "@rx .*\.(?:php\d*|phtml)\..*$" \
+SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X.Filename|REQUEST_HEADERS:X-File-Name "@rx .*\.(?:php\d*|phtml)\..*$" \
     "id:933111,\
     phase:2,\
     block,\

--- a/util/regression-tests/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933110.yaml
+++ b/util/regression-tests/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933110.yaml
@@ -288,3 +288,63 @@
           uri: /
         output:
           no_log_contains: id "933110"
+  -
+    test_title: 933110-20
+    desc: PHP script uploads
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+            X.Filename: a.php
+          port: 80
+          uri: /upload2
+        output:
+          log_contains: id "933110"
+  -
+    test_title: 933110-21
+    desc: PHP script uploads
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+            X.Filename: fda.php5...
+          port: 80
+          uri: /upload6
+        output:
+          log_contains: id "933110"
+  -
+    test_title: 933110-22
+    desc: PHP script uploads
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+            X.Filename: fthisfewfda.php.
+          port: 80
+          uri: /upload7
+        output:
+          log_contains: id "933110"
+  -
+    test_title: 933110-23
+    desc: PHP script uploads
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+            X.Filename: fthi/sfewfda.phtml987...
+          port: 80
+          uri: /
+        output:
+          no_log_contains: id "933110"


### PR DESCRIPTION
PHP will transform dots to underscore in variable names since dot is invalid.

Fixes #1386.