### PR TITLE
New PL3 rule 920490 to protect against content-type charset bypassing

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1372,9 +1372,7 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     SecRule REQUEST_HEADERS:User-Agent "@rx ^(?i)up" \
         "t:none,\
         t:lowercase,\
-        setvar:'tx.msg=%{rule.msg}',\
-        setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+        setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1455,7 +1455,7 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
     chain"
-    SecRule REQUEST_HEADERS:User-Agent "@beginsWith up" \
+    SecRule REQUEST_HEADERS:User-Agent "@rx ^(?i)up" \
         "t:none,\
         t:lowercase,\
         setvar:'tx.msg=%{rule.msg}',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1457,7 +1457,6 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@rx ^(?i)up" \
         "t:none,\
-        t:lowercase,\
         setvar:'tx.msg=%{rule.msg}',\
         setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
         setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1430,6 +1430,39 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
     setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
 
+#
+# PL3: The little known x-up-devcap-post-charset request header can be used to submit
+# a request with a different encoding as an alternative to the charset parameter in
+# the Content-Type header. This can be used to circumvent charset restrictions on
+# the Content-Type header.
+# Note that this only works in combination with a User-Agent prefix.
+#
+# This rule is based on a blog post by Soroush Dalili at
+# https://soroush.secproject.com/blog/2019/05/x-up-devcap-post-charset-header-in-aspnet-to-bypass-wafs-again/
+#
+SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
+    "id:920490,\
+    phase:1,\
+    block,\
+    t:none,\
+    msg:'Request header x-up-devcap-post-charset detected in combination with prefix \'UP\' to User-Agent',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
+    tag:'language-aspnet',\
+    tag:'platform-windows',\
+    tag:'attack-protocol',\
+    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
+    tag:'paranoia-level/3',\
+    ver:'OWASP_CRS/3.1.0',\
+    severity:'CRITICAL',\
+    chain"
+    SecRule REQUEST_HEADERS:User-Agent "@beginsWith up" \
+        "t:none,\
+        t:lowercase,\
+        setvar:'tx.msg=%{rule.msg}',\
+        setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
+        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:920018,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1434,7 +1434,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
 # PL3: The little known x-up-devcap-post-charset request header can be used to submit
 # a request with a different encoding as an alternative to the charset parameter in
 # the Content-Type header. This can be used to circumvent charset restrictions on
-# the Content-Type header.
+# the Content-Type header in ASP.NET.
 # Note that this only works in combination with a User-Agent prefix.
 #
 # This rule is based on a blog post by Soroush Dalili at

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1375,38 +1375,6 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
         setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-#
-# PL3: The little known x-up-devcap-post-charset request header can be used to submit
-# a request with a different encoding as an alternative to the charset parameter in
-# the Content-Type header. This can be used to circumvent charset restrictions on
-# the Content-Type header in ASP.NET.
-# Note that this only works in combination with a User-Agent prefix.
-#
-# This rule is based on a blog post by Soroush Dalili at
-# https://soroush.secproject.com/blog/2019/05/x-up-devcap-post-charset-header-in-aspnet-to-bypass-wafs-again/
-#
-SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
-    "id:920490,\
-    phase:1,\
-    block,\
-    t:none,\
-    msg:'Request header x-up-devcap-post-charset detected in combination with prefix \'UP\' to User-Agent',\
-    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
-    tag:'language-aspnet',\
-    tag:'platform-windows',\
-    tag:'attack-protocol',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
-    tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.1.0',\
-    severity:'CRITICAL',\
-    chain"
-    SecRule REQUEST_HEADERS:User-Agent "@rx ^(?i)up" \
-        "t:none,\
-        setvar:'tx.msg=%{rule.msg}',\
-        setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.%{rule.id}-OWASP_CRS/PROTOCOL_VIOLATION/EVASION-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
-
-
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:920018,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920490.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920490.yaml
@@ -1,0 +1,51 @@
+---
+  meta:
+    author: "Christian Folini"
+    enabled: true
+    name: "920490.yaml"
+    description: "Tests for the charset protection in combination with the x-up-devcap-post-charset header"
+  tests:
+    - test_title: 920490-1
+      stages:
+        - stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "POST"
+              headers:
+                  User-Agent: "UP ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "application/x-www-form-urlencoded; charset=utf-8"
+                  x-up-devcap-post-charset: "ibm500"
+              data: "%89%95%97%A4%A3%F1=%A7%A7%A7%A7%A7%A7%A7"
+            output:
+              log_contains: "id \"920490\""
+    - test_title: 920490-2
+      stages:
+        - stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "POST"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "application/x-www-form-urlencoded; charset=utf-8"
+                  x-up-devcap-post-charset: "ibm500"
+              data: "%89%95%97%A4%A3%F1=%A7%A7%A7%A7%A7%A7%A7"
+            output:
+              no_log_contains: "id \"920490\""
+    - test_title: 920490-3
+      stages:
+        - stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "POST"
+              headers:
+                  User-Agent: "UP ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "application/x-www-form-urlencoded; charset=utf-8"
+              data: "%89%95%97%A4%A3%F1=%A7%A7%A7%A7%A7%A7%A7"
+            output:
+              no_log_contains: "id \"920490\""


### PR DESCRIPTION
PL3: The little known x-up-devcap-post-charset request header can be used to submit
a request with a different encoding as an alternative to the charset parameter in
the Content-Type header. This can be used to circumvent charset restrictions on
the Content-Type header.
Note that this only works in combination with a User-Agent prefix.

This rule is based on a blog post by Soroush Dalili:
https://soroush.secproject.com/blog/2019/05/x-up-devcap-post-charset-header-in-aspnet-to-bypass-wafs-again/