### PR TITLE
920470: allow dot characters in Content-Type multipart boundary

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -919,7 +919,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - text/plain; charset="UTF-8"
 # - multipart/form-data; boundary=----WebKitFormBoundary12345
 #
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w\d/\.\-\+]+(?:\s?;\s?(?:boundary|charset)\s?=\s?['\"\w\d_\-]+)?$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w\d/\.\-\+]+(?:\s?;\s?(?:boundary|charset)\s?=\s?['\"\w\d\.\-]+)?$" \
     "id:920470,\
     phase:1,\
     block,\

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
@@ -113,3 +113,17 @@
                   Content-Length: 0
             output:
               no_log_contains: "id \"920470\""
+    - test_title: 920470-9
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              method: POST
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'multipart/form-data; boundary=----formdata-polyfill-0.40616634299_704013'
+                  Content-Length: 0
+            output:
+              no_log_contains: "id \"920470\""


### PR DESCRIPTION
Apparently dots also sometimes show up after: `Content-Type: multipart/form-data; boundary=`

This caused a false alert, which is fixed by this commit.

(Also spotted that `\w` includes `_` so I cleaned that up.)