### PR TITLE
Fix regexp with incorrect dot '.' escape in rule 943120 (#1413)

### DIFF
--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -76,7 +76,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
             setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp.net_sessionid|phpsession|phpsessid|weblogicsession|session_id|session-id|cfid|cftoken|cfsid|jservsession|jwsession)$" \
+SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsession|phpsessid|weblogicsession|session_id|session-id|cfid|cftoken|cfsid|jservsession|jwsession)$" \
     "id:943120,\
     phase:2,\
     block,\


### PR DESCRIPTION
@lifeforms