### PR TITLE
Ensure Docker image can be built

### DIFF
--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM owasp/modsecurity:v2-ubuntu-apache
+FROM owasp/modsecurity:2.9-apache-ubuntu
 MAINTAINER Chaim Sanders chaim.sanders@gmail.com
 
 ARG COMMIT=v3.1/dev
@@ -11,17 +11,18 @@ RUN apt-get update && \
 RUN cd /opt && \
   git clone https://github.com/${REPO}.git owasp-modsecurity-crs-3.1 && \
   cd owasp-modsecurity-crs-3.1 && \
-  git checkout -qf ${COMMIT} 
+  git checkout -qf ${COMMIT}
 
 RUN cd /opt && \
+  mkdir -pv /etc/apache2/modsecurity.d && \
   cp -R /opt/owasp-modsecurity-crs-3.1/ /etc/apache2/modsecurity.d/owasp-crs/ && \
   mv /etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf.example /etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf && \
   cd /etc/apache2/modsecurity.d && \
   printf "include modsecurity.d/owasp-crs/crs-setup.conf\ninclude modsecurity.d/owasp-crs/rules/*.conf" > include.conf && \
-  sed -i -e 's/SecRuleEngine DetectionOnly/SecRuleEngine On/g' /etc/apache2/modsecurity.d/modsecurity.conf && \
+  sed -i -e 's/SecRuleEngine DetectionOnly/SecRuleEngine On/g' /etc/modsecurity.d/modsecurity.conf && \
   a2enmod proxy proxy_http
 
-COPY proxy.conf           /etc/apache2/modsecurity.d/proxy.conf
+COPY proxy.conf           /etc/modsecurity.d/proxy.conf
 COPY docker-entrypoint.sh /
 
 EXPOSE 80


### PR DESCRIPTION
Hi! This is a minimal PR to ensure the 3.1 branch can at least be built. This should help with #1420.

I know you're working on the 3.2 branch, but the 3.1 Tag on Docker Hub is horribly out of date and contains a lot of critical CVEs, which is kind of bad of r a security-related project.

Changes:
* Use a base image tag that exists
* /etc/apache2/modsecurity.d has been moved to /etc/modsecurity.d