### PR TITLE
Fix Travis Merge not being able to find HEAD

### DIFF
--- a/util/docker/Dockerfile-2.9-apache
+++ b/util/docker/Dockerfile-2.9-apache
@@ -1,7 +1,7 @@
 FROM owasp/modsecurity:2.9-apache
 LABEL maintainer="Chaim Sanders <chaim.sanders@gmail.com>"
 
-ARG COMMIT=HEAD
+ARG COMMIT=v3.2/dev
 ARG BRANCH=v3.2/dev
 ARG REPO=SpiderLabs/owasp-modsecurity-crs
 ENV WEBSERVER=Apache


### PR DESCRIPTION
When I added commits to move to the design described by @bittner, I made the assumption that git checkout HEAD would grab the commit we needed. When no branch has been checked out and there is no SHA hash,  this will not work and we need to use the name of the branch instead. This commit fixes that issue.