### PR TITLE
Ensure OWASP CRS v3.1 uses new upstream Modsecurity Docker image

### DIFF
--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -1,27 +1,26 @@
-FROM owasp/modsecurity:v2-ubuntu-apache
-MAINTAINER Chaim Sanders chaim.sanders@gmail.com
+FROM owasp/modsecurity:2.9-apache
+LABEL maintainer="Chaim Sanders <chaim.sanders@gmail.com>"
 
 ARG COMMIT=v3.1/dev
+ARG BRANCH=v3.1/dev
 ARG REPO=SpiderLabs/owasp-modsecurity-crs
+ENV WEBSERVER=Apache
 ENV PARANOIA=1
 
 RUN apt-get update && \
-    apt-get -y install python git ca-certificates iproute2
+  apt-get -y install python git ca-certificates iproute2 && \
+  mkdir /opt/owasp-modsecurity-crs-3.2 && \
+  cd /opt/owasp-modsecurity-crs-3.2 && \
+  git init && \
+  git remote add origin https://github.com/${REPO} && \
+  git fetch --depth 1 origin ${BRANCH} && \
+  git checkout ${COMMIT} && \
+  mv crs-setup.conf.example crs-setup.conf && \
+  ln -sv /opt/owasp-modsecurity-crs-3.2 /etc/modsecurity.d/owasp-crs && \
+  printf "include /etc/modsecurity.d/owasp-crs/crs-setup.conf\ninclude /etc/modsecurity.d/owasp-crs/rules/*.conf" >> /etc/modsecurity.d/include.conf && \
+  sed -i -e 's/SecRuleEngine DetectionOnly/SecRuleEngine On/g' /etc/modsecurity.d/modsecurity.conf
 
-RUN cd /opt && \
-  git clone https://github.com/${REPO}.git owasp-modsecurity-crs-3.1 && \
-  cd owasp-modsecurity-crs-3.1 && \
-  git checkout -qf ${COMMIT} 
-
-RUN cd /opt && \
-  cp -R /opt/owasp-modsecurity-crs-3.1/ /etc/apache2/modsecurity.d/owasp-crs/ && \
-  mv /etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf.example /etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf && \
-  cd /etc/apache2/modsecurity.d && \
-  printf "include modsecurity.d/owasp-crs/crs-setup.conf\ninclude modsecurity.d/owasp-crs/rules/*.conf" > include.conf && \
-  sed -i -e 's/SecRuleEngine DetectionOnly/SecRuleEngine On/g' /etc/apache2/modsecurity.d/modsecurity.conf && \
-  a2enmod proxy proxy_http
-
-COPY proxy.conf           /etc/apache2/modsecurity.d/proxy.conf
+COPY proxy.conf           /etc/modsecurity.d/proxy.conf
 COPY docker-entrypoint.sh /
 
 EXPOSE 80

--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -9,14 +9,14 @@ ENV PARANOIA=1
 
 RUN apt-get update && \
   apt-get -y install python git ca-certificates iproute2 && \
-  mkdir /opt/owasp-modsecurity-crs-3.2 && \
-  cd /opt/owasp-modsecurity-crs-3.2 && \
+  mkdir /opt/owasp-modsecurity-crs-3.1 && \
+  cd /opt/owasp-modsecurity-crs-3.1 && \
   git init && \
   git remote add origin https://github.com/${REPO} && \
   git fetch --depth 1 origin ${BRANCH} && \
   git checkout ${COMMIT} && \
   mv crs-setup.conf.example crs-setup.conf && \
-  ln -sv /opt/owasp-modsecurity-crs-3.2 /etc/modsecurity.d/owasp-crs && \
+  ln -sv /opt/owasp-modsecurity-crs-3.1 /etc/modsecurity.d/owasp-crs && \
   printf "include /etc/modsecurity.d/owasp-crs/crs-setup.conf\ninclude /etc/modsecurity.d/owasp-crs/rules/*.conf" >> /etc/modsecurity.d/include.conf && \
   sed -i -e 's/SecRuleEngine DetectionOnly/SecRuleEngine On/g' /etc/modsecurity.d/modsecurity.conf
 

--- a/util/docker/docker-entrypoint.sh
+++ b/util/docker/docker-entrypoint.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
-python -c "import re;import os;out=re.sub('(#SecAction[\S\s]{7}id:900000[\s\S]*tx\.paranoia_level=1\")','SecAction \\\\\n  \"id:900000, \\\\\n   phase:1, \\\\\n   nolog, \\\\\n   pass, \\\\\n   t:none, \\\\\n   setvar:tx.paranoia_level='+os.environ['PARANOIA']+'\"',open('/etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf','r').read());open('/etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)" && \
-python -c "import re;import os;out=re.sub('(#SecAction[\S\s]{6}id:900330[\s\S]*total_arg_length=64000\")','SecAction \\\\\n \"id:900330, \\\\\n phase:1, \\\\\n nolog, \\\\\n pass, \\\\\n t:none, \\\\\n setvar:tx.total_arg_length=64000\"',open('/etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf','r').read());open('/etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)" && \
 
-if [ ! -z $PROXY ]; then
-  if [ $PROXY -eq 1 ]; then
-    APACHE_ARGUMENTS='-D crs_proxy'
-    if [ -z "$UPSTREAM" ]; then
-      export UPSTREAM=$(/sbin/ip route | grep ^default | perl -pe 's/^.*?via ([\d.]+).*/$1/g'):81
+python -c "import re;import os;out=re.sub('(#SecAction[\S\s]{7}id:900000[\s\S]*tx\.paranoia_level=1\")','SecAction \\\\\n  \"id:900000, \\\\\n   phase:1, \\\\\n   nolog, \\\\\n   pass, \\\\\n   t:none, \\\\\n   setvar:tx.paranoia_level='+os.environ['PARANOIA']+'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read());open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)" && \
+python -c "import re;import os;out=re.sub('(#SecAction[\S\s]{6}id:900330[\s\S]*total_arg_length=64000\")','SecAction \\\\\n \"id:900330, \\\\\n phase:1, \\\\\n nolog, \\\\\n pass, \\\\\n t:none, \\\\\n setvar:tx.total_arg_length=64000\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read());open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)" && \
+
+if [ $WEBSERVER = "Apache" ]; then
+  if [ ! -z $PROXY ]; then
+    if [ $PROXY -eq 1 ]; then
+      WEBSERVER_ARGUMENTS='-D crs_proxy'
+      if [ -z "$UPSTREAM" ]; then
+        export UPSTREAM=$(/sbin/ip route | grep ^default | perl -pe 's/^.*?via ([\d.]+).*/$1/g'):81
+      fi
     fi
   fi
+elif [ $WEBSERVER = "Nginx" ]; then
+  WEBSERVER_ARGUMENTS=''
 fi
 
 
-exec "$@" $APACHE_ARGUMENTS
+exec "$@" $WEBSERVER_ARGUMENTS


### PR DESCRIPTION
@mhutter wisely pointed out that the 3.1 image is broken via the new upstream rules. This will fix that.