### PR TITLE
Fixing commit default for non 2.9 branch

### DIFF
--- a/util/docker/Dockerfile-3.0-apache
+++ b/util/docker/Dockerfile-3.0-apache
@@ -1,7 +1,7 @@
 FROM owasp/modsecurity:3.0-apache
 LABEL maintainer="Chaim Sanders <chaim.sanders@gmail.com>"
 
-ARG COMMIT=HEAD
+ARG COMMIT=v3.2/dev
 ARG BRANCH=v3.2/dev
 ARG REPO=SpiderLabs/owasp-modsecurity-crs
 ENV WEBSERVER=Apache

--- a/util/docker/Dockerfile-3.0-nginx
+++ b/util/docker/Dockerfile-3.0-nginx
@@ -1,7 +1,7 @@
 FROM owasp/modsecurity:3.0-nginx
 LABEL maintainer="Chaim Sanders <chaim.sanders@gmail.com>"
 
-ARG COMMIT=HEAD
+ARG COMMIT=v3.2/dev
 ARG BRANCH=v3.2/dev
 ARG REPO=SpiderLabs/owasp-modsecurity-crs
 ENV WEBSERVER=Nginx


### PR DESCRIPTION
so i only made changes for 2.9 and not nginx 3 or apache 3. As a result those builds failed, but since they were allowed to fail -- it wasn't caught. This PR fixes it for future generations!