### PR TITLE
replace ctl:ruleRemoveTargetByTag=CRS with ruleRemoveTargetById

### DIFF
--- a/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
@@ -117,8 +117,8 @@ SecRule REQUEST_FILENAME "@endsWith /core/install.php" \
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:account[pass][pass1],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:account[pass][pass2]"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:account[pass][pass1],\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:account[pass][pass2]"
 
 SecRule REQUEST_FILENAME "@endsWith /user/login" \
     "id:9001112,\
@@ -126,24 +126,24 @@ SecRule REQUEST_FILENAME "@endsWith /user/login" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:pass"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:pass"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/people/create" \
     "id:9001114,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:pass[pass1],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:pass[pass2]"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:pass[pass1],\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:pass[pass2]"
 
 SecRule REQUEST_FILENAME "@rx /user/[0-9]+/edit$" \
     "id:9001116,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:current_pass,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:pass[pass1],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:pass[pass2]"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:current_pass,\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:pass[pass1],\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:pass[pass2]"
 
 
 #
@@ -171,14 +171,14 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/people/accounts" \
     nolog,\
     ctl:ruleRemoveById=920271,\
     ctl:ruleRemoveById=942440,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_cancel_confirm_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_password_reset_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_register_admin_created_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_register_no_approval_required_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_register_pending_approval_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_status_activated_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_status_blocked_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_status_canceled_body"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:user_mail_cancel_confirm_body,\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:user_mail_password_reset_body,\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:user_mail_register_admin_created_body,\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:user_mail_register_no_approval_required_body,\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:user_mail_register_pending_approval_body,\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:user_mail_status_activated_body,\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:user_mail_status_blocked_body,\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:user_mail_status_canceled_body"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/configuration/single/import" \
     "id:9001126,\
@@ -242,8 +242,8 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/content/formats/manage/full_ht
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:editor[settings][toolbar][button_groups],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:filters[filter_html][settings][allowed_html]"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:editor[settings][toolbar][button_groups],\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:filters[filter_html][settings][allowed_html]"
 
 
 #
@@ -316,7 +316,7 @@ SecRule REQUEST_FILENAME "@endsWith /node/add/article" \
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:body[0][value],\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:body[0][value],\
     ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id]"
 
 SecRule REQUEST_FILENAME "@endsWith /node/add/page" \
@@ -324,7 +324,7 @@ SecRule REQUEST_FILENAME "@endsWith /node/add/page" \
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:body[0][value],\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:body[0][value],\
     ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id]"
 
 SecRule REQUEST_FILENAME "@rx /node/[0-9]+/edit$" \
@@ -332,7 +332,7 @@ SecRule REQUEST_FILENAME "@rx /node/[0-9]+/edit$" \
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:body[0][value],\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:body[0][value],\
     ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id],\
     ctl:ruleRemoveTargetById=932110;ARGS:destination"
 
@@ -341,42 +341,42 @@ SecRule REQUEST_FILENAME "@endsWith /block/add" \
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:body[0][value]"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:body[0][value]"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/structure/block/block-content/manage/basic" \
     "id:9001208,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:description"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:description"
 
 SecRule REQUEST_FILENAME "@rx /editor/filter_xss/(?:full|basic)_html$" \
     "id:9001210,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:value"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:value"
 
 SecRule REQUEST_FILENAME "@rx /user/[0-9]+/contact$" \
     "id:9001212,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:message[0][value]"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:message[0][value]"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     "id:9001214,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:maintenance_mode_message"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:maintenance_mode_message"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/services/rss-publishing" \
     "id:9001216,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:feed_description"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:feed_description"
 
 
 SecMarker "END-DRUPAL-RULE-EXCLUSIONS"

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -49,7 +49,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:pwd"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:pwd"
 
 # Reset password
 SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
@@ -64,9 +64,9 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass1,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass1-text,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass2"
 
 
 #
@@ -95,8 +95,8 @@ SecRule REQUEST_FILENAME "@rx ^/wp\-json/wp/v[0-9]+/(?:posts|pages)" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:json.content"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:content,\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:json.content"
 
 # Gutenberg via rest_route for sites without pretty permalinks
 SecRule REQUEST_FILENAME "@endsWith /index.php" \
@@ -112,8 +112,8 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
         chain"
         SecRule ARGS:rest_route "@rx ^/wp/v[0-9]+/(?:posts|pages)" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:json.content"
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:content,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:json.content"
 
 #
 # [ Live preview ]
@@ -253,7 +253,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/setup-config.php" \
         chain"
         SecRule &ARGS:step "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pwd"
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pwd"
 
 # WordPress installation: exclude admin password
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/install.php" \
@@ -268,9 +268,9 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/install.php" \
         chain"
         SecRule &ARGS:step "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:admin_password,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:admin_password2,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text"
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:admin_password,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:admin_password2,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass1-text"
 
 
 #
@@ -293,9 +293,9 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
             ctl:ruleRemoveTargetById=931130;ARGS:url,\
             ctl:ruleRemoveTargetById=931130;ARGS:facebook,\
             ctl:ruleRemoveTargetById=931130;ARGS:googleplus,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass1,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass1-text,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass2"
 
 # Edit user
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-edit.php" \
@@ -311,9 +311,9 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-edit.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetById=931130;ARGS:url,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass1,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass1-text,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass2"
 
 # Create user
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-new.php" \
@@ -329,9 +329,9 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-new.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetById=931130;ARGS:url,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass1,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass1-text,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass2"
 
 
 #
@@ -385,7 +385,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/post.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:post_title,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:content,\
             ctl:ruleRemoveById=920272,\
             ctl:ruleRemoveById=921180"
 
@@ -404,7 +404,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:data[wp_autosave][post_title],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:data[wp_autosave][content],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:data[wp_autosave][content],\
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-refresh-post-lock][post_id],\
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-refresh-post-lock][lock],\
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-check-locked-posts][],\
@@ -448,46 +448,46 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[0][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[1][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[2][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[3][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[4][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[5][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[6][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[7][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[8][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[9][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[10][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[11][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[12][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[13][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[14][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[15][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[16][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[17][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[18][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[19][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[20][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[21][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[22][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[23][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[24][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[25][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[26][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[27][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[28][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[29][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[30][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[31][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[32][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[33][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[34][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[35][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[36][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[37][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[38][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[39][text]"
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[0][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[1][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[2][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[3][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[4][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[5][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[6][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[7][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[8][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[9][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[10][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[11][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[12][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[13][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[14][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[15][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[16][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[17][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[18][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[19][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[20][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[21][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[22][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[23][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[24][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[25][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[26][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[27][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[28][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[29][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[30][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[31][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[32][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[33][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[34][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[35][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[36][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[37][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[38][text],\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:widget-text[39][text]"
 
 # Reorder widgets
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
@@ -560,7 +560,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:html"
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:html"
 
 
 #
@@ -624,8 +624,8 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
                 chain"
                 SecRule &ARGS:action "@eq 1" \
                     "t:none,\
-                    ctl:ruleRemoveTargetByTag=CRS;ARGS:blacklist_keys,\
-                    ctl:ruleRemoveTargetByTag=CRS;ARGS:moderation_keys"
+                    ctl:ruleRemoveTargetById=910000-999999;ARGS:blacklist_keys,\
+                    ctl:ruleRemoveTargetById=910000-999999;ARGS:moderation_keys"
 
 # Posts/pages overview search
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
@@ -634,7 +634,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:s"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:s"
 
 
 #

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -243,7 +243,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:filecontents,\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:filecontents,\
     ctl:ruleRemoveTargetById=921110-921160;ARGS:filecontents,\
     ctl:ruleRemoveTargetById=932150;ARGS:filename,\
     ctl:ruleRemoveTargetById=920370-920390;ARGS:filecontents,\
@@ -318,7 +318,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/login" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=941100;ARGS:requesttoken,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:password"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:password"
 
 # Reset password.
 
@@ -334,9 +334,9 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass1,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass1-text,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass2"
 
 # Change Password and Setting up a new user/password
 
@@ -346,8 +346,8 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:newuserpassword,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:password"
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:newuserpassword,\
+    ctl:ruleRemoveTargetById=910000-999999;ARGS:password"
 
 
 SecMarker "END-NEXTCLOUD-ADMIN"

--- a/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
@@ -85,11 +85,11 @@ SecRule REQUEST_FILENAME "@rx (?:/doku.php|/lib/exe/ajax.php)$" \
         SecRule REQUEST_COOKIES:/S?DW[a-f0-9]+/ "@rx ^[%a-zA-Z0-9_-]+" \
             "t:none,\
             ctl:ruleRemoveTargetByTag=attack-protocol;ARGS:wikitext,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:wikitext,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:wikitext,\
             ctl:ruleRemoveTargetByTag=attack-protocol;ARGS:suffix,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:suffix,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:suffix,\
             ctl:ruleRemoveTargetByTag=attack-protocol;ARGS:prefix,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:prefix,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:prefix,\
             ctl:ruleRemoveTargetById=930100-930110;REQUEST_BODY"
 
 
@@ -149,7 +149,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
         chain"
         SecRule &ARGS:do "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:p"
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:p"
 
 
 #
@@ -191,9 +191,9 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
 	chain"
         SecRule &ARGS:do "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass1,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass1-text,\
+            ctl:ruleRemoveTargetById=910000-999999;ARGS:pass2"
 
 
 # [ Save config ]


### PR DESCRIPTION
As discussed during the CRS meeting, this PR replace all `ctl:ruleRemoveTargetByTag=CRS;...` occurrences with `ctl:ruleRemoveTargetById=910000-999999;...` because of an incompatibility with the libmodsecurity (v3). For more information, please refer to https://github.com/SpiderLabs/ModSecurity/issues/2109

thanks @j0k2r for reporting this issue.