### PR TITLE
add 941370 prevent bypass 941180

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -239,7 +239,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 # [Blacklist Keywords from Node-Validator]
 # https://raw.github.com/chriso/node-validator/master/validator.js
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pm document.cookie document.write document[ self[ .parentnode .innerhtml window.location -moz-binding <!-- --> <![cdata[" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pm document.cookie document.write .parentnode .innerhtml window.location -moz-binding <!-- --> <![cdata[" \
     "id:941180,\
     phase:2,\
     block,\
@@ -657,6 +657,32 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     t:none,\
     msg:'JSFuck / Hieroglyphy obfuscation detected',\
     logdata:'Matched Data: Suspicious payload found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'attack-xss',\
+    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
+    tag:'OWASP_TOP_10/A7',\
+    tag:'CAPEC-63',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.2.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+#
+# Prevent 941180 bypass by using JavaScript global variables
+# Examples:
+#    - /?search=/?a=";+alert(self["document"]["cookie"]);//
+#    - /?search=/?a=";+document+/*foo*/+.+/*bar*/+cookie;//
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:/* "@rx (?:self|document|this|top|window)\s*\)*(?:\[[^\]]+\]|\.\s*document|\.\s*cookie)" \
+    "id:941370,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:removeComments,t:urlDecodeUni,\
+    msg:'JavaScript global variable found',\
+    logdata:'Matched Data: Suspicious JS global variable found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'attack-xss',\

--- a/util/regression-tests/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941370.yaml
+++ b/util/regression-tests/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941370.yaml
@@ -5,11 +5,11 @@
     enabled: true
     name: 941370.yaml
   tests:
-  - 
+  -
     test_title: 941370-1
     desc: "Filter bypass using JS global variable"
     stages:
-    - 
+    -
       stage:
         input:
           dest_addr: 127.0.0.1
@@ -21,11 +21,11 @@
           version: HTTP/1.1
         output:
           log_contains: id "941370"
-  - 
+  -
     test_title: 941370-2
     desc: "Filter bypass using JS global variable"
     stages:
-    - 
+    -
       stage:
         input:
           dest_addr: 127.0.0.1
@@ -34,6 +34,54 @@
           method: POST
           port: 80
           data: "a=\";window+%2f%2A+foo+%2A%2f+.+document+.+%2f%2A+bar+%2A%2f+cookie%2f%2f"
+          version: HTTP/1.1
+        output:
+          log_contains: id "941370"
+  -
+    test_title: 941370-3
+    desc: "Filter bypass using JS global variable"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          data: "a=document.cookie"
+          version: HTTP/1.1
+        output:
+          log_contains: id "941370"
+  -
+    test_title: 941370-4
+    desc: "Filter bypass using JS global variable"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          data: "a=document .cookie"
+          version: HTTP/1.1
+        output:
+          log_contains: id "941370"
+  -
+    test_title: 941370-5
+    desc: "Filter bypass using JS global variable"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          data: "a=document%5B%27cookie%27%5D"
           version: HTTP/1.1
         output:
           log_contains: id "941370"

--- a/util/regression-tests/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941370.yaml
+++ b/util/regression-tests/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941370.yaml
@@ -1,0 +1,39 @@
+---
+  meta:
+    author: "Andrea Menin"
+    description: None
+    enabled: true
+    name: 941370.yaml
+  tests:
+  - 
+    test_title: 941370-1
+    desc: "Filter bypass using JS global variable"
+    stages:
+    - 
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          data: "a=\";document+%2f%2A+foo+%2A%2f+%5B+%22cookie%22+%5D;%2f%2f"
+          version: HTTP/1.1
+        output:
+          log_contains: id "941370"
+  - 
+    test_title: 941370-2
+    desc: "Filter bypass using JS global variable"
+    stages:
+    - 
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: POST
+          port: 80
+          data: "a=\";window+%2f%2A+foo+%2A%2f+.+document+.+%2f%2A+bar+%2A%2f+cookie%2f%2f"
+          version: HTTP/1.1
+        output:
+          log_contains: id "941370"


### PR DESCRIPTION
I'm moving JS global variable `self[` and `document[` from 941180 to a stricter 941370 that prevents bypass using syntax like `document /*foo*/ . /*bar*/ cookie` or `self ["document"] /* foo */ ["cookie"]`.