### PR TITLE
Add extended access.log

### DIFF
--- a/util/docker/Dockerfile-2.9-apache
+++ b/util/docker/Dockerfile-2.9-apache
@@ -20,6 +20,8 @@ RUN apt-get update && \
   printf "include /etc/modsecurity.d/owasp-crs/crs-setup.conf\ninclude /etc/modsecurity.d/owasp-crs/rules/*.conf" >> /etc/modsecurity.d/include.conf && \
   sed -i -e 's/SecRuleEngine DetectionOnly/SecRuleEngine On/g' /etc/modsecurity.d/modsecurity.conf
 
+COPY httpd-logging-before-modsec.conf  /usr/local/apache2/conf/extra/httpd-logging-before-modsec.conf
+COPY httpd-logging-after-modsec.conf   /usr/local/apache2/conf/extra/httpd-logging-after-modsec.conf
 COPY proxy.conf           /etc/modsecurity.d/proxy.conf
 COPY docker-entrypoint.sh /
 

--- a/util/docker/httpd-logging-after-modsec.conf
+++ b/util/docker/httpd-logging-after-modsec.conf
@@ -1,0 +1,25 @@
+# === ModSec Timestamps at the End of Each Phase (ids: 90010 - 90019)
+
+SecAction "id:90010,phase:1,pass,nolog,setvar:TX.ModSecTimestamp1end=%{DURATION}"
+SecAction "id:90011,phase:2,pass,nolog,setvar:TX.ModSecTimestamp2end=%{DURATION}"
+SecAction "id:90012,phase:3,pass,nolog,setvar:TX.ModSecTimestamp3end=%{DURATION}"
+SecAction "id:90013,phase:4,pass,nolog,setvar:TX.ModSecTimestamp4end=%{DURATION}"
+SecAction "id:90014,phase:5,pass,nolog,setvar:TX.ModSecTimestamp5end=%{DURATION}"
+
+
+# === ModSec performance calculations and variable export (ids: 90100 - 90199)
+
+SecAction "id:90100,phase:5,pass,nolog,\
+  setvar:TX.perf_modsecinbound=%{PERF_PHASE1},\
+  setvar:TX.perf_modsecinbound=+%{PERF_PHASE2},\
+  setvar:TX.perf_application=%{TX.ModSecTimestamp3start},\
+  setvar:TX.perf_application=-%{TX.ModSecTimestamp2end},\
+  setvar:TX.perf_modsecoutbound=%{PERF_PHASE3},\
+  setvar:TX.perf_modsecoutbound=+%{PERF_PHASE4},\
+  setenv:ModSecTimeIn=%{TX.perf_modsecinbound},\
+  setenv:ApplicationTime=%{TX.perf_application},\
+  setenv:ModSecTimeOut=%{TX.perf_modsecoutbound},\
+  setenv:ModSecAnomalyScoreInPLs=%{tx.anomaly_score_pl1}-%{tx.anomaly_score_pl2}-%{tx.anomaly_score_pl3}-%{tx.anomaly_score_pl4},\
+  setenv:ModSecAnomalyScoreOutPLs=%{tx.outbound_anomaly_score_pl1}-%{tx.outbound_anomaly_score_pl2}-%{tx.outbound_anomaly_score_pl3}-%{tx.outbound_anomaly_score_pl4},\
+  setenv:ModSecAnomalyScoreIn=%{TX.anomaly_score},\
+  setenv:ModSecAnomalyScoreOut=%{TX.outbound_anomaly_score}"

--- a/util/docker/httpd-logging-before-modsec.conf
+++ b/util/docker/httpd-logging-before-modsec.conf
@@ -1,0 +1,24 @@
+ErrorLog		/var/log/apache2/error.log
+
+# For more information regarding the extended log format and the timestamp variables, please read:
+# https://www.netnea.com/cms/apache-tutorial-5_extending-access-log/
+# https://www.netnea.com/cms/apache-tutorial-7_including-modsecurity-core-rules/
+
+LoadModule logio_module /usr/local/apache2/modules/mod_logio.so
+
+LogFormat "%h %{GEOIP_COUNTRY_CODE}e %u [%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t] \"%r\" %>s %b \
+\"%{Referer}i\" \"%{User-Agent}i\" %v %A %p %R %{BALANCER_WORKER_ROUTE}e %X \"%{cookie}n\" \
+%{UNIQUE_ID}e %{SSL_PROTOCOL}x %{SSL_CIPHER}x %I %O %{ratio}n%% \
+%D %{ModSecTimeIn}e %{ApplicationTime}e %{ModSecTimeOut}e \
+%{ModSecAnomalyScoreIn}e %{ModSecAnomalyScoreOut}e" extended
+
+CustomLog		/var/log/apache2/access.log extended
+
+
+# === ModSec timestamps at the start of each phase (ids: 90000 - 90009)
+
+SecAction "id:90000,phase:1,nolog,pass,setvar:TX.ModSecTimestamp1start=%{DURATION}"
+SecAction "id:90001,phase:2,nolog,pass,setvar:TX.ModSecTimestamp2start=%{DURATION}"
+SecAction "id:90002,phase:3,nolog,pass,setvar:TX.ModSecTimestamp3start=%{DURATION}"
+SecAction "id:90003,phase:4,nolog,pass,setvar:TX.ModSecTimestamp4start=%{DURATION}"
+SecAction "id:90004,phase:5,nolog,pass,setvar:TX.ModSecTimestamp5start=%{DURATION}"

--- a/util/docker/httpd-logging-before-modsec.conf
+++ b/util/docker/httpd-logging-before-modsec.conf
@@ -1,6 +1,7 @@
 ErrorLog		/var/log/apache2/error.log
 
-# For more information regarding the extended log format and the timestamp variables, please read:
+# For more information regarding the values in the extended log format
+# and aliases and scripts to extract information please read:
 # https://www.netnea.com/cms/apache-tutorial-5_extending-access-log/
 # https://www.netnea.com/cms/apache-tutorial-7_including-modsecurity-core-rules/
 

--- a/util/docker/httpd-logging-before-modsec.conf
+++ b/util/docker/httpd-logging-before-modsec.conf
@@ -7,9 +7,10 @@ ErrorLog		/var/log/apache2/error.log
 LoadModule logio_module /usr/local/apache2/modules/mod_logio.so
 
 LogFormat "%h %{GEOIP_COUNTRY_CODE}e %u [%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t] \"%r\" %>s %b \
-\"%{Referer}i\" \"%{User-Agent}i\" %v %A %p %R %{BALANCER_WORKER_ROUTE}e %X \"%{cookie}n\" \
-%{UNIQUE_ID}e %{SSL_PROTOCOL}x %{SSL_CIPHER}x %I %O %{ratio}n%% \
-%D %{ModSecTimeIn}e %{ApplicationTime}e %{ModSecTimeOut}e \
+\"%{Referer}i\" \"%{User-Agent}i\" \"%{Content-Type}i\" %{remote}p %v %A %p %R \
+%{BALANCER_WORKER_ROUTE}e %X \"%{cookie}n\" %{UNIQUE_ID}e %{SSL_PROTOCOL}x %{SSL_CIPHER}x \
+%I %O %{ratio}n%% %D %{ModSecTimeIn}e %{ApplicationTime}e %{ModSecTimeOut}e \
+%{ModSecAnomalyScoreInPLs}e %{ModSecAnomalyScoreOutPLs}e \
 %{ModSecAnomalyScoreIn}e %{ModSecAnomalyScoreOut}e" extended
 
 CustomLog		/var/log/apache2/access.log extended


### PR DESCRIPTION
See also: https://github.com/CRS-support/modsecurity-docker/pull/29
This PR adds timeout variables to CRS container.
The load of these include files was prepared in modsecurity parent image in httpd.conf.
See: https://github.com/CRS-support/modsecurity-docker/pull/29/files#diff-3254677a7917c6c01f55212f86c57fbfR80 and https://github.com/CRS-support/modsecurity-docker/pull/29/files#diff-3254677a7917c6c01f55212f86c57fbfR83