### PR TITLE
RE2 compatibility for 920220, 920240, 920230

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -310,8 +310,6 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
 # different variables - REQUEST_URI and REQUEST_BODY.   For REQUEST_BODY, we only want to
 # run the @validateUrlEncoding operator if the content-type is application/x-www-form-urlencoding.
 #
-# Not supported by re2 (?!re).
-#
 # -=[ References ]=-
 # http://www.ietf.org/rfc/rfc1738.txt
 #
@@ -319,7 +317,7 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
 # http://localhost/?s=a%20b%20c%'/
 # reason: %'/ is not a valid url encoding
 #
-SecRule REQUEST_URI "@rx \%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
+SecRule REQUEST_URI "@rx \%\w" \
     "id:920220,\
     phase:2,\
     block,\
@@ -337,8 +335,6 @@ SecRule REQUEST_URI "@rx \%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
     SecRule REQUEST_URI "@validateUrlEncoding" \
         "setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
-# Not supported by re2 (?!re).
-#
 SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded" \
     "id:920240,\
     phase:2,\
@@ -354,7 +350,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded
     ver:'OWASP_CRS/3.1.0',\
     severity:'WARNING',\
     chain"
-    SecRule REQUEST_BODY "@rx \%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
+    SecRule REQUEST_BODY "@rx \%\w" \
         "chain"
         SecRule REQUEST_BODY "@validateUrlEncoding" \
             "setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
@@ -1095,9 +1091,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
         "setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 
 
-# Not supported by re2 (?!re).
-#
-SecRule ARGS "@rx \%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})" \
+SecRule ARGS "@rx \%\w" \
     "id:920230,\
     phase:2,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -317,7 +317,7 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
 # http://localhost/?s=a%20b%20c%'/
 # reason: %'/ is not a valid url encoding
 #
-SecRule REQUEST_URI "@rx \%\w" \
+SecRule REQUEST_URI "@contains %" \
     "id:920220,\
     phase:2,\
     block,\
@@ -350,7 +350,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded
     ver:'OWASP_CRS/3.1.0',\
     severity:'WARNING',\
     chain"
-    SecRule REQUEST_BODY "@rx \%\w" \
+    SecRule REQUEST_BODY "@contains %" \
         "chain"
         SecRule REQUEST_BODY "@validateUrlEncoding" \
             "setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
@@ -1091,7 +1091,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
         "setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 
 
-SecRule ARGS "@rx \%\w" \
+SecRule ARGS "@rx %[0-9a-fA-F]{2}" \
     "id:920230,\
     phase:2,\
     block,\

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920230.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920230.yaml
@@ -44,4 +44,4 @@
                   Keep-Alive: "300"
                   Proxy-Connection: "keep-alive"
             output: 
-              log_contains: "id \"920230\""
+              no_log_contains: "id \"920230\""


### PR DESCRIPTION
Problem: Negative lookahead.

Original expression in 2.2.9:
```
\%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})
```

Original expression in 3.0:
```
\%((?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})
```

Original expression in 3.1:
```
\%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})
```

Original expression in 3.2:
```
\%(?:(?!$|\W)|[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})
```

Suggested rewrite:
---

"(?!$|\W)" is a negative lookahead. It says "after this there should not be either an end of line, or a non-word character".

It appears "[0-9a-fA-F]{2}" and "u[0-9a-fA-F]{4}" are never used, because !\W would always match that anyway. So we can get rid of those two.

If we just search for word-characters, that will satisfy the original search for not-non-word characters. And a word character is not the end of a line, so that will be satisfied too.

It's kind of odd there was so much unused code in this regex, so maybe the intention was slightly different than what it actually did. However, since this is just a gate that decides which values to pass to @validateUrlEncoding, I don't think it matters that much. In the case of 920230 it was used to check for double encoding, and arguably it was and still is overly sensitive.

Conclusion: \%\w

Testing
---

Manually on regex101.com:
```
should trigger:
# This gets a percent but not a number after, invalid
test_title: 920220-1
/?x=%w20

# testURL Encoding Abuse Attack Attempt from old modsec regressions
test_title: 920220-4
/?parm=%7%6F%6D%65%74%65%78%74%5F%31%32%33%

# testURL Encoding Abuse Attack Attempt from old modsec regressions
test_title: 920220-5
/?parm=%1G

should not trigger:
# We have a valid percent encoding here
test_title: 920220-2
/?x=xyz%20%99

# url encoding includes spaces as plusses, this is valid
test_title: 920220-3
/?test=This+is+a+test
```

Automation:
```
Ran just the expected affected tests and compared results to before my change
  920220.yaml
  920230.yaml
  920240.yaml

Ran all tests from branches "v3.0/dev", "v3.1/dev", "v3.2/dev" and compared results to before my change
```
