### PR TITLE
RE2 compatibility for 941130

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -120,9 +120,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 #
 # -=[ XSS Filters - Category 3 ]=-
 #
-# Not supported by re2 (?=re).
-#
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\S](?:x(?:link:href|html|mlns)|!ENTITY.*?SYSTEM|data:text\/html|pattern(?=.*?=)|formaction|\@import|base64)\b" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\S]((?:x(?:link:href|html|mlns)|!ENTITY.*?SYSTEM|data:text\/html|formaction|\@import|base64)\b|pattern\b.*?=)" \
     "id:941130,\
     phase:2,\
     block,\


### PR DESCRIPTION
Problem: Positive Lookahead "pattern(?=.*?=)"

Original expression:
```
(?i)[\s\S](?:x(?:link:href|html|mlns)|!ENTITY.*?SYSTEM|data:text\/html|pattern(?=.*?=)|formaction|\@import|base64)\b
```

Suggested rewrite:
---

This must be dealing with the `pattern` attribute on `<input>`, which can contain a regex to validate text input fields against. https://www.w3schools.com/TAGS/att_input_pattern.asp .

Broken up for readability:
```
  [\s\S]
  (?:
    x(?:link:href|html|mlns)
    |
    !ENTITY.*?SYSTEM
    |
    data:text\/html
    |
    pattern(?=.*?=)
    |
    formaction
    |
    \@import
    |
    base64
  )
  \b
```

Simplified for the interesting part
```
[\s\S]pattern(?=.*?=)\b
```

This is ensuring that `.*?=` comes after `pattern`, but without comsuming it. It's therefore also ensuring that there's a word boundary `\b` after `pattern`.

I suggest extracting the part that relates to `pattern` out of the alternatives-group, and separately ensuring there's a word boundary after `pattern` followed by the `.*?=` part. I believe this is equivalent.

Conclusion (with secrule escaping):
```
(?i)[\s\S]((?:x(?:link:href|html|mlns)|!ENTITY.*?SYSTEM|data:text\/html|formaction|\@import|base64)\b|pattern\b.*?=)
```


Testing
---

Manually on regex101.com:
```
/char_test?mime=text/xml&body=<x:script xmlns:x="http://www.w3.org/1999/xhtml" src="data:,alert(1)" />

xlink:href


pattern=

a pattern=

a pattern x =

a pattern x =x

a pattern x = x

a pattern x ="x

<form action="/action_page.php">
Country code: <input type="text" name="country_code" pattern="[A-Za-z]{3}" title="Three letter country code">
<input type="submit">
</form>

a pattern="[A-Za-z]{3}"
```

Automation:
```
Ran just the expected affected tests and compared results to before my change
    ./tests/REQUEST-941-APPLICATION-ATTACK-XSS/941130.yaml
Ran all tests from branches "v3.0/dev", "v3.1/dev", "v3.2/dev" and compared results to before my change
```

