### PR TITLE
Simpler regression test Docker image

### DIFF
--- a/util/regression-tests/Dockerfile
+++ b/util/regression-tests/Dockerfile
@@ -1,40 +1,42 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # Install dependencies from apt and then tidy up cache
 RUN apt-get update && \
-    apt-get install -y apache2 libapache2-mod-security2 python-pip git nano vim && \
+    apt-get install -y apache2 libapache2-mod-security2 python-pip git nano vim curl && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install pytest>=2.9.1 ftw
+RUN pip install ftw
 
 RUN cd / && \
     git clone https://github.com/CRS-support/secrules_parsing && \
     pip install -r /secrules_parsing/requirements.txt
 
-RUN printf "include /etc/modsecurity/owasp-crs/crs-setup.conf\ninclude /etc/modsecurity/owasp-crs/rules/*.conf\n" >> /etc/modsecurity/include.conf && \
+RUN rm -fr /usr/share/modsecurity-crs/ && \
+    printf "include /etc/modsecurity/crs/crs-setup.conf\ninclude /etc/modsecurity/crs/rules/*.conf\n" >> /etc/modsecurity/include.conf && \
     cp /etc/modsecurity/modsecurity.conf-recommended /etc/modsecurity/modsecurity.conf && \
-    sed -i -e 's/SecRuleEngine DetectionOnly/SecRuleEngine On/g' /etc/modsecurity/modsecurity.conf && \
-    echo ServerName 127.0.0.1 >> /etc/apache2/apache2.conf
+    sed -i -e 's/SecRuleEngine .*/SecRuleEngine DetectionOnly/g' /etc/modsecurity/modsecurity.conf && \
+    echo ServerName 127.0.0.1 >> /etc/apache2/apache2.conf && \
+    echo Hello World > /var/www/html/index.html
 
 ENTRYPOINT ["/bin/bash", "-c", "\
-    cp /etc/modsecurity/owasp-crs/crs-setup.conf.example /etc/modsecurity/owasp-crs/crs-setup.conf && \
-    echo 'SecAction id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=5' >> /etc/modsecurity/owasp-crs/crs-setup.conf && \
+    cp /etc/modsecurity/crs/crs-setup.conf.example /etc/modsecurity/crs/crs-setup.conf && \
+    echo 'SecAction id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=5' >> /etc/modsecurity/crs/crs-setup.conf && \
     apachectl start && \
-    cd /etc/modsecurity/owasp-crs/ && \
+    cd /etc/modsecurity/crs/ && \
+    export PYTHONDONTWRITEBYTECODE=1 && \
     if [[ \"$0\" != \"\" ]]; then \
         exec $0 $@ ; \
     else \
-        export PYTHONDONTWRITEBYTECODE=1 && \
         echo ====== Syntax check ====== && \
-        python /secrules_parsing/secrules_parser.py -c -f /etc/modsecurity/owasp-crs/rules/*.conf  && \
+        python /secrules_parsing/secrules_parser.py -c -f /etc/modsecurity/crs/rules/*.conf  && \
         echo '' && \
         echo ====== Formatting check ====== && \
-        cd /etc/modsecurity/owasp-crs/ && \
+        cd /etc/modsecurity/crs/ && \
         py.test -vs ./util/integration/format_tests.py && \
         echo '' && \
         echo ====== CRS regressions tests using FTW  ====== && \
-        cd /etc/modsecurity/owasp-crs/ && \
+        cd /etc/modsecurity/crs/ && \
         py.test -vs util/regression-tests/CRS_Tests.py --rule=util/regression-tests/tests/test.yaml && \
         py.test -vs util/regression-tests/CRS_Tests.py --ruledir_recurse=util/regression-tests/tests/ ; \
     fi \

--- a/util/regression-tests/Dockerfile
+++ b/util/regression-tests/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:16.04
+
+# Install dependencies from apt and then tidy up cache
+RUN apt-get update && \
+    apt-get install -y apache2 libapache2-mod-security2 python-pip git nano vim && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install pytest>=2.9.1 ftw
+
+RUN cd / && \
+    git clone https://github.com/CRS-support/secrules_parsing && \
+    pip install -r /secrules_parsing/requirements.txt
+
+RUN printf "include /etc/modsecurity/owasp-crs/crs-setup.conf\ninclude /etc/modsecurity/owasp-crs/rules/*.conf\n" >> /etc/modsecurity/include.conf && \
+    cp /etc/modsecurity/modsecurity.conf-recommended /etc/modsecurity/modsecurity.conf && \
+    sed -i -e 's/SecRuleEngine DetectionOnly/SecRuleEngine On/g' /etc/modsecurity/modsecurity.conf && \
+    echo ServerName 127.0.0.1 >> /etc/apache2/apache2.conf
+
+ENTRYPOINT ["/bin/bash", "-c", "\
+    cp /etc/modsecurity/owasp-crs/crs-setup.conf.example /etc/modsecurity/owasp-crs/crs-setup.conf && \
+    echo 'SecAction id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=5' >> /etc/modsecurity/owasp-crs/crs-setup.conf && \
+    apachectl start && \
+    cd /etc/modsecurity/owasp-crs/ && \
+    if [[ \"$0\" != \"\" ]]; then \
+        exec $0 $@ ; \
+    else \
+        export PYTHONDONTWRITEBYTECODE=1 && \
+        echo ====== Syntax check ====== && \
+        python /secrules_parsing/secrules_parser.py -c -f /etc/modsecurity/owasp-crs/rules/*.conf  && \
+        echo '' && \
+        echo ====== Formatting check ====== && \
+        cd /etc/modsecurity/owasp-crs/ && \
+        py.test -vs ./util/integration/format_tests.py && \
+        echo '' && \
+        echo ====== CRS regressions tests using FTW  ====== && \
+        cd /etc/modsecurity/owasp-crs/ && \
+        py.test -vs util/regression-tests/CRS_Tests.py --rule=util/regression-tests/tests/test.yaml && \
+        py.test -vs util/regression-tests/CRS_Tests.py --ruledir_recurse=util/regression-tests/tests/ ; \
+    fi \
+"]
+CMD [""]

--- a/util/regression-tests/README.md
+++ b/util/regression-tests/README.md
@@ -5,6 +5,28 @@ Introduction
 ============
 Welcome to the OWASP Core Rule Set regression testing suite. This suite is meant to test specific rules in OWASP CRS version 3. The suite is designed to uses preconfigured IDs that are specific to this version of CRS. The tests themselves can be run without CRS and one would expect the same elements to be blocked, however one must override the default Output parameter in the tests. 
 
+Run tests using Docker
+======================
+
+This is a simple self-contained way to run the tests against the currently checked out repo, without having to separately have to set up a test web server with ModSecurity or any of the test framework tools on your real dev machine. If you use this approach, you will not need to do any of the other below installation and run steps.
+
+First build the container image. You only needed to do once. You do not need to rebuild the image between changes to CRS files in this repo, as you will be mounting the repo directly when you run the container.
+```
+docker build --tag crsregressiontests .
+```
+
+Running tests:
+```
+# Run all tests
+docker run -it --rm -v `realpath ../../`:/etc/modsecurity/owasp-crs crsregressiontests
+
+# Run a single test file
+docker run -it --rm -v `realpath ../../`:/etc/modsecurity/owasp-crs crsregressiontests py.test -vs util/regression-tests/CRS_Tests.py --rule=util/regression-tests/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942320.yaml
+
+# Run a shell from which you can also run the test and troubleshoot log files, etc.:
+docker run -it --rm -v `realpath ../../`:/etc/modsecurity/owasp-crs crsregressiontests bash
+```
+
 Installation
 ============
 The OWASP Core Rule Set project was part of the effort to develop FTW, the Framework for Testing WAFs. As a result, we use this project in order to run our regression testing. FTW is designed to use existing Python testing frameworks to allow for easy to read web based testing, provided in YAML. You can install FTW by from the repository (at https://github.com/CRS-support/ftw) or by running pip.

--- a/util/regression-tests/README.md
+++ b/util/regression-tests/README.md
@@ -18,13 +18,13 @@ docker build --tag crsregressiontests .
 Running tests:
 ```
 # Run all tests
-docker run -it --rm -v `realpath ../../`:/etc/modsecurity/owasp-crs crsregressiontests
+docker run -it --rm -v `realpath ../../`:/etc/modsecurity/crs crsregressiontests
 
 # Run a single test file
-docker run -it --rm -v `realpath ../../`:/etc/modsecurity/owasp-crs crsregressiontests py.test -vs util/regression-tests/CRS_Tests.py --rule=util/regression-tests/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942320.yaml
+docker run -it --rm -v `realpath ../../`:/etc/modsecurity/crs crsregressiontests py.test -vs util/regression-tests/CRS_Tests.py --rule=util/regression-tests/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942320.yaml
 
 # Run a shell from which you can also run the test and troubleshoot log files, etc.:
-docker run -it --rm -v `realpath ../../`:/etc/modsecurity/owasp-crs crsregressiontests bash
+docker run -it --rm -v `realpath ../../`:/etc/modsecurity/crs crsregressiontests bash
 ```
 
 Installation

--- a/util/regression-tests/README.md
+++ b/util/regression-tests/README.md
@@ -7,7 +7,6 @@ Welcome to the OWASP Core Rule Set regression testing suite. This suite is meant
 
 Run tests using Docker
 ======================
-
 This is a simple self-contained way to run the tests against the currently checked out repo, without having to separately have to set up a test web server with ModSecurity or any of the test framework tools on your real dev machine. If you use this approach, you will not need to do any of the other below installation and run steps.
 
 First build the container image. You only needed to do once. You do not need to rebuild the image between changes to CRS files in this repo, as you will be mounting the repo directly when you run the container.


### PR DESCRIPTION
Was having trouble with using the Docker image over in the ../docker folder. Seems it just runs the server part, and doesn't actually run the tests? Deduced from the .travis.yml file what actually goes on in the checkin gate, but it seemed odd to me that there wasn't one-liner simple way to do the same locally.

Created this self-contained Docker image, which runs both the server and the Pytest client. This eliminates the need for any setup on dev boxes besides just Docker, and makes running the regression tests as simple as
```
# Run all tests
docker run -it --rm -v `realpath ../../`:/etc/modsecurity/crs crsregressiontests

# Run a single test file
docker run -it --rm -v `realpath ../../`:/etc/modsecurity/crs crsregressiontests py.test -vs util/regression-tests/CRS_Tests.py --rule=util/regression-tests/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942320.yaml

# Run a shell from which you can also run the test and troubleshoot log files, etc.:
docker run -it --rm -v `realpath ../../`:/etc/modsecurity/crs crsregressiontests bash
```

I didn't see any clear need or benefit of extending it from owasp/modsecurity or owasp/modsecurity-crs, so I just extended it directly from ubuntu:18.04.