### PR TITLE
WordPress: exclude more profile.php fields from RFI

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -293,6 +293,8 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
             ctl:ruleRemoveTargetById=931130;ARGS:url,\
             ctl:ruleRemoveTargetById=931130;ARGS:facebook,\
             ctl:ruleRemoveTargetById=931130;ARGS:googleplus,\
+            ctl:ruleRemoveTargetById=931130;ARGS:instagram,\
+            ctl:ruleRemoveTargetById=931130;ARGS:linkedin,\
             ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
             ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
             ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"


### PR DESCRIPTION
Excludes some extra social media fields in `/wp-admin/profile.php`.