### PR TITLE
Replacing all @\pmf with @\pmFromFile for readability

### DIFF
--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -53,7 +53,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     setvar:'ip.reput_block_reason=%{rule.msg}',\
     expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
 
-SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmf scanners-headers.data" \
+SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmFromFile scanners-headers.data" \
     "id:913110,\
     phase:2,\
     block,\
@@ -78,7 +78,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmf scanners-headers.data" \
 
 
 
-SecRule REQUEST_FILENAME|ARGS "@pmf scanners-urls.data" \
+SecRule REQUEST_FILENAME|ARGS "@pmFromFile scanners-urls.data" \
     "id:913120,\
     phase:2,\
     block,\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -71,7 +71,7 @@ SecRule REQUEST_URI|REQUEST_BODY|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/*
 #
 # Ref: https://github.com/lightos/Panoptic/blob/master/cases.xml
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmf lfi-os-files.data" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmFromFile lfi-os-files.data" \
     "id:930120,\
     phase:2,\
     block,\
@@ -98,7 +98,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Detects attempts to retrieve application source code, metadata,
 # credentials and version control history possibly reachable in a web root.
 #
-SecRule REQUEST_FILENAME "@pmf restricted-files.data" \
+SecRule REQUEST_FILENAME "@pmFromFile restricted-files.data" \
     "id:930130,\
     phase:2,\
     block,\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -305,7 +305,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # https://technet.microsoft.com/en-us/magazine/ff714569.aspx
 # https://msdn.microsoft.com/en-us/powershell/scripting/core-powershell/console/powershell.exe-command-line-help
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmf windows-powershell-commands.data" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmFromFile windows-powershell-commands.data" \
     "id:932120,\
     phase:2,\
     block,\
@@ -477,7 +477,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # This rule is also triggered by an Oracle WebLogic Remote Command Execution exploit:
 # [ Oracle WebLogic vulnerability CVE-2017-10271 - Exploit tested: https://www.exploit-db.com/exploits/43458 ]
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmf unix-shell.data" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmFromFile unix-shell.data" \
     "id:932160,\
     phase:2,\
     block,\
@@ -567,7 +567,7 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
 # code execution.
 #
 SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X-File-Name \
-        "@pmf restricted-upload.data" \
+        "@pmFromFile restricted-upload.data" \
     "id:932180,\
     phase:2,\
     block,\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -110,7 +110,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
 #
 # [ PHP Configuration Directives ]
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmf php-config-directives.data" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmFromFile php-config-directives.data" \
     "id:933120,\
     phase:2,\
     block,\
@@ -137,7 +137,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # [ PHP Variables ]
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmf php-variables.data" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmFromFile php-variables.data" \
     "id:933130,\
     phase:2,\
     block,\
@@ -235,7 +235,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # - Rule 933150: ~40 words highly common to PHP injection payloads and extremely rare in
 #		natural language or other contexts.
 #		Examples: 'base64_decode', 'file_get_contents'.
-#		These words are detected as a match directly using @pmf.
+#		These words are detected as a match directly using @pmFromFile.
 #		Function names are defined in php-function-names-933150.data
 #
 # - Rule 933160: ~220 words which are common in PHP code, but have a higher chance to cause
@@ -246,7 +246,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # - Rule 933151: ~1300 words of lesser importance. This includes most PHP functions and keywords.
 #		Examples: 'addslashes', 'array_diff'.
-#		For performance reasons, the @pmf operator is used, and many functions from lesser
+#		For performance reasons, the @pmFromFile operator is used, and many functions from lesser
 #		used PHP extensions are removed.
 #		To mitigate false positives, we only match when the '(' character is also found.
 #		This rule only runs in paranoia level 2 or higher.
@@ -268,7 +268,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # We block these function names outright, without using a complex regexp or chain.
 # This could make the detection a bit more robust against possible bypasses.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@pmf php-function-names-933150.data" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@pmFromFile php-function-names-933150.data" \
     "id:933150,\
     phase:2,\
     block,\
@@ -505,7 +505,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:933014,phase:2,pass,nolog,skipAf
 # The size of the PHP function list is considerable.
 # Even after excluding the more obscure PHP extensions, 1300+ functions remain.
 # For performance and maintenance reasons, this rule does not use a regexp,
-# but uses a phrase file (@pmf), and additionally looks for an '(' character
+# but uses a phrase file (@pmFromFile), and additionally looks for an '(' character
 # in the matched variable.
 #
 # This approach carries some risk for false positives. Therefore, the function list
@@ -514,7 +514,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:933014,phase:2,pass,nolog,skipAf
 #
 # This rule is a stricter sibling of rule 933150.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@pmf php-function-names-933151.data" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@pmFromFile php-function-names-933151.data" \
     "id:933151,\
     phase:2,\
     block,\
@@ -561,7 +561,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:933016,phase:2,pass,nolog,skipAf
 # parameter names or values and this will lead to false positives.
 # Because this list is not expected to change and it is limited in size we use a
 # regex in this case to look for these values whereas in its sibling rule we use
-# @pmf for flexibility and performance.
+# @pmFromFile for flexibility and performance.
 #
 # To rebuild the regexp:
 #   cd util/regexp-assemble

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -127,7 +127,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
 # [ Apache Struts vulnerability CVE-2018-11776 - Exploit tested: https://www.exploit-db.com/exploits/45260 ]
 #
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_FILENAME|REQUEST_HEADERS|XML:/*|XML://@* \
-    "@pmf java-classes.data" \
+    "@pmFromFile java-classes.data" \
     "id:944130,\
     phase:2,\
     block,\

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -22,7 +22,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:953012,phase:4,pass,nolog,skipAf
 #
 # -=[ PHP Error Message Leakage ]=-
 #
-SecRule RESPONSE_BODY "@pmf php-errors.data" \
+SecRule RESPONSE_BODY "@pmFromFile php-errors.data" \
     "id:953100,\
     phase:4,\
     block,\


### PR DESCRIPTION
Very small cosmetic change that bothered me when reading through a couple rules last week.

Reasoning: Readability of operator @\pmFromFile is better than @\pmf
Since both were used, consistency should be kept.