### PR TITLE
Fixing Bad Regex on Rule 931130

### DIFF
--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -113,7 +113,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:931014,nolog,pass,skipAfter:END-RE
 # -= Paranoia Level 2 =- (apply only when tx.paranoia_level is sufficiently high: 2 or higher)
 #
 
-SecRule ARGS "^(?i)(?:file|ftps?|https?)://(.*)$" \
+SecRule ARGS "^(?i)(?:file|ftps?|https?):\/\/(.*)$" \
 	"chain,\
 	phase:request,\
 	rev:'3',\


### PR DESCRIPTION
Problem: Regex for Rule 931130 

Original expression in 3.0:

^(?i)(?:file|ftps?|https?)://(.*)$

Suggested rewrite:

^(?i)(?:file|ftps?|https?):\/\/(.*)$

Testing

Manually on regex101.com:

Suggested Rewrite shows as a valid Regex.