### PR TITLE
Drop unneeded unicode from 941110

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -63,7 +63,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 # http://xssplayground.net23.net/xssfilter.html
 # script tag based XSS vectors, e.g., <script> alert(1)</script>
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[<＜]script[^>＞]*[>＞][\s\S]*?" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<script[^>]*>[\s\S]*?" \
     "id:941110,\
     phase:2,\
     block,\

--- a/util/regression-tests/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941110.yaml
+++ b/util/regression-tests/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941110.yaml
@@ -50,7 +50,7 @@
             port: 80
             uri: '/'
             headers:
-              User-Agent: "<script >alert(1);</script>"
+              User-Agent: "&#60;script+&#62;alert(1);&#60;/script&#62;=value"
               Host: localhost
           output:
             log_contains: id "941110"        
@@ -88,3 +88,93 @@
               User-Agent: ModSecurity CRS 3 Tests
           output:
             log_contains: id "941110"
+    -
+      test_title: 941110-6
+      desc: XSS in payload using %uNNNN
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: POST
+            port: 80
+            uri: /
+            headers:
+              Host: localhost
+              Accept: "*/*"
+              User-Agent: ModSecurity CRS 3 Tests
+              Content-Type: application/x-www-form-urlencoded
+            data:
+              - var=%uff1cscript%u0020%uff1ealert%281%29%uff1c/script%uff1e
+          output:
+            log_contains: id "941110"
+    -
+      test_title: 941110-7
+      desc: XSS in payload with individual code points urlencoded
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: POST
+            port: 80
+            uri: /
+            headers:
+              Host: localhost
+              Accept: "*/*"
+              User-Agent: ModSecurity CRS 3 Tests
+              Content-Type: application/x-www-form-urlencoded
+            data:
+              - var=%ef%bc%9cscript%20%ef%bc%9ealert%281%29%ef%bc%9c/script%ef%bc%9e
+          output:
+            log_contains: id "941110"
+    -
+      test_title: 941110-8
+      desc: XSS in cookie name using unicode
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: GET
+            port: 80
+            uri: /
+            headers:
+              Host: localhost
+              Accept: "*/*"
+              User-Agent: ModSecurity CRS 3 Tests
+              Cookie: ＜script ＞alert(1)＜/script＞=value
+          output:
+            log_contains: id "941110"
+    -
+      test_title: 941110-9
+      desc: XSS in Referer using html entities
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: GET
+            port: 80
+            headers:
+              Host: localhost
+              Accept: "*/*"
+              Referer: "&lt;script+&gt;alert(1);&lt;/script&gt"
+          output:
+            log_contains: id "941110"
+    -
+      test_title: 941110-10
+      desc: GH issue 1481
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: GET
+            port: 80
+            uri: "/?%9cscript+%bcalert(1);%bc/script%9e=value"
+            headers:
+              User-Agent: ModSecurity CRS 3 Tests
+              Host: localhost
+          output:
+            no_log_contains: id "941110"


### PR DESCRIPTION
Add tests to cover a few more variants as well as a negative test
to exercise the problem described in the issue.

Partially addresses #1481.