### PR TITLE
Fix wrong regex, assembly result, in 942370

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -993,11 +993,11 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # To rebuild the regexp:
 #   cd util/regexp-assemble
 #   ./regexp-assemble.pl regexp-942370.data
-# Note that after assemble an outer bracket with an ignore case flag is added
+# Note that after assemble an ignore case flag is added
 # to the Regexp::Assemble output:
 #   (?i:ASSEMBLE_OUTPUT)
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:[\"'`](?:\s*?(?:(?:\*.+(?:(?:an|i)d|between|like|x?or|div)\W*?[\"'`]|(?:between|like|x?or|and|div)\s[^\d]+[\w-]+.*?)\d|[^\w\s?]+\s*?[^\w\s]+\s*?[\"'`]|[^\w\s]+\s*?[\W\d].*?(?:--|#))|.*?\*\s*?\d)|^[\w\s\"'`-]*(and\s)(?:(between)|(and\s)|(like)|(div)|(xor)|(or))(xor\s)(nand\s)(not\s)(\|\|)(\&\&)\w+\(|[()\*<>%+-][\w-]+[^\w\s]+[\"'`][^,]|\^[\"'`]))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\"'`](?:\s*?(?:(?:\*.+(?:(?:an|i)d|between|like|x?or|div)\W*?[\"'`]|(?:between|like|x?or|and|div)\s[^\d]+[\w-]+.*?)\d|[^\w\s?]+\s*?[^\w\s]+\s*?[\"'`]|[^\w\s]+\s*?[\W\d].*?(?:--|#))|.*?\*\s*?\d)|[()\*<>%+-][\w-]+[^\w\s]+[\"'`][^,]|\^[\"'`])" \
     "id:942370,\
     phase:2,\
     block,\


### PR DESCRIPTION
Fix the wrong regex in 942370 (see issue #1504).
The result of the regex assemble was wrong.