### PR TITLE
request header Sec-Fetch-User uses '?'

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1388,7 +1388,7 @@ SecRule REQUEST_HEADERS:Sec-Fetch-User "@validateByteRange 32,34,38,42-59,61,63,
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
-   
+
 # -=[ Abnormal Character Escapes ]=-
 #
 # [ Rule Logic ]

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1352,7 +1352,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
 #
 # This is a stricter sibling of 920270.
 #
-SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!REQUEST_HEADERS:Cookie "@validateByteRange 32,34,38,42-59,61,65-90,95,97-122" \
+SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!REQUEST_HEADERS:Cookie|!REQUEST_HEADERS:Sec-Fetch-User "@validateByteRange 32,34,38,42-59,61,65-90,95,97-122" \
     "id:920274,\
     phase:2,\
     block,\
@@ -1369,7 +1369,26 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
-
+#
+# This is a stricter sibling of 920270.
+# Sec-Fetch-User dedicated rule, needs '?' (63)
+SecRule REQUEST_HEADERS:Sec-Fetch-User "@validateByteRange 32,34,38,42-59,61,63,65-90,95,97-122" \
+    "id:920275,\
+    phase:2,\
+    block,\
+    t:none,t:urlDecodeUni,\
+    msg:'Invalid character in request headers (outside of very strict set)',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
+    tag:'paranoia-level/4',\
+    ver:'OWASP_CRS/3.1.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
+   
 # -=[ Abnormal Character Escapes ]=-
 #
 # [ Rule Logic ]

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1413,7 +1413,10 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
 
 #
 # This is a stricter sibling of 920270.
-# Sec-Fetch-User dedicated rule, needs '?' (63)
+# The 'Sec-Fetch-User' header may contain the '?' (63) character.
+# Therefore we exclude this header from rule 920274 which forbids '?'.
+# https://www.w3.org/TR/fetch-metadata/#http-headerdef-sec-fetch-user
+#
 SecRule REQUEST_HEADERS:Sec-Fetch-User "@validateByteRange 32,34,38,42-59,61,63,65-90,95,97-122" \
     "id:920275,\
     phase:2,\


### PR DESCRIPTION
All Chrome clients are affected since release 76 issued 2019/08/06
Sec-Fetch-User need to have '?' accepted. Removed target from ruleid 920274 + added new dedicated rule id 920275
Details : 
https://www.w3.org/TR/fetch-metadata/#http-headerdef-sec-fetch-user
https://www.chromestatus.com/feature/5155867204780032