### PR TITLE
Add OWASP_CRS tag to all detection rules

### DIFF
--- a/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
+++ b/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
@@ -141,7 +141,7 @@
 #     phase:2,\
 #     pass,\
 #     nolog,\
-#     ctl:ruleRemoveTargetByTag=CRS;ARGS:pwd"
+#     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pwd"
 
 #
 # Example Exclusion Rule: Removing a range of rules

--- a/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
@@ -117,8 +117,8 @@ SecRule REQUEST_FILENAME "@endsWith /core/install.php" \
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:account[pass][pass1],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:account[pass][pass2]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:account[pass][pass1],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:account[pass][pass2]"
 
 SecRule REQUEST_FILENAME "@endsWith /user/login" \
     "id:9001112,\
@@ -126,24 +126,24 @@ SecRule REQUEST_FILENAME "@endsWith /user/login" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:pass"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/people/create" \
     "id:9001114,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:pass[pass1],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:pass[pass2]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass1],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass2]"
 
 SecRule REQUEST_FILENAME "@rx /user/[0-9]+/edit$" \
     "id:9001116,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:current_pass,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:pass[pass1],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:pass[pass2]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:current_pass,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass1],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass2]"
 
 
 #
@@ -171,14 +171,14 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/people/accounts" \
     nolog,\
     ctl:ruleRemoveById=920271,\
     ctl:ruleRemoveById=942440,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_cancel_confirm_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_password_reset_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_register_admin_created_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_register_no_approval_required_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_register_pending_approval_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_status_activated_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_status_blocked_body,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:user_mail_status_canceled_body"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_cancel_confirm_body,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_password_reset_body,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_register_admin_created_body,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_register_no_approval_required_body,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_register_pending_approval_body,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_status_activated_body,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_status_blocked_body,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_status_canceled_body"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/configuration/single/import" \
     "id:9001126,\
@@ -242,8 +242,8 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/content/formats/manage/full_ht
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:editor[settings][toolbar][button_groups],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:filters[filter_html][settings][allowed_html]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:editor[settings][toolbar][button_groups],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:filters[filter_html][settings][allowed_html]"
 
 
 #
@@ -316,7 +316,7 @@ SecRule REQUEST_FILENAME "@endsWith /node/add/article" \
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:body[0][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
     ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id]"
 
 SecRule REQUEST_FILENAME "@endsWith /node/add/page" \
@@ -324,7 +324,7 @@ SecRule REQUEST_FILENAME "@endsWith /node/add/page" \
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:body[0][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
     ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id]"
 
 SecRule REQUEST_FILENAME "@rx /node/[0-9]+/edit$" \
@@ -332,7 +332,7 @@ SecRule REQUEST_FILENAME "@rx /node/[0-9]+/edit$" \
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:body[0][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
     ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id],\
     ctl:ruleRemoveTargetById=932110;ARGS:destination"
 
@@ -341,42 +341,42 @@ SecRule REQUEST_FILENAME "@endsWith /block/add" \
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:body[0][value]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value]"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/structure/block/block-content/manage/basic" \
     "id:9001208,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:description"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description"
 
 SecRule REQUEST_FILENAME "@rx /editor/filter_xss/(?:full|basic)_html$" \
     "id:9001210,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:value"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:value"
 
 SecRule REQUEST_FILENAME "@rx /user/[0-9]+/contact$" \
     "id:9001212,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:message[0][value]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message[0][value]"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     "id:9001214,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:maintenance_mode_message"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:maintenance_mode_message"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/services/rss-publishing" \
     "id:9001216,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:feed_description"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:feed_description"
 
 
 SecMarker "END-DRUPAL-RULE-EXCLUSIONS"

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -49,7 +49,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:pwd"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pwd"
 
 # Reset password
 SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
@@ -64,9 +64,9 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
 
 
 #
@@ -95,8 +95,8 @@ SecRule REQUEST_FILENAME "@rx ^/wp\-json/wp/v[0-9]+/(?:posts|pages)" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:json.content"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:content,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.content"
 
 # Gutenberg via rest_route for sites without pretty permalinks
 SecRule REQUEST_FILENAME "@endsWith /index.php" \
@@ -112,8 +112,8 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
         chain"
         SecRule ARGS:rest_route "@rx ^/wp/v[0-9]+/(?:posts|pages)" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:json.content"
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:content,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.content"
 
 #
 # [ Live preview ]
@@ -253,7 +253,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/setup-config.php" \
         chain"
         SecRule &ARGS:step "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pwd"
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pwd"
 
 # WordPress installation: exclude admin password
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/install.php" \
@@ -268,9 +268,9 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/install.php" \
         chain"
         SecRule &ARGS:step "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:admin_password,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:admin_password2,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text"
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:admin_password,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:admin_password2,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text"
 
 
 #
@@ -295,9 +295,9 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
             ctl:ruleRemoveTargetById=931130;ARGS:googleplus,\
             ctl:ruleRemoveTargetById=931130;ARGS:instagram,\
             ctl:ruleRemoveTargetById=931130;ARGS:linkedin,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
 
 # Edit user
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-edit.php" \
@@ -313,9 +313,9 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-edit.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetById=931130;ARGS:url,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
 
 # Create user
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-new.php" \
@@ -331,9 +331,9 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-new.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetById=931130;ARGS:url,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
 
 
 #
@@ -387,7 +387,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/post.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:post_title,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:content,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:content,\
             ctl:ruleRemoveById=920272,\
             ctl:ruleRemoveById=921180"
 
@@ -406,7 +406,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:data[wp_autosave][post_title],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:data[wp_autosave][content],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:data[wp_autosave][content],\
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-refresh-post-lock][post_id],\
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-refresh-post-lock][lock],\
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-check-locked-posts][],\
@@ -450,46 +450,46 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[0][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[1][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[2][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[3][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[4][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[5][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[6][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[7][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[8][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[9][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[10][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[11][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[12][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[13][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[14][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[15][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[16][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[17][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[18][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[19][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[20][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[21][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[22][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[23][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[24][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[25][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[26][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[27][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[28][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[29][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[30][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[31][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[32][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[33][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[34][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[35][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[36][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[37][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[38][text],\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:widget-text[39][text]"
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[0][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[1][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[2][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[3][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[4][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[5][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[6][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[7][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[8][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[9][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[10][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[11][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[12][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[13][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[14][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[15][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[16][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[17][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[18][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[19][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[20][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[21][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[22][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[23][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[24][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[25][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[26][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[27][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[28][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[29][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[30][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[31][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[32][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[33][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[34][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[35][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[36][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[37][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[38][text],\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:widget-text[39][text]"
 
 # Reorder widgets
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
@@ -562,7 +562,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:html"
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:html"
 
 
 #
@@ -626,8 +626,8 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
                 chain"
                 SecRule &ARGS:action "@eq 1" \
                     "t:none,\
-                    ctl:ruleRemoveTargetByTag=CRS;ARGS:blacklist_keys,\
-                    ctl:ruleRemoveTargetByTag=CRS;ARGS:moderation_keys"
+                    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:blacklist_keys,\
+                    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:moderation_keys"
 
 # Posts/pages overview search
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
@@ -636,7 +636,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:s"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:s"
 
 
 #

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -123,7 +123,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
     chain"
     SecRule REQUEST_FILENAME "@rx (?:/public\.php/webdav/|/remote\.php/dav/uploads/)" \
         "ctl:ruleRemoveById=920340,\
-         ctl:ruleRemoveById=920420"
+        ctl:ruleRemoveById=920420"
 
 
 # Allow characters like /../ in files.
@@ -243,7 +243,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:filecontents,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:filecontents,\
     ctl:ruleRemoveTargetById=921110-921160;ARGS:filecontents,\
     ctl:ruleRemoveTargetById=932150;ARGS:filename,\
     ctl:ruleRemoveTargetById=920370-920390;ARGS:filecontents,\
@@ -318,7 +318,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/login" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=941100;ARGS:requesttoken,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:password"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
 
 # Reset password.
 
@@ -334,9 +334,9 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
 
 # Change Password and Setting up a new user/password
 
@@ -346,8 +346,8 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:newuserpassword,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:password"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:newuserpassword,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
 
 
 SecMarker "END-NEXTCLOUD-ADMIN"

--- a/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
@@ -85,17 +85,17 @@ SecRule REQUEST_FILENAME "@rx (?:/doku.php|/lib/exe/ajax.php)$" \
         SecRule REQUEST_COOKIES:/S?DW[a-f0-9]+/ "@rx ^[%a-zA-Z0-9_-]+" \
             "t:none,\
             ctl:ruleRemoveTargetByTag=attack-protocol;ARGS:wikitext,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:wikitext,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:wikitext,\
             ctl:ruleRemoveTargetByTag=attack-protocol;ARGS:suffix,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:suffix,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:suffix,\
             ctl:ruleRemoveTargetByTag=attack-protocol;ARGS:prefix,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:prefix,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:prefix,\
             ctl:ruleRemoveTargetById=930100-930110;REQUEST_BODY"
 
 
 # Allow it to upload files. But check for cookies just to make sure.
 
-SecRule REQUEST_FILENAME "@endsWith /lib/exe/ajax.php"\
+SecRule REQUEST_FILENAME "@endsWith /lib/exe/ajax.php" \
     "id:9004110,\
     phase:2,\
     pass,\
@@ -113,7 +113,7 @@ SecRule REQUEST_FILENAME "@endsWith /lib/exe/ajax.php"\
 
 # Show the index, even if things like "postgresql" or other things show up.
 
-SecRule REQUEST_FILENAME "@endsWith /doku.php"\
+SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     "id:9004130,\
     phase:2,\
     pass,\
@@ -137,7 +137,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php"\
 # Turn off checks for password.
 
 SecRule REQUEST_FILENAME "@endsWith /doku.php" \
-   "id:9004200,\
+    "id:9004200,\
     phase:2,\
     pass,\
     t:none,\
@@ -149,7 +149,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
         chain"
         SecRule &ARGS:do "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:p"
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:p"
 
 
 #
@@ -188,12 +188,12 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     chain"
     SecRule ARGS:do "@streq login" \
         "t:none,\
-	chain"
+        chain"
         SecRule &ARGS:do "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=CRS;ARGS:pass2"
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
 
 
 # [ Save config ]

--- a/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
@@ -42,8 +42,8 @@ SecRule REQUEST_FILENAME "@endsWith /proxy.php" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:image,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:link,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:image,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:link,\
     ctl:ruleRemoveTargetById=931130;ARGS:referrer,\
     ctl:ruleRemoveTargetById=942230;ARGS:referrer"
 
@@ -62,9 +62,9 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations|(?:conversations|forums|threads)
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=931130;ARGS:href,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:title,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:message,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:message_html,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:title,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message_html,\
     ctl:ruleRemoveTargetById=942200;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942260;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942340;ARGS:attachment_hash_combined,\
@@ -87,9 +87,9 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations/add(?:-preview)?|conversations/m
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:title,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:message,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:message_html,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:title,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message_html,\
     ctl:ruleRemoveTargetById=942200;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942260;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942340;ARGS:attachment_hash_combined,\
@@ -103,7 +103,7 @@ SecRule REQUEST_FILENAME "@rx /posts/\d+/quote$" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:quoteHtml"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:quoteHtml"
 
 # Multi quote
 # POST /xf/conversations/convo-title.12345/multi-quote
@@ -115,17 +115,17 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations|threads)/.*\.\d+/multi-quote$" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:quotes,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:insert[0][value],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:insert[1][value],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:insert[2][value],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:insert[3][value],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:insert[4][value],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:insert[5][value],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:insert[6][value],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:insert[7][value],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:insert[8][value],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:insert[9][value]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:quotes,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[0][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[1][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[2][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[3][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[4][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[5][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[6][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[7][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[8][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[9][value]"
 
 # Delete thread
 SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/delete$" \
@@ -144,7 +144,7 @@ SecRule REQUEST_FILENAME "@streq /inline-mod/" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:message"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message"
 
 # Warn member
 # POST /xf/members/name.12345/warn
@@ -154,8 +154,8 @@ SecRule REQUEST_FILENAME "@rx /members/\*\.\d+/warn$" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:conversation_message,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:notes"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:conversation_message,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:notes"
 
 # Editor
 SecRule REQUEST_URI "@endsWith /index.php?editor/to-html" \
@@ -164,7 +164,7 @@ SecRule REQUEST_URI "@endsWith /index.php?editor/to-html" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:bb_code,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:bb_code,\
     ctl:ruleRemoveTargetById=942200;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942260;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942340;ARGS:attachment_hash_combined,\
@@ -177,7 +177,7 @@ SecRule REQUEST_URI "@endsWith /index.php?editor/to-bb-code" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:html"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:html"
 
 # Post attachment
 # POST /xf/account/avatar
@@ -224,7 +224,7 @@ SecRule REQUEST_FILENAME "@endsWith /login/login" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:password"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
 
 # Register account
 # POST /xf/register/register
@@ -238,7 +238,7 @@ SecRule REQUEST_FILENAME "@endsWith /register/register" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=942130;ARGS,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:reg_key"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:reg_key"
 
 # Edit account
 # POST /xf/account/account-details
@@ -249,7 +249,7 @@ SecRule REQUEST_FILENAME "@endsWith /account/account-details" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=931130;ARGS:custom_fields[picture],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:about_html"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:about_html"
 
 # Lost password
 # POST /xf/lost-password/user-name.12345/confirm?c=foo
@@ -259,7 +259,7 @@ SecRule REQUEST_FILENAME "@rx /lost-password/.*\.\d+/confirm$" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:c"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:c"
 
 # Set forum signature
 # POST /xf/account/signature
@@ -269,7 +269,7 @@ SecRule REQUEST_FILENAME "@endsWith /account/signature" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:signature_html"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:signature_html"
 
 # Search
 # POST /xf/search/search
@@ -279,7 +279,7 @@ SecRule REQUEST_FILENAME "@endsWith /search/search" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:keywords,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:keywords,\
     ctl:ruleRemoveTargetById=942200;ARGS:constraints,\
     ctl:ruleRemoveTargetById=942260;ARGS:constraints,\
     ctl:ruleRemoveTargetById=942340;ARGS:constraints,\
@@ -293,7 +293,7 @@ SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/(?:page\d+)?$" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:highlight"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:highlight"
 
 # Search within search result
 # GET /xf/search/12345/?q=foo
@@ -303,7 +303,7 @@ SecRule REQUEST_FILENAME "@rx /search/\d+/$" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:q"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:q"
 
 # Contact form
 # POST /xf/misc/contact
@@ -313,8 +313,8 @@ SecRule REQUEST_FILENAME "@endsWith /misc/contact" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:message,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:subject"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:subject"
 
 # Report post
 # POST /xf/posts/12345/report
@@ -324,7 +324,7 @@ SecRule REQUEST_FILENAME "@rx /posts/\d+/report$" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:message"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message"
 
 # Alternate thread view route
 # /xf/index.php?threads/title-having-some-sql.12345/
@@ -359,9 +359,9 @@ SecRule REQUEST_URI "@endsWith /index.php?dbtech-security/fingerprint" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:components[14][value],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:components[15][value],\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:components[16][value]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:components[14][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:components[15][value],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:components[16][value]"
 
 # Get location info
 SecRule REQUEST_FILENAME "@endsWith /misc/location-info" \
@@ -370,7 +370,7 @@ SecRule REQUEST_FILENAME "@endsWith /misc/location-info" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=CRS;ARGS:location"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:location"
 
 #
 # -=[ XenForo Global Exclusions ]=-
@@ -397,7 +397,7 @@ SecAction \
     ctl:ruleRemoveTargetById=942440;REQUEST_COOKIES:xf_csrf,\
     ctl:ruleRemoveTargetById=942150;REQUEST_COOKIES:xf_emoji_usage,\
     ctl:ruleRemoveTargetById=942410;REQUEST_COOKIES:xf_emoji_usage,\
-    ctl:ruleRemoveTargetByTag=CRS;REQUEST_COOKIES:xf_ls,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;REQUEST_COOKIES:xf_ls,\
     ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:xf_user"
 
 #
@@ -414,7 +414,7 @@ SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
     nolog,\
     skipAfter:END-XENFORO-ADMIN"
 
-SecRule REQUEST_FILENAME "!@endsWith /admin.php"  \
+SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
     "id:9006901,\
     phase:2,\
     pass,\
@@ -433,7 +433,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin.php" \
     chain"
     SecRule REQUEST_URI "@rx /admin\.php\?users/.*\.\d+/edit$" \
         "t:none,\
-        ctl:ruleRemoveTargetByTag=CRS;ARGS:profile[about],\
+        ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:profile[about],\
         ctl:ruleRemoveTargetById=931130;ARGS:profile[website]"
 
 # Admin save user
@@ -447,11 +447,11 @@ SecRule REQUEST_FILENAME "@endsWith /admin.php" \
     chain"
     SecRule REQUEST_URI "@rx /admin\.php\?users/.*\.\d+/save$" \
         "t:none,\
-        ctl:ruleRemoveTargetByTag=CRS;ARGS:custom_fields[occupation],\
-        ctl:ruleRemoveTargetByTag=CRS;ARGS:custom_fields[personal_quote],\
-        ctl:ruleRemoveTargetByTag=CRS;ARGS:profile[about],\
-        ctl:ruleRemoveTargetByTag=CRS;ARGS:profile[signature],\
-        ctl:ruleRemoveTargetByTag=CRS;ARGS:custom_fields[sexuality],\
+        ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:custom_fields[occupation],\
+        ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:custom_fields[personal_quote],\
+        ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:profile[about],\
+        ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:profile[signature],\
+        ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:custom_fields[sexuality],\
         ctl:ruleRemoveTargetById=931130;ARGS:custom_fields[picture],\
         ctl:ruleRemoveTargetById=931130;ARGS:profile[website]"
 
@@ -468,8 +468,8 @@ SecRule REQUEST_FILENAME "@endsWith /admin.php" \
     chain"
     SecRule REQUEST_URI "@rx /admin\.php\?notices/(?:.*\.)?\d+/save$" \
         "t:none,\
-        ctl:ruleRemoveTargetByTag=CRS;ARGS:message,\
-        ctl:ruleRemoveTargetByTag=CRS;ARGS:title"
+        ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
+        ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:title"
 
 # Admin batch thread update
 # POST /xf/admin.php?threads/batch-update/action

--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -34,6 +34,7 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-generic',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/POLICY/METHOD_NOT_ALLOWED',\
     tag:'WASCTC/WASC-15',\
     tag:'OWASP_TOP_10/A6',\

--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -42,6 +42,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-scanner',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/AUTOMATION/SECURITY_SCANNER',\
     tag:'WASCTC/WASC-21',\
     tag:'OWASP_TOP_10/A7',\
@@ -65,6 +66,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmFromFile scanners-headers.data
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-scanner',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/AUTOMATION/SECURITY_SCANNER',\
     tag:'WASCTC/WASC-21',\
     tag:'OWASP_TOP_10/A7',\
@@ -90,6 +92,7 @@ SecRule REQUEST_FILENAME|ARGS "@pmFromFile scanners-urls.data" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-scanner',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/AUTOMATION/SECURITY_SCANNER',\
     tag:'WASCTC/WASC-21',\
     tag:'OWASP_TOP_10/A7',\
@@ -130,6 +133,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scripting-user-agents.data" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-scripting',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/AUTOMATION/SCRIPTING',\
     tag:'WASCTC/WASC-21',\
     tag:'OWASP_TOP_10/A7',\
@@ -165,6 +169,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile crawlers-user-agents.data" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-crawler',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/AUTOMATION/CRAWLER',\
     tag:'WASCTC/WASC-21',\
     tag:'OWASP_TOP_10/A7',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -55,6 +55,7 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ',\
     tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.1.0',\
@@ -105,6 +106,7 @@ SecRule FILES_NAMES|FILES "@rx (?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ',\
     tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.1.0',\
@@ -133,6 +135,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.1.0',\
@@ -166,6 +169,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.1.0',\
@@ -190,6 +194,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.1.0',\
@@ -220,6 +225,7 @@ SecRule REQUEST_METHOD "@rx ^POST$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.1.0',\
@@ -266,6 +272,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)\-(\d+)\,"
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'WARNING',\
@@ -297,6 +304,7 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'WARNING',\
@@ -328,6 +336,7 @@ SecRule REQUEST_URI "@rx \x25" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'WARNING',\
@@ -346,6 +355,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'WARNING',\
@@ -376,6 +386,7 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'WARNING',\
@@ -464,6 +475,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -493,6 +505,7 @@ SecRule &REQUEST_HEADERS:Host "@eq 0" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_HOST',\
     tag:'WASCTC/WASC-21',\
     tag:'OWASP_TOP_10/A7',\
@@ -513,6 +526,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_HOST',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'WARNING',\
@@ -551,6 +565,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_ACCEPT',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'NOTICE',\
@@ -574,6 +589,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_ACCEPT',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'NOTICE',\
@@ -605,6 +621,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/EMPTY_HEADER_UA',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'NOTICE',\
@@ -669,6 +686,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^[\d.:]+$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/IP_HOST',\
     tag:'WASCTC/WASC-21',\
     tag:'OWASP_TOP_10/A7',\
@@ -702,6 +720,7 @@ SecRule &TX:MAX_NUM_ARGS "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/POLICY/SIZE_LIMIT',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -725,6 +744,7 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/POLICY/SIZE_LIMIT',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -750,6 +770,7 @@ SecRule &TX:ARG_LENGTH "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/POLICY/SIZE_LIMIT',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -772,6 +793,7 @@ SecRule &TX:TOTAL_ARG_LENGTH "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/POLICY/SIZE_LIMIT',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -795,6 +817,7 @@ SecRule &TX:MAX_FILE_SIZE "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/POLICY/SIZE_LIMIT',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -819,6 +842,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/POLICY/SIZE_LIMIT',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -854,6 +878,7 @@ SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w\d/\.\-\+]+(?:\s?;\s?(?:boundary|
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/CONTENT_TYPE',\
     tag:'WASCTC/WASC-20',\
     tag:'OWASP_TOP_10/A1',\
@@ -877,6 +902,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/POLICY/CONTENT_TYPE_NOT_ALLOWED',\
     tag:'WASCTC/WASC-20',\
     tag:'OWASP_TOP_10/A1',\
@@ -906,6 +932,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*([^;\s]+)" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/CONTENT_TYPE_CHARSET',\
     tag:'WASCTC/WASC-20',\
     tag:'OWASP_TOP_10/A1',\
@@ -935,6 +962,7 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/POLICY/PROTOCOL_NOT_ALLOWED',\
     tag:'WASCTC/WASC-21',\
     tag:'OWASP_TOP_10/A6',\
@@ -958,6 +986,7 @@ SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/POLICY/EXT_RESTRICTED',\
     tag:'WASCTC/WASC-15',\
     tag:'OWASP_TOP_10/A7',\
@@ -1002,11 +1031,12 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     capture,\
     t:none,t:lowercase,\
     msg:'HTTP header is restricted by policy (%{MATCHED_VAR})',\
-    logdata:' Restricted header detected: %{MATCHED_VAR}',\
+    logdata:'Restricted header detected: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/POLICY/HEADER_RESTRICTED',\
     tag:'WASCTC/WASC-21',\
     tag:'OWASP_TOP_10/A7',\
@@ -1059,6 +1089,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.1.0',\
@@ -1082,6 +1113,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.1.0',\
@@ -1102,6 +1134,7 @@ SecRule ARGS "@rx %[0-9a-fA-F]{2}" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.1.0',\
@@ -1125,6 +1158,7 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_ACCEPT',\
     tag:'WASCTC/WASC-21',\
     tag:'OWASP_TOP_10/A7',\
@@ -1153,6 +1187,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.1.0',\
@@ -1178,6 +1213,7 @@ SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_UA',\
     tag:'WASCTC/WASC-21',\
     tag:'OWASP_TOP_10/A7',\
@@ -1202,6 +1238,7 @@ SecRule FILES_NAMES|FILES "@rx ['\";=]" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ',\
     tag:'CAPEC-272',\
     tag:'paranoia-level/2',\
@@ -1259,6 +1296,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.1.0',\
@@ -1286,6 +1324,7 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     tag:'language-aspnet',\
     tag:'platform-windows',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.1.0',\
@@ -1317,6 +1356,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.1.0',\
@@ -1343,6 +1383,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.1.0',\
@@ -1363,6 +1404,7 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.1.0',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -42,6 +42,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx [\n\r]+(?:get|post|head|options|connect|put|
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/REQUEST_SMUGGLING',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
@@ -73,6 +74,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/RESPONSE_SPLITTING',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
@@ -93,6 +95,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/RESPONSE_SPLITTING',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
@@ -126,6 +129,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/HEADER_INJECTION',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
@@ -153,6 +157,7 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/HEADER_INJECTION',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
@@ -173,6 +178,7 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx (?:\n|\r)+(?:\s|location|refresh|(?:set-)?c
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/HEADER_INJECTION',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
@@ -208,6 +214,7 @@ SecRule ARGS_GET "@rx [\n\r]" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/HEADER_INJECTION',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
@@ -265,6 +272,7 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/HTTP_PARAMETER_POLLUTION',\
     tag:'paranoia-level/3',\
     tag:'CAPEC-460',\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -38,6 +38,7 @@ SecRule REQUEST_URI_RAW|REQUEST_BODY|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XM
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-lfi',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -59,6 +60,7 @@ SecRule REQUEST_URI|REQUEST_BODY|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/*
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-lfi',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -83,6 +85,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-lfi',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/FILE_INJECTION',\
     tag:'WASCTC/WASC-33',\
     tag:'OWASP_TOP_10/A4',\
@@ -110,6 +113,7 @@ SecRule REQUEST_FILENAME "@pmFromFile restricted-files.data" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-lfi',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/FILE_INJECTION',\
     tag:'WASCTC/WASC-33',\
     tag:'OWASP_TOP_10/A4',\

--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -45,6 +45,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?):\/\/(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-rfi',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/RFI',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
@@ -64,6 +65,7 @@ SecRule QUERY_STRING|REQUEST_BODY "@rx (?i)(?:\binclude\s*\([^)]*|mosConfig_abso
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-rfi',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/RFI',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
@@ -83,6 +85,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?).*?\?+$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-rfi',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/RFI',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.1.0',\
@@ -110,6 +113,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?)://(.*)$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-rfi',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/RFI',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -111,6 +111,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -147,6 +148,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -244,6 +246,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-shell',\
     tag:'platform-windows',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -283,6 +286,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-shell',\
     tag:'platform-windows',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -318,6 +322,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-powershell',\
     tag:'platform-windows',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -355,6 +360,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -401,6 +407,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-shell',\
     tag:'platform-windows',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -452,6 +459,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -489,6 +497,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -521,6 +530,7 @@ SecRule REQUEST_HEADERS|REQUEST_LINE "@rx ^\(\s*\)\s+{" \
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -543,6 +553,7 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -567,7 +578,7 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
 # code execution.
 #
 SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X-File-Name \
-        "@pmFromFile restricted-upload.data" \
+    "@pmFromFile restricted-upload.data" \
     "id:932180,\
     phase:2,\
     block,\
@@ -579,6 +590,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -633,6 +645,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -666,6 +679,7 @@ SecRule ARGS "@rx (?:/|\\\\)(?:[\?\*]+[a-z/\\\\]+|[a-z/\\\\]+[\?\*]+)" \
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -57,6 +57,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
@@ -98,6 +99,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
@@ -122,6 +124,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
@@ -149,6 +152,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
@@ -185,6 +189,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
@@ -213,6 +218,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
@@ -280,6 +286,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
@@ -332,6 +339,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
@@ -387,6 +395,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
@@ -442,6 +451,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
@@ -483,6 +493,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
@@ -526,6 +537,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     tag:'paranoia-level/2',\
@@ -580,6 +592,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     tag:'paranoia-level/3',\
@@ -625,6 +638,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     tag:'paranoia-level/3',\
@@ -668,6 +682,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     tag:'paranoia-level/3',\
@@ -701,6 +716,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     tag:'paranoia-level/3',\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -45,6 +45,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -75,6 +76,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -104,6 +106,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -132,6 +135,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -161,6 +165,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -199,6 +204,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -227,6 +233,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -256,6 +263,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -286,6 +294,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -311,6 +320,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -336,6 +346,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -361,6 +372,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -386,6 +398,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -411,6 +424,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -436,6 +450,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -461,6 +476,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -486,6 +502,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -511,6 +528,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -536,6 +554,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -561,6 +580,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -591,6 +611,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-tomcat',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -620,6 +641,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-internet-explorer',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -665,6 +687,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'OWASP_TOP_10/A7',\
     tag:'CAPEC-63',\
@@ -691,6 +714,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'OWASP_TOP_10/A7',\
     tag:'CAPEC-63',\
@@ -722,6 +746,7 @@ SecRule REQUEST_HEADERS:Referer "@detectXSS" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -752,6 +777,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -839,6 +865,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -863,6 +890,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -890,6 +918,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'WASCTC/WASC-8',\
     tag:'WASCTC/WASC-22',\
@@ -926,6 +955,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'OWASP_TOP_10/A7',\
     tag:'CAPEC-63',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -54,6 +54,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -89,6 +90,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -118,6 +120,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     ver:'OWASP_CRS/3.1.0',\
     severity:'CRITICAL',\
@@ -144,6 +147,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -174,6 +178,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -196,6 +201,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -218,6 +224,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -248,6 +255,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -270,6 +278,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -292,6 +301,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -322,6 +332,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -344,6 +355,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -374,6 +386,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -404,6 +417,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -445,6 +459,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -482,6 +497,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -527,6 +543,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -566,6 +583,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?:^\s*[\"'`;]+|[\"'`]+\s*$)" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -604,6 +622,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:(?:^|\W)in[+\s]*\([\s\d\"]+[^()]*\)|\
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -641,6 +660,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\s'\"`()]*?([\d\w]++)[\s'\"`()]*?(?:<(?
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -681,6 +701,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -713,6 +734,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -747,6 +769,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -781,6 +804,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -812,6 +836,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -843,6 +868,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -874,6 +900,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -913,6 +940,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -946,6 +974,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -973,6 +1002,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1009,6 +1039,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1037,6 +1068,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1066,6 +1098,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1098,6 +1131,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1137,6 +1171,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1172,6 +1207,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1207,6 +1243,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1251,6 +1288,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1297,6 +1335,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1324,6 +1363,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1364,6 +1404,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1390,6 +1431,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1432,6 +1474,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1463,6 +1506,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1495,6 +1539,7 @@ SecRule ARGS "@rx \W{4}" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1531,6 +1576,7 @@ SecRule REQUEST_BASENAME "@detectSQLi" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1567,6 +1613,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\
@@ -1598,6 +1645,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     tag:'WASCTC/WASC-19',\
     tag:'OWASP_TOP_10/A1',\

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -39,6 +39,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-fixation',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SESSION_FIXATION',\
     tag:'WASCTC/WASC-37',\
     tag:'CAPEC-61',\
@@ -61,6 +62,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-fixation',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SESSION_FIXATION',\
     tag:'WASCTC/WASC-37',\
     tag:'CAPEC-61',\
@@ -88,6 +90,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-fixation',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/SESSION_FIXATION',\
     tag:'WASCTC/WASC-37',\
     tag:'CAPEC-61',\

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -42,6 +42,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -77,6 +78,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -104,6 +106,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -139,6 +142,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -179,6 +183,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -202,6 +207,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -225,6 +231,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -251,6 +258,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
@@ -288,6 +296,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -39,6 +39,7 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/INFO_DIRECTORY_LISTING',\
     tag:'WASCTC/WASC-13',\
     tag:'OWASP_TOP_10/A6',\
@@ -73,6 +74,7 @@ SecRule RESPONSE_BODY "@rx ^#\!\s?/" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/SOURCE_CODE_CGI',\
     tag:'WASCTC/WASC-13',\
     tag:'OWASP_TOP_10/A6',\

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -50,6 +50,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-msaccess',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -74,6 +75,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-oracle',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -98,6 +100,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-db2',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -122,6 +125,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-emc',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -146,6 +150,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-firebird',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -171,6 +176,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-frontbase',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -195,6 +201,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-hsqldb',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -219,6 +226,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-informix',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -244,6 +252,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-ingres',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -269,6 +278,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-interbase',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -293,6 +303,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-maxdb',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -317,6 +328,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-mssql',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -341,6 +353,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-mysql',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -365,6 +378,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-pgsql',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -389,6 +403,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-sqlite',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\
@@ -413,6 +428,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'language-multi',\
     tag:'platform-sybase',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
     ctl:auditLogParts=+E,\

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -34,6 +34,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-code-leakages.data" \
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/SOURCE_CODE_JAVA',\
     tag:'WASCTC/WASC-13',\
     tag:'OWASP_TOP_10/A6',\
@@ -61,6 +62,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_JAVA',\
     tag:'WASCTC/WASC-13',\
     tag:'OWASP_TOP_10/A6',\

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -34,6 +34,7 @@ SecRule RESPONSE_BODY "@pmFromFile php-errors.data" \
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_PHP',\
     tag:'WASCTC/WASC-13',\
     tag:'OWASP_TOP_10/A6',\
@@ -61,6 +62,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scan
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/SOURCE_CODE_PHP',\
     tag:'WASCTC/WASC-13',\
     tag:'OWASP_TOP_10/A6',\
@@ -92,6 +94,7 @@ SecRule RESPONSE_BODY "@rx <\?(?!xml)" \
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/SOURCE_CODE_PHP',\
     tag:'WASCTC/WASC-13',\
     tag:'OWASP_TOP_10/A6',\

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -77,6 +77,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:A(?:DODB\.Command\b.{0,100}?\b(?:Application 
     tag:'platform-iis',\
     tag:'platform-windows',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_IIS',\
     tag:'WASCTC/WASC-13',\
     tag:'OWASP_TOP_10/A6',\
@@ -101,6 +102,7 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
     tag:'platform-iis',\
     tag:'platform-windows',\
     tag:'attack-disclosure',\
+    tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_IIS',\
     tag:'WASCTC/WASC-13',\
     tag:'OWASP_TOP_10/A6',\


### PR DESCRIPTION
This patch fixes the issue #1445:

- added a new tag to every rule which has "OWASP_CRS/..." pattern; the new tag inserted before the existing ones
- replace the "CRS" tag argument at every `ctl=ruleRemoveTargetByTag` action

Note, that this patch modifies some other lines, which contains extra spaces/missing spaces.