### PR TITLE
restricted_extensions: add .rdb (Redis dump file)

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -417,8 +417,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 # Forbidden file extensions.
 # Guards against unintended exposure of development/configuration files.
-# Default: .asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/
-# Example: .bak/ .config/ .conf/ .db/ .ini/ .log/ .old/ .pass/ .pdb/ .sql/
+# Default: .asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/
+# Example: .bak/ .config/ .conf/ .db/ .ini/ .log/ .old/ .pass/ .pdb/ .rdb/ .sql/
 # Uncomment this rule to change the default.
 #SecAction \
 # "id:900240,\
@@ -426,7 +426,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
+#  setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
 # Forbidden request headers.
 # Header names should be lowercase, enclosed by /slashes/ as delimiters.

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -192,7 +192,7 @@ SecRule &TX:restricted_extensions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
+    setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
 # Default HTTP policy: restricted_headers (rule 900250)
 SecRule &TX:restricted_headers "@eq 0" \

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920440.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920440.yaml
@@ -90,3 +90,24 @@ tests:
             version: HTTP/1.1
           output:
             log_contains: id "920440"
+  - test_title: 920440-5
+    desc: Redis dump file
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+              Accept-Encoding: gzip,deflate
+              Accept-Language: en-us,en;q=0.5
+              Host: localhost
+              Keep-Alive: "300"
+              Proxy-Connection: keep-alive
+              User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
+            method: GET
+            port: 80
+            uri: /dump.rdb
+            version: HTTP/1.1
+          output:
+            log_contains: id "920440"

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920440.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920440.yaml
@@ -1,100 +1,92 @@
 ---
-  meta:
-    author: csanders-git
-    description: None
-    enabled: true
-    name: 920440.yaml
-  tests:
-  - 
-    test_title: 920440-1
+meta:
+  author: csanders-git
+  description: None
+  enabled: true
+  name: 920440.yaml
+tests:
+  - test_title: 920440-1
     desc: URL file extension is restricted by policy (920440) from old modsec regressions
     stages:
-    - 
-      stage:
-        input:
-          dest_addr: 127.0.0.1
-          headers:
-            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
-            Accept-Encoding: gzip,deflate
-            Accept-Language: en-us,en;q=0.5
-            Host: localhost
-            Keep-Alive: '300'
-            Proxy-Connection: keep-alive
-            User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
-          method: GET
-          port: 80
-          uri: /foo.bak
-          version: HTTP/1.1
-        output:
-          log_contains: id "920440"
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+              Accept-Encoding: gzip,deflate
+              Accept-Language: en-us,en;q=0.5
+              Host: localhost
+              Keep-Alive: "300"
+              Proxy-Connection: keep-alive
+              User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
+            method: GET
+            port: 80
+            uri: /foo.bak
+            version: HTTP/1.1
+          output:
+            log_contains: id "920440"
 
-  - 
-    test_title: 920440-2
+  - test_title: 920440-2
     desc: URL file extension is restricted by policy (920440) from old modsec regressions
     stages:
-    - 
-      stage:
-        input:
-          dest_addr: 127.0.0.1
-          headers:
-            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
-            Accept-Encoding: gzip,deflate
-            Accept-Language: en-us,en;q=0.5
-            Host: localhost
-            Keep-Alive: '300'
-            Proxy-Connection: keep-alive
-            User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
-          method: GET
-          port: 80
-          uri: /foo.db
-          version: HTTP/1.1
-        output:
-          log_contains: id "920440"
-  - 
-    test_title: 920440-3
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+              Accept-Encoding: gzip,deflate
+              Accept-Language: en-us,en;q=0.5
+              Host: localhost
+              Keep-Alive: "300"
+              Proxy-Connection: keep-alive
+              User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
+            method: GET
+            port: 80
+            uri: /foo.db
+            version: HTTP/1.1
+          output:
+            log_contains: id "920440"
+  - test_title: 920440-3
     desc: URL file extension is restricted by policy (920440) from old modsec regressions
     stages:
-    - 
-      stage:
-        input:
-          dest_addr: 127.0.0.1
-          headers:
-            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
-            Accept-Encoding: gzip,deflate
-            Accept-Language: en-us,en;q=0.5
-            Host: localhost
-            Keep-Alive: '300'
-            Proxy-Connection: keep-alive
-            User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
-          method: GET
-          port: 80
-          uri: /foo.old
-          version: HTTP/1.1
-        output:
-          log_contains: id "920440"
-  -
-    test_title: 920440-4
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+              Accept-Encoding: gzip,deflate
+              Accept-Language: en-us,en;q=0.5
+              Host: localhost
+              Keep-Alive: "300"
+              Proxy-Connection: keep-alive
+              User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
+            method: GET
+            port: 80
+            uri: /foo.old
+            version: HTTP/1.1
+          output:
+            log_contains: id "920440"
+  - test_title: 920440-4
     desc: URL file extension is restricted by policy (920440) - GH issue 1296
     stages:
-    -
-      stage:
-        input:
-          dest_addr: 127.0.0.1
-          headers:
-            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
-            Accept-Encoding: gzip,deflate
-            Accept-Language: en-us,en;q=0.5
-            Host: localhost
-            Keep-Alive: '300'
-            Proxy-Connection: keep-alive
-            User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
-          method: GET
-          port: 80
-          uri: /foo.bar.sql
-          version: HTTP/1.1
-        output:
-          log_contains: id "920440"
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+              Accept-Encoding: gzip,deflate
+              Accept-Language: en-us,en;q=0.5
+              Host: localhost
+              Keep-Alive: "300"
+              Proxy-Connection: keep-alive
+              User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
+            method: GET
+            port: 80
+            uri: /foo.bar.sql
+            version: HTTP/1.1
+          output:
+            log_contains: id "920440"


### PR DESCRIPTION
During a website migration I found a .rdb (Redis dump file) in the web root.
Seems similarly dangerous to .sql dumps, so I've added them to the list of restricted_extensions.