### PR TITLE
remove unused protected_uploads settings from setup

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -417,8 +417,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 # Forbidden file extensions.
 # Guards against unintended exposure of development/configuration files.
-# Default: .asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/
-# Example: .bak/ .config/ .conf/ .db/ .ini/ .log/ .old/ .pass/ .pdb/ .sql/
+# Default: .asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/
+# Example: .bak/ .config/ .conf/ .db/ .ini/ .log/ .old/ .pass/ .pdb/ .rdb/ .sql/
 # Uncomment this rule to change the default.
 #SecAction \
 # "id:900240,\
@@ -426,7 +426,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
+#  setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
 # Forbidden request headers.
 # Header names should be lowercase, enclosed by /slashes/ as delimiters.

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -454,17 +454,6 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  t:none,\
 #  setvar:'tx.static_extensions=/.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/'"
 
-# Locations that will be inspected to enforce only images and documents uploads.
-# Default: /wp-admin/upload.php /wp-admin/media-new.php
-# Uncomment this rule to change the default set in 901180
-#SecAction \
-# "id:900270,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:'tx.protected_uploads=#/wp-admin/upload.php# #/wp-admin/media-new.php#'"
-
 # Content-Types charsets that a client is allowed to send in a request.
 # Default: utf-8|iso-8859-1|iso-8859-15|windows-1252
 # Uncomment this rule to change the default.

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -218,17 +218,6 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     nolog,\
     setvar:'tx.enforce_bodyproc_urlencoded=0'"
 
-# If a default protected_uploads variable is not set in crs-setup rule 900270
-# then a generic default will be set here.
-SecRule &TX:protected_uploads "@eq 0" \
-    "id:901180,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    noauditlog,\
-    setvar:'tx.protected_uploads=#/upload.php# #/upload.asp# #/upload.jsp#'"
-
 #
 # -=[ Initialize internal variables ]=-
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -192,7 +192,7 @@ SecRule &TX:restricted_extensions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
+    setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
 # Default HTTP policy: restricted_headers (rule 900250)
 SecRule &TX:restricted_headers "@eq 0" \

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920440.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920440.yaml
@@ -90,3 +90,24 @@ tests:
             version: HTTP/1.1
           output:
             log_contains: id "920440"
+  - test_title: 920440-5
+    desc: Redis dump file
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+              Accept-Encoding: gzip,deflate
+              Accept-Language: en-us,en;q=0.5
+              Host: localhost
+              Keep-Alive: "300"
+              Proxy-Connection: keep-alive
+              User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
+            method: GET
+            port: 80
+            uri: /dump.rdb
+            version: HTTP/1.1
+          output:
+            log_contains: id "920440"

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920440.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920440.yaml
@@ -1,100 +1,92 @@
 ---
-  meta:
-    author: csanders-git
-    description: None
-    enabled: true
-    name: 920440.yaml
-  tests:
-  - 
-    test_title: 920440-1
+meta:
+  author: csanders-git
+  description: None
+  enabled: true
+  name: 920440.yaml
+tests:
+  - test_title: 920440-1
     desc: URL file extension is restricted by policy (920440) from old modsec regressions
     stages:
-    - 
-      stage:
-        input:
-          dest_addr: 127.0.0.1
-          headers:
-            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
-            Accept-Encoding: gzip,deflate
-            Accept-Language: en-us,en;q=0.5
-            Host: localhost
-            Keep-Alive: '300'
-            Proxy-Connection: keep-alive
-            User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
-          method: GET
-          port: 80
-          uri: /foo.bak
-          version: HTTP/1.1
-        output:
-          log_contains: id "920440"
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+              Accept-Encoding: gzip,deflate
+              Accept-Language: en-us,en;q=0.5
+              Host: localhost
+              Keep-Alive: "300"
+              Proxy-Connection: keep-alive
+              User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
+            method: GET
+            port: 80
+            uri: /foo.bak
+            version: HTTP/1.1
+          output:
+            log_contains: id "920440"
 
-  - 
-    test_title: 920440-2
+  - test_title: 920440-2
     desc: URL file extension is restricted by policy (920440) from old modsec regressions
     stages:
-    - 
-      stage:
-        input:
-          dest_addr: 127.0.0.1
-          headers:
-            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
-            Accept-Encoding: gzip,deflate
-            Accept-Language: en-us,en;q=0.5
-            Host: localhost
-            Keep-Alive: '300'
-            Proxy-Connection: keep-alive
-            User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
-          method: GET
-          port: 80
-          uri: /foo.db
-          version: HTTP/1.1
-        output:
-          log_contains: id "920440"
-  - 
-    test_title: 920440-3
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+              Accept-Encoding: gzip,deflate
+              Accept-Language: en-us,en;q=0.5
+              Host: localhost
+              Keep-Alive: "300"
+              Proxy-Connection: keep-alive
+              User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
+            method: GET
+            port: 80
+            uri: /foo.db
+            version: HTTP/1.1
+          output:
+            log_contains: id "920440"
+  - test_title: 920440-3
     desc: URL file extension is restricted by policy (920440) from old modsec regressions
     stages:
-    - 
-      stage:
-        input:
-          dest_addr: 127.0.0.1
-          headers:
-            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
-            Accept-Encoding: gzip,deflate
-            Accept-Language: en-us,en;q=0.5
-            Host: localhost
-            Keep-Alive: '300'
-            Proxy-Connection: keep-alive
-            User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
-          method: GET
-          port: 80
-          uri: /foo.old
-          version: HTTP/1.1
-        output:
-          log_contains: id "920440"
-  -
-    test_title: 920440-4
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+              Accept-Encoding: gzip,deflate
+              Accept-Language: en-us,en;q=0.5
+              Host: localhost
+              Keep-Alive: "300"
+              Proxy-Connection: keep-alive
+              User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
+            method: GET
+            port: 80
+            uri: /foo.old
+            version: HTTP/1.1
+          output:
+            log_contains: id "920440"
+  - test_title: 920440-4
     desc: URL file extension is restricted by policy (920440) - GH issue 1296
     stages:
-    -
-      stage:
-        input:
-          dest_addr: 127.0.0.1
-          headers:
-            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
-            Accept-Encoding: gzip,deflate
-            Accept-Language: en-us,en;q=0.5
-            Host: localhost
-            Keep-Alive: '300'
-            Proxy-Connection: keep-alive
-            User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
-          method: GET
-          port: 80
-          uri: /foo.bar.sql
-          version: HTTP/1.1
-        output:
-          log_contains: id "920440"
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+              Accept-Encoding: gzip,deflate
+              Accept-Language: en-us,en;q=0.5
+              Host: localhost
+              Keep-Alive: "300"
+              Proxy-Connection: keep-alive
+              User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
+            method: GET
+            port: 80
+            uri: /foo.bar.sql
+            version: HTTP/1.1
+          output:
+            log_contains: id "920440"


### PR DESCRIPTION
There are no rules checking this variable, so they should be removed from config and initialization.