### PR TITLE
remove unused protected_uploads setting from setup

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -454,17 +454,6 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  t:none,\
 #  setvar:'tx.static_extensions=/.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/'"
 
-# Locations that will be inspected to enforce only images and documents uploads.
-# Default: /wp-admin/upload.php /wp-admin/media-new.php
-# Uncomment this rule to change the default set in 901180
-#SecAction \
-# "id:900270,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:'tx.protected_uploads=#/wp-admin/upload.php# #/wp-admin/media-new.php#'"
-
 # Content-Types charsets that a client is allowed to send in a request.
 # Default: utf-8|iso-8859-1|iso-8859-15|windows-1252
 # Uncomment this rule to change the default.

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -218,17 +218,6 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     nolog,\
     setvar:'tx.enforce_bodyproc_urlencoded=0'"
 
-# If a default protected_uploads variable is not set in crs-setup rule 900270
-# then a generic default will be set here.
-SecRule &TX:protected_uploads "@eq 0" \
-    "id:901180,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    noauditlog,\
-    setvar:'tx.protected_uploads=#/upload.php# #/upload.asp# #/upload.jsp#'"
-
 #
 # -=[ Initialize internal variables ]=-
 #


### PR DESCRIPTION
There are no rules checking the `protected_uploads` variable, so it should be removed from config and initialization.