### PR TITLE
Fix bypass in 931130

### DIFF
--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -101,7 +101,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:931014,phase:2,pass,nolog,skipAf
 # -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
 #
 
-SecRule ARGS "@rx ^(?i:file|ftps?|https?)://(.*)$" \
+SecRule ARGS "@rx ^(?i:file|ftps?|https?)://([^/]*).*$" \
     "id:931130,\
     phase:2,\
     block,\
@@ -119,9 +119,9 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?)://(.*)$" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
-    setvar:'tx.rfi_parameter_%{MATCHED_VAR_NAME}=%{tx.1}',\
+    setvar:'tx.rfi_parameter_%{MATCHED_VAR_NAME}=.%{tx.1}',\
     chain"
-    SecRule TX:/rfi_parameter_.*/ "!@beginsWith %{request_headers.host}" \
+    SecRule TX:/rfi_parameter_.*/ "!@endsWith .%{request_headers.host}" \
         "setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 

--- a/util/regression-tests/tests/REQUEST-931-APPLICATION-ATTACK-RFI/931130.yaml
+++ b/util/regression-tests/tests/REQUEST-931-APPLICATION-ATTACK-RFI/931130.yaml
@@ -89,3 +89,105 @@
               version: HTTP/1.1
             output:
               log_contains: id "931130"
+    -
+      test_title: 931130-6
+      desc: Partial match
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: 127.0.0.1
+              headers:
+                User-Agent: "ModSecurity CRS 3 Tests"
+                Host: example.com
+              method: GET
+              port: 80
+              uri: /?x=https://evilexample.com/
+              version: HTTP/1.1
+            output:
+              log_contains: id "931130"
+    -
+      test_title: 931130-7
+      desc: Mismatching domains
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: 127.0.0.1
+              headers:
+                User-Agent: "ModSecurity CRS 3 Tests"
+                Host: example.com
+              method: GET
+              port: 80
+              uri: /?x=https://example.com.evil.com/
+              version: HTTP/1.1
+            output:
+              log_contains: id "931130"
+    -
+      test_title: 931130-8
+      desc: Mismatching ports
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: 127.0.0.1
+              headers:
+                User-Agent: "ModSecurity CRS 3 Tests"
+                Host: example.com
+              method: GET
+              port: 80
+              uri: /?x=https://example.com:1234/
+              version: HTTP/1.1
+            output:
+              log_contains: id "931130"
+    -
+      test_title: 931130-9
+      desc: Matching hosts
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: 127.0.0.1
+              headers:
+                User-Agent: "ModSecurity CRS 3 Tests"
+                Host: example.com
+              method: GET
+              port: 80
+              uri: /?x=https://example.com/
+              version: HTTP/1.1
+            output:
+              no_log_contains: id "931130"
+    -
+      test_title: 931130-10
+      desc: Matching hosts and ports
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: 127.0.0.1
+              headers:
+                User-Agent: "ModSecurity CRS 3 Tests"
+                Host: example.com
+              method: GET
+              port: 80
+              uri: /?x=https://example.com:1234/
+              version: HTTP/1.1
+            output:
+              log_contains: id "931130"
+    -
+      test_title: 931130-11
+      desc: Subdomains
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: 127.0.0.1
+              headers:
+                User-Agent: "ModSecurity CRS 3 Tests"
+                Host: example.com
+              method: GET
+              port: 80
+              uri: /?x=http://www.example.com/some/path
+              version: HTTP/1.1
+            output:
+              no_log_contains: id "931130"


### PR DESCRIPTION
Don't rely on beginsWith as it might allow attackers to create
subdomains matching the prefix. Add tests to cover this and other
cases.

The latter fixes #1404.