### PR TITLE
Code cosmetics: reorder the actions of rules

### DIFF
--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -40,8 +40,8 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     tag:'OWASP_TOP_10/A6',\
     tag:'OWASP_AppSensor/RE1',\
     tag:'PCI/12.1',\
-    severity:'CRITICAL',\
     ver:'OWASP_CRS/3.2.0',\
+    severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 

--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -105,11 +105,11 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     "id:912120,\
     phase:1,\
     drop,\
+    msg:'Denial of Service (DoS) attack identified from %{tx.real_ip} (%{tx.dos_block_counter} hits since last alert)',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-dos',\
-    msg:'Denial of Service (DoS) attack identified from %{tx.real_ip} (%{tx.dos_block_counter} hits since last alert)',\
     chain"
     SecRule &IP:DOS_BLOCK_FLAG "@eq 0" \
         "setvar:'ip.dos_block_counter=+1',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -895,6 +895,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     "id:920420,\
     phase:2,\
     block,\
+    capture,\
     t:none,\
     msg:'Request content type is not allowed by policy',\
     logdata:'%{MATCHED_VAR}',\
@@ -910,7 +911,6 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
-    capture,\
     chain"
     SecRule TX:0 "!@rx ^%{tx.allowed_request_content_type}$" \
         "t:none,\
@@ -925,6 +925,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*([^;\s]+)" \
     "id:920480,\
     phase:1,\
     block,\
+    capture,\
     t:none,t:lowercase,\
     msg:'Request content type charset is not allowed by policy',\
     logdata:'%{MATCHED_VAR}',\
@@ -940,7 +941,6 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*([^;\s]+)" \
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
-    capture,\
     chain"
     SecRule TX:1 "!@rx ^%{tx.allowed_request_content_type_charset}$" \
         "t:none,\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -68,8 +68,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     block,\
     capture,\
     t:none,t:urlDecodeUni,t:lowercase,\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     msg:'HTTP Response Splitting Attack',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -89,8 +89,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     block,\
     capture,\
     t:none,t:urlDecodeUni,t:htmlEntityDecode,t:lowercase,\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     msg:'HTTP Response Splitting Attack',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -107,8 +107,8 @@ SecRule REQUEST_FILENAME "@pmFromFile restricted-files.data" \
     block,\
     capture,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,t:lowercase,\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     msg:'Restricted File Access Attempt',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -584,8 +584,8 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     block,\
     capture,\
     t:none,t:lowercase,\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     msg:'Restricted File Upload Attempt',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -704,16 +704,13 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
 # See issue #654 for discussion.
 #
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pm ?>" \
-    "msg:'PHP Injection Attack: PHP Closing Tag Found',\
+    "id:933190,\
     phase:2,\
-    ver:'OWASP_CRS/3.2.0',\
-    t:none,t:urlDecodeUni,\
-    ctl:auditLogParts=+E,\
     block,\
     capture,\
+    t:none,t:urlDecodeUni,\
+    msg:'PHP Injection Attack: PHP Closing Tag Found',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    id:933190,\
-    severity:'CRITICAL',\
     tag:'application-multi',\
     tag:'language-php',\
     tag:'platform-multi',\
@@ -722,6 +719,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     tag:'paranoia-level/3',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.2.0',\
+    severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 

--- a/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
@@ -50,7 +50,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:2,\
     block,\
     capture,\
-    multiMatch,\
     t:none,t:urlDecodeUni,t:base64Decode,\
     msg:'Node.js Injection Attack',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -64,6 +63,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
+    multiMatch,\
     setvar:'tx.rce_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -959,8 +959,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS/WEB_ATTACK/XSS',\
     tag:'OWASP_TOP_10/A7',\
     tag:'CAPEC-63',\
-    ctl:auditLogParts=+E,\
     tag:'paranoia-level/2',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1079,8 +1079,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     block,\
     capture,\
     t:none,t:urlDecodeUni,\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     msg:'SQL Injection Attack',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -34,10 +34,10 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     "id:944100,\
     phase:2,\
     block,\
+    t:none,t:lowercase,\
     log,\
     msg:'Remote Command Execution: Suspicious Java class detected',\
     logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',\
-    t:none,t:lowercase,\
     tag:'application-multi',\
     tag:'language-java',\
     tag:'platform-multi',\
@@ -134,10 +134,10 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     "id:944130,\
     phase:2,\
     block,\
+    t:none,t:lowercase,\
     log,\
     msg:'Suspicious Java class detected',\
     logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',\
-    t:none,t:lowercase,\
     tag:'application-multi',\
     tag:'language-java',\
     tag:'platform-multi',\
@@ -250,10 +250,10 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     "id:944250,\
     phase:2,\
     block,\
+    t:lowercase,\
     log,\
     msg:'Remote Command Execution: Suspicious Java method detected',\
     logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',\
-    t:lowercase,\
     tag:'application-multi',\
     tag:'language-java',\
     tag:'platform-multi',\

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -29,8 +29,8 @@ SecRule RESPONSE_BODY "@pmFromFile sql-errors.data" \
     "id:951100,\
     phase:4,\
     pass,\
-    nolog,\
     t:none,\
+    nolog,\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -104,8 +104,8 @@ SecRule RESPONSE_BODY "@rx <\?(?!xml)" \
     severity:'ERROR',\
     chain"
     SecRule RESPONSE_BODY "!@rx (?:\x1f\x8b\x08|\b(?:(?:i(?:nterplay|hdr|d3)|m(?:ovi|thd)|r(?:ar!|iff)|(?:ex|jf)if|f(?:lv|ws)|varg|cws)\b|gif)|B(?:%pdf|\.ra)\b)" \
-        "t:none,\
-        capture,\
+        "capture,\
+        t:none,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -112,8 +112,8 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
     severity:'ERROR',\
     chain"
     SecRule RESPONSE_BODY "@rx \bServer Error in.{0,50}?\bApplication\b" \
-        "t:none,\
-        capture,\
+        "capture,\
+        t:none,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -44,8 +44,8 @@ SecRule &TX:'/AVAILABILITY\\\/APP_NOT_AVAIL/' "@ge 1" \
     t:none,\
     log,\
     msg:'Correlated Attack Attempt Identified: (Total Score: %{tx.anomaly_score}) Inbound Attack (Inbound Anomaly Score: %{TX.INBOUND_ANOMALY_SCORE}) + Outbound Application Error (Outbound Anomaly Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
-    severity:'ALERT',\
     tag:'event-correlation',\
+    severity:'ALERT',\
     chain,\
     skipAfter:END-CORRELATION"
     SecRule &TX:'/WEB_ATTACK/' "@ge 1" "t:none"


### PR DESCRIPTION
This patch contains some modifications, which reorders the actions at SecRules.

The reference order was this:
https://github.com/SpiderLabs/owasp-modsecurity-crs/wiki/Order-of-ModSecurity-Actions-in-CRS-rules

but this list doesn't contains all actions, so I extended it - this is the used order:
```
[
            "id",
            "phase",
            "pass",
            "block",
            "deny",
            "drop",        # new
            "status",
            "capture",
            "t",
            "log",
            "nolog",
            "auditlog",
            "noauditlog",
            "msg",
            "logdata",
            "tag",
            "sanitiseArg",
            "sanitiseRequestHeader",
            "sanitiseMatched",
            "sanitiseMatchedBytes",
            "ctl",
            "ver",         # new
            "severity",    # new
            "multiMatch",  # new
            "initcol",     # new
            "setenv",
            "setvar",
            "expirevar",   # new
            "chain",
            "skip",
            "skipAfter",
]
```