### PR TITLE
920470: include chars from rfc 2046

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -867,7 +867,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - text/plain; charset="UTF-8"
 # - multipart/form-data; boundary=----WebKitFormBoundary12345
 #
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.\-+]+(?:\s?;\s?(?:boundary|charset)\s?=\s?['\"\w.\-()+,/:=?]+)?$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:boundary|charset)\s?=\s?['\"\w.()+,/:=?-]+)?$" \
     "id:920470,\
     phase:1,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -867,7 +867,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - text/plain; charset="UTF-8"
 # - multipart/form-data; boundary=----WebKitFormBoundary12345
 #
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w\d/\.\-\+]+(?:\s?;\s?(?:boundary|charset)\s?=\s?['\"\w\d\.\-]+)?$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.\-+]+(?:\s?;\s?(?:boundary|charset)\s?=\s?['\"\w.\-()+,/:=?]+)?$" \
     "id:920470,\
     phase:1,\
     block,\

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
@@ -43,7 +43,7 @@
                   Content-Type: 'text/plain; charset=/gar/bage'
                   Content-Length: 0
             output:
-              log_contains: "id \"920470\""
+              no_log_contains: "id \"920470\""
     - test_title: 920470-4
       stages:
         - stage:
@@ -127,3 +127,45 @@
                   Content-Length: 0
             output:
               no_log_contains: "id \"920470\""
+    - test_title: 920470-10
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              method: POST
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'multipart/mixed; boundary=-----boundary_data:55780(123,45:667)+part'
+                  Content-Length: 0
+            output:
+              no_log_contains: "id \"920470\""
+    - test_title: 920470-11
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              method: POST
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'multipart/mixed; boundary= gc0p4Jq0M2Yt,08/jU534c0p?==:test'
+                  Content-Length: 0
+            output:
+              no_log_contains: "id \"920470\""
+    - test_title: 920470-12
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              method: POST
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'multipart/form-data; boundary=  test_data_123456'
+                  Content-Length: 0
+            output:
+              log_contains: "id \"920470\""


### PR DESCRIPTION
RFC 2046 allows additional chars for the boundary.
\d removed as it is covered by \w in the regex. 
Removed unnecessary escapes.

This should fix https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/1409 by adding the missing characters for the boundary.