### PR TITLE
Node.js: fix score variable

### DIFF
--- a/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
@@ -64,7 +64,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     multiMatch,\
-    setvar:'tx.rce_injection_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 


### PR DESCRIPTION
I accidentally used `tx.rce_injection_score` instead of `tx.rce_score`, well spotted by @fgsch !