### PR TITLE
942510, 942511: fix anomaly score variable

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1379,7 +1379,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:942015,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
@@ -1646,7 +1646,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:942017,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:942018,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"


### PR DESCRIPTION
Rule 942510 is at PL2, 942511 is at PL3, but they increment the wrong (PL1) anomaly score.

Thanks to @franbuehler for reminding me of this!