### PR TITLE
Rule 941370: Remove deprecated t:removeComments

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -699,16 +699,18 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 
 #
 # Prevent 941180 bypass by using JavaScript global variables
+# Refer to: https://www.secjuice.com/bypass-xss-filters-using-javascript-global-variables/
+#
 # Examples:
 #    - /?search=/?a=";+alert(self["document"]["cookie"]);//
 #    - /?search=/?a=";+document+/*foo*/+.+/*bar*/+cookie;//
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:/* "@rx (?:self|document|this|top|window)\s*\)*(?:\[[^\]]+\]|\.\s*document|\.\s*cookie)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:/* "@rx (?:self|document|this|top|window)\s*(?:/\*|[\[)]).+?(?:\]|\*/)" \
     "id:941370,\
     phase:2,\
     block,\
     capture,\
-    t:none,t:removeComments,t:urlDecodeUni,\
+    t:none,t:urlDecodeUni,t:compressWhitespace,\
     msg:'JavaScript global variable found',\
     logdata:'Matched Data: Suspicious JS global variable found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/util/regression-tests/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941370.yaml
+++ b/util/regression-tests/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941370.yaml
@@ -7,7 +7,7 @@
   tests:
   -
     test_title: 941370-1
-    desc: "Filter bypass using JS global variable"
+    desc: "Bypass using comment in syntax and multiple whitespaces"
     stages:
     -
       stage:
@@ -17,13 +17,13 @@
             Host: localhost
           method: GET
           port: 80
-          data: "a=\";document+%2f%2A+foo+%2A%2f+%5B+%22cookie%22+%5D;%2f%2f"
+          data: "a=document+%2F%2Afoo%2A%2F+.+++++cookie"
           version: HTTP/1.1
         output:
           log_contains: id "941370"
   -
     test_title: 941370-2
-    desc: "Filter bypass using JS global variable"
+    desc: "Bypass using comments in syntax"
     stages:
     -
       stage:
@@ -33,13 +33,13 @@
             Host: localhost
           method: POST
           port: 80
-          data: "a=\";window+%2f%2A+foo+%2A%2f+.+document+.+%2f%2A+bar+%2A%2f+cookie%2f%2f"
+          data: "a=document%2F%2Afoo%2A%2F.%2F%2Abar%2A%2Fcookie"
           version: HTTP/1.1
         output:
           log_contains: id "941370"
   -
     test_title: 941370-3
-    desc: "Filter bypass using JS global variable"
+    desc: "Bypass using JavaScript global variables"
     stages:
     -
       stage:
@@ -49,13 +49,13 @@
             Host: localhost
           method: GET
           port: 80
-          data: "a=document.cookie"
+          data: "a=window%5B%22alert%22%5D%28window%5B%22document%22%5D%5B%22cookie%22%5D%29"
           version: HTTP/1.1
         output:
           log_contains: id "941370"
   -
     test_title: 941370-4
-    desc: "Filter bypass using JS global variable"
+    desc: "Bypass using JavaScript global variables and comments in syntax"
     stages:
     -
       stage:
@@ -65,13 +65,13 @@
             Host: localhost
           method: GET
           port: 80
-          data: "a=document .cookie"
+          data: "a=self%5B%2F%2Afoo%2A%2F%22alert%22%5D%28self%5B%22document%22%2F%2Abar%2A%2F%5D%5B%22cookie%22%5D%29"
           version: HTTP/1.1
         output:
           log_contains: id "941370"
   -
     test_title: 941370-5
-    desc: "Filter bypass using JS global variable"
+    desc: "Bypass using JavaScript global variables and string concatenation"
     stages:
     -
       stage:
@@ -81,8 +81,92 @@
             Host: localhost
           method: GET
           port: 80
-          data: "a=document%5B%27cookie%27%5D"
+          data: "a=self%5B%2F%2Afoo%2A%2F%22alert%22%5D%28self%5B%22document%22%2F%2Abar%2A%2F%5D%5B%22cookie%22%5D%29"
           version: HTTP/1.1
         output:
           log_contains: id "941370"
 
+  -
+    test_title: 941370-6
+    desc: "Bypass using JavaScript global variables and comments in syntax"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          data: "a=self++%2F%2Ajhb%2A%2F++%5B++%2F%2Abar%2A%2F++%22alert%22%5D%28%22xss%22%29"
+          version: HTTP/1.1
+        output:
+          log_contains: id "941370"
+
+  -
+    test_title: 941370-7
+    desc: "Bypass using JavaScript global variables and jQuery globalEval"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          data: "a=self%5B%22%24%22%5D%5B%22globalEval%22%5D%28%22alert%281%29%22%29"
+          version: HTTP/1.1
+        output:
+          log_contains: id "941370"
+
+  -
+    test_title: 941370-8
+    desc: "Bypass using JavaScript global variables and hex escape sequence"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          data: "a=self%5B%22%5Cx24%22%5D"
+          version: HTTP/1.1
+        output:
+          log_contains: id "941370"
+
+  -
+    test_title: 941370-9
+    desc: "Bypass trying to access document.cookie using alternative syntax like (document)['cookie']"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          data: "a=%28document%29%5B%22cookie%22%5D"
+          version: HTTP/1.1
+        output:
+          log_contains: id "941370"
+
+  -
+    test_title: 941370-10
+    desc: "Bypass trying to access document.cookie using alternative syntax and comments like (document/*foo*/)['cookie']"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          data: "a=%28document%2F%2Afoo%2A%2F%29%5B%22cookie%22%5D"
+          version: HTTP/1.1
+        output:
+          log_contains: id "941370"


### PR DESCRIPTION
Removing the deprecated transformation function `t:removeComments` led me to change the regex to catch all possible bypass techniques that uses JavaScript comments inside syntax:

Examples:
- `document /*foo*/ .     cookie`
- `document/*foo*/./*bar*/cookie`
- `self  /*foo*/  [  /*bar*/  "alert"]("xss");`
more examples at https://regex101.com/r/FEpvHO/8

I've added `t:compressWhitespace` to convert newline characters into 0x20, always to prevent bypass.

This regex could lead to 2 type of FPs (see the link above). IMO both should not be critical and not new to other XSS rules.

Please, feel free to send advices, fixes and comments as well!