### PR TITLE
Update mailing list links to google group

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,8 +2,8 @@
 
 == Report Bugs/Issues to GitHub Issues Tracker or the mailinglist ==
 * https://github.com/SpiderLabs/owasp-modsecurity-crs/issues
-  or the CRS mailinglist at
-* https://lists.owasp.org/mailman/listinfo/owasp-modsecurity-core-rule-set
+  or the CRS Google Group at
+* https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project
 
 == Version 3.2.0 - 2019-09-24 ==
 

--- a/KNOWN_BUGS
+++ b/KNOWN_BUGS
@@ -2,8 +2,8 @@
 
 == Report Bugs/Issues to GitHub Issues Tracker or the mailinglist ==
 * https://github.com/SpiderLabs/owasp-modsecurity-crs/issues
-or the CRS mailinglist at
-* https://lists.owasp.org/mailman/listinfo/owasp-modsecurity-core-rule-set
+or the CRS Google Group at
+* https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project
 
 * There are still false positives for standard web applications in
   the default install (paranoia level 1). Please report these when

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We strive to make the OWASP ModSecurity CRS accessible to a wide audience of beg
 
 [Create an issue on GitHub](https://github.com/SpiderLabs/owasp-modsecurity-crs/issues) to report a false positive or false negative (evasion). Please include your installed version and the relevant portions of your ModSecurity audit log.
 
-[Sign up for the mailing list](https://lists.owasp.org/mailman/listinfo/owasp-modsecurity-core-rule-set) to ask general usage questions and participate in discussions on the CRS.
+[Sign up for our Google Group](https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project) to ask general usage questions and participate in discussions on the CRS.
 
 [Join the #modsecurity channel on Freenode IRC](https://webchat.freenode.net/?channels=%23modsecurity) to chat about the CRS.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We strive to make the OWASP ModSecurity CRS accessible to a wide audience of beg
 
 [Create an issue on GitHub](https://github.com/SpiderLabs/owasp-modsecurity-crs/issues) to report a false positive or false negative (evasion). Please include your installed version and the relevant portions of your ModSecurity audit log.
 
-[Sign up for our Google Group](https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project) to ask general usage questions and participate in discussions on the CRS.Also [here](https://lists.owasp.org/pipermail/owasp-modsecurity-core-rule-set/index) you can find the archives for the previous mailing list.
+[Sign up for our Google Group](https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project) to ask general usage questions and participate in discussions on the CRS. Also [here](https://lists.owasp.org/pipermail/owasp-modsecurity-core-rule-set/index) you can find the archives for the previous mailing list.
 
 [Join the #modsecurity channel on Freenode IRC](https://webchat.freenode.net/?channels=%23modsecurity) to chat about the CRS.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We strive to make the OWASP ModSecurity CRS accessible to a wide audience of beg
 
 [Create an issue on GitHub](https://github.com/SpiderLabs/owasp-modsecurity-crs/issues) to report a false positive or false negative (evasion). Please include your installed version and the relevant portions of your ModSecurity audit log.
 
-[Sign up for our Google Group](https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project) to ask general usage questions and participate in discussions on the CRS.
+[Sign up for our Google Group](https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project) to ask general usage questions and participate in discussions on the CRS.Also [here](https://lists.owasp.org/pipermail/owasp-modsecurity-core-rule-set/index) you can find the archives for the previous mailing list.
 
 [Join the #modsecurity channel on Freenode IRC](https://webchat.freenode.net/?channels=%23modsecurity) to chat about the CRS.
 


### PR DESCRIPTION
OWASP moved away from mailing lists.

This PR updated the links to the new google groups. 