### PR TITLE
Change chain order

### DIFF
--- a/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+++ b/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
@@ -32,7 +32,7 @@ SecRule REQUEST_LINE "@streq GET /" \
 #
 # Exception for Apache internal dummy connection
 #
-SecRule REQUEST_LINE "@rx ^(?:GET /|OPTIONS \*) HTTP/[12]\.[01]$" \
+SecRule REQUEST_HEADERS:User-Agent "@endsWith (internal dummy connection)" \
     "id:905110,\
     phase:1,\
     pass,\
@@ -46,7 +46,7 @@ SecRule REQUEST_LINE "@rx ^(?:GET /|OPTIONS \*) HTTP/[12]\.[01]$" \
     SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
         "t:none,\
         chain"
-        SecRule REQUEST_HEADERS:User-Agent "@rx ^.*\(internal dummy connection\)$" \
+        SecRule REQUEST_LINE "@rx ^(?:GET /|OPTIONS \*) HTTP/[12]\.[01]$" \
             "t:none,\
             ctl:ruleEngine=Off,\
             ctl:auditEngine=Off"

--- a/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+++ b/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
@@ -32,7 +32,7 @@ SecRule REQUEST_LINE "@streq GET /" \
 #
 # Exception for Apache internal dummy connection
 #
-SecRule REQUEST_HEADERS:User-Agent "@endsWith (internal dummy connection)" \
+SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
     "id:905110,\
     phase:1,\
     pass,\
@@ -43,7 +43,7 @@ SecRule REQUEST_HEADERS:User-Agent "@endsWith (internal dummy connection)" \
     tag:'platform-apache',\
     tag:'attack-generic',\
     chain"
-    SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
+    SecRule REQUEST_HEADERS:User-Agent "@endsWith (internal dummy connection)" \
         "t:none,\
         chain"
         SecRule REQUEST_LINE "@rx ^(?:GET /|OPTIONS \*) HTTP/[12]\.[01]$" \


### PR DESCRIPTION
Changes chain ordering so the first match is narrow than the previous one.

Also changed regexp to be `@endswith`.