### PR TITLE
New rule 920500: block backup extensions

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1031,6 +1031,31 @@ SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
+# Backup or "working" file extension
+# example: index.php~, /index.php~/foo/
+#
+SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
+    "id:920500,\
+    phase:2,\
+    block,\
+    t:none,t:urlDecodeUni,\
+    msg:'Attempt to access a backup or working file',\
+    logdata:'%{TX.0}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'OWASP_CRS/POLICY/EXT_RESTRICTED',\
+    tag:'WASCTC/WASC-15',\
+    tag:'OWASP_TOP_10/A7',\
+    tag:'PCI/6.5.10',\
+    ver:'OWASP_CRS/3.2.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+#
 # Restricted HTTP headers
 #
 # -=[ Rule Logic ]=-

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920500.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920500.yaml
@@ -1,0 +1,49 @@
+---
+  meta:
+    author: "Andrea Menin"
+    enabled: true
+    name: "920500.yaml"
+    description: "Tests for backup or working file extensions"
+  tests:
+    - test_title: 920500-1
+      desc: "Check request filename ends with ~"
+      stages:
+        - stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "GET"
+              uri: "/index.php~"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+            output:
+              log_contains: "id \"920500\""
+    - test_title: 920500-2
+      desc: "Check request filename contains file that ends with ~ but not at end of string (bypass)"
+      stages:
+        - stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "GET"
+              uri: "/index.php~/foo/bar/"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+            output:
+              log_contains: "id \"920500\""
+    - test_title: 920500-3
+      desc: "Rules 920500 should not block user dir such as /~user/"
+      stages:
+        - stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "GET"
+              uri: "/~user/"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+            output:
+              no_log_contains: "id \"920500\""


### PR DESCRIPTION
Relating to https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/1531 I've created the rule 920500 in `rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf` that matches all following request filename:

- `index.php~`
- `index.php~/foo/`

but not matches user html dir like `/~user/`.

I've added 3 new test in `util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920500.yaml`, from my local CRS_Test.py:

```
util/regression-tests/CRS_Tests.py::test_crs[ruleset2112-920500.yaml -- 920500-1] PASSED
util/regression-tests/CRS_Tests.py::test_crs[ruleset2113-920500.yaml -- 920500-2] PASSED
util/regression-tests/CRS_Tests.py::test_crs[ruleset2114-920500.yaml -- 920500-3] PASSED
```

I'm not sure about the transformation function `t:urlDecodeUni`. In my test on nginx seems to work with or without it, with both encoded and decoded ~ to %7e. Any thoughts?