### PR TITLE
Ignore configuration files generated by the JetBrains editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ util/geo-location/GeoIP.dat
 __pycache__/
 *.py[cod]
 *$py.class
+
+.idea/


### PR DESCRIPTION
Ignore the config directory (`.idea/`) that JetBrains editors create.