### PR TITLE
Correct rule 941310

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -599,7 +599,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Reported by Mazin Ahmed
 #
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:¾|¼).*(?:¾|¼|>)|(?:¾|¼|<).*(?:¾|¼)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\xbc\xbe].*[\xbc\xbe>]|[\xbc\xbe<].*[\xbc\xbe]" \
     "id:941310,\
     phase:2,\
     block,\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -599,7 +599,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Reported by Mazin Ahmed
 #
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\xbc\xbe].*[\xbc\xbe>]|[\xbc\xbe<].*[\xbc\xbe]" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \xbc[^\xbe>]*[\xbe>]|<[^\xbe]*\xbe" \
     "id:941310,\
     phase:2,\
     block,\

--- a/util/regression-tests/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941310.yaml
+++ b/util/regression-tests/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941310.yaml
@@ -1,13 +1,13 @@
 ---
   meta:
-    author: "Christian S.J. Peron"
+    author: Christian S.J. Peron
     description: None
     enabled: true
     name: 941310.yaml
   tests:
   -
     test_title: 941310-1
-    desc: "US-ASCII Malformed Encoding XSS Filter"
+    desc: US-ASCII Malformed Encoding XSS Filter
     stages:
     -
       stage:
@@ -15,10 +15,27 @@
           dest_addr: 127.0.0.1
           headers:
             Host: localhost
-            Content-type: "iso-8859-15"
+            Content-type: us-ascii
           method: POST
           port: 80
-          uri: "/"
-          data: "var=.*¾.*¼.*"
+          uri: /
+          data: var=\xbcscript\xbealert(\xa2XSS\xa2)\xbc/script\xbe
+        output:
+          log_contains: id "941310"
+  -
+    test_title: 941310-2
+    desc: US-ASCII Malformed Encoding XSS Filter
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Content-type: us-ascii
+          method: POST
+          port: 80
+          uri: /
+          data: var=\xc2\xbcscript\xc2\xbealert(\xc2\xa2XSS\xc2\xa2)\xc2\xbc/script\xc2\xbe
         output:
           log_contains: id "941310"

--- a/util/regression-tests/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941310.yaml
+++ b/util/regression-tests/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941310.yaml
@@ -1,13 +1,13 @@
 ---
   meta:
-    author: Christian S.J. Peron
-    description: None
+    author: Christian S.J. Peron, Federico G. Schwindt
+    description: US-ASCII Malformed Encoding XSS Filter
     enabled: true
     name: 941310.yaml
   tests:
   -
     test_title: 941310-1
-    desc: US-ASCII Malformed Encoding XSS Filter
+    desc: Positive test using single byte
     stages:
     -
       stage:
@@ -24,7 +24,7 @@
           log_contains: id "941310"
   -
     test_title: 941310-2
-    desc: US-ASCII Malformed Encoding XSS Filter
+    desc: Positive test using utf-8
     stages:
     -
       stage:
@@ -39,3 +39,37 @@
           data: var=\xc2\xbcscript\xc2\xbealert(\xc2\xa2XSS\xc2\xa2)\xc2\xbc/script\xc2\xbe
         output:
           log_contains: id "941310"
+  -
+    test_title: 941310-3
+    desc: Negative test for opening tag
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Content-type: us-ascii
+          method: POST
+          port: 80
+          uri: /
+          data: var=\xbc\xbc
+        output:
+          no_log_contains: id "941310"
+  -
+    test_title: 941310-4
+    desc: Negative test for closing tag
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Content-type: us-ascii
+          method: POST
+          port: 80
+          uri: /
+          data: var=\xbe\xbe
+        output:
+          no_log_contains: id "941310"


### PR DESCRIPTION
Patterns in ModSecurity are not treated as UTF strings.

Fixes #1595.