### PR TITLE
932200: PL1 RCE bypass uninitialized variable (DRAFT)

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -612,6 +612,40 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
+#
+# -=[ Rule 932200 ]=-
+#
+# Intercept RCE Bypass using uninitialized variables
+# Refer to: https://www.secjuice.com/web-application-firewall-waf-evasion/
+#
+# Examples:
+# - foo;cat$u/etc$u/passwd
+# - bar;cd+/etc;/bin$u/ca*+passwd
+#
+# (remove this line) Regex notes: https://regex101.com/r/JgZFRi/2/
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:bin|boot|dev|etc|home|lib|media|mnt|opt|proc|root|run|sbin|srv|sys|tmp|usr|var|[a-z]\*|\*[a-z]+)\$[a-zA-Z@]" \
+    "id:932200,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:lowercase,\
+    msg:'RCE Bypass using Uninitialized Variable',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'OWASP_CRS',\
+    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
+    tag:'WASCTC/WASC-31',\
+    tag:'OWASP_TOP_10/A1',\
+    tag:'PCI/6.5.2',\
+    ver:'OWASP_CRS/3.2.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"


### PR DESCRIPTION
**This PR is a draft**

Referring to #1513 I think we've 2 different kinds of RCE bypass in PL1 (at least with bash/dash like interpreters):
- Uninitialized variables
- Globbing patterns

We already got a rule at PL3 that handles globbing patterns bypass attempts (930120) but it isn't suitable for PL1 because it's likely prone to many false positive. Assuming that the first part of the original payloads twitted by the user (`{ 1 }; `) should be removed (otherwise, both doesn't represent a valid syntax) I think we can start with these two:

- Uninitialized variables: `;cat$u+/etc$u/passwd`
- Globbing patterns: `;cd+/etc;/bin/c*t+passwd` 

Maybe, when these two techniques are used together, it would be really hard to intercept them at PL1. I mean something like:
`www.google.com;cd+/et*;/bi*$u/ca*+passwd`

I'm testing it against the following script:

```php
<?php

   // resolve a given hostname in the host ARG
   // example: /?host=www.google.com
   system("host "+$_GET["host"]);
```

If you want to try my PoC you can easily use this https://github.com/theMiddleBlue/OWASP-CRS-PoC:
```bash
git clone https://github.com/theMiddleBlue/OWASP-CRS-PoC.git
cd OWASP-CRS-PoC/bash-rce-bypass
bash start.sh -f https://github.com/theMiddleBlue/owasp-modsecurity-crs -b pl1-rce-bypass
```

run exploit:
```bash
# bash exploit/uninitialized_variables.sh 
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8001 (#0)
> GET /?host=www.google.com;cat$u+/etc$u/passwd HTTP/1.1
> Host: localhost:8001
> User-Agent: curl/7.64.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Mon, 21 Oct 2019 14:32:18 GMT
< Server: Apache
< Host: 172.16.7.26:3000
< X-Powered-By: PHP/7.2.19-0ubuntu0.18.04.2
< Content-type: text/html; charset=UTF-8
< Content-Length: 1067
< 
www.google.com has address 216.58.205.36
www.google.com has IPv6 address 2a00:1450:4009:808::2004
Host www.google.com not found: 3(NXDOMAIN)
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
_apt:x:100:65534::/nonexistent:/usr/sbin/nologin
* Connection #0 to host localhost left intact
* Closing connection 0
```

check audit logs:
```bash
# python3 logs/viewlogs.py 
[932200] RCE Bypass using Uninitialized Variable
        `- Matched Data: etc$u found within ARGS:host: www.google.com;cat$u /etc$u/passwd
[949110] Inbound Anomaly Score Exceeded (Total Score: 5)
[980130] Inbound Anomaly Score Exceeded (Total Inbound Score: 5 - SQLI=0,XSS=0,RFI=0,LFI=5,RCE=0,PHPI=0,HTTP=0,SESS=0): individual paranoia level scores: 5, 0, 0, 0
```