### PR TITLE
New Rule 921190: HTTP Splitting

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -193,6 +193,31 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx (?:\n|\r)+(?:\s|location|refresh|(?:set-)?c
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
+# -=[ HTTP Splitting ]=-
+#
+# This rule detect \n or \r in the REQUEST FILENAME
+# Reference: https://www.owasp.org/index.php/Testing_for_HTTP_Splitting/Smuggling_(OTG-INPVAL-016)
+#
+SecRule REQUEST_FILENAME "@rx [\n\r]" \
+    "id:921190,\
+    phase:1,\
+    block,\
+    t:none,t:urlDecodeUni,\
+    msg:'HTTP Splitting (CR/LF in request filename detected)',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'OWASP_CRS/WEB_ATTACK/HTTP_SPLITTING',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.2.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:921013,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:921014,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"

--- a/util/regression-tests/tests/REQUEST-921-PROTOCOL-ATTACK/921190.yaml
+++ b/util/regression-tests/tests/REQUEST-921-PROTOCOL-ATTACK/921190.yaml
@@ -1,0 +1,63 @@
+---
+  meta:
+    author: "Andrea Menin (theMiddle)"
+    description: "HTTP Splitting"
+    enabled: true
+    name: 921190.yaml
+  tests:
+  -
+    test_title: 921190-1
+    desc: "New line char in request filename (1)"
+    stages:
+    - stage:
+        input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "ModSecurity CRS 3 Tests"
+          port: 80
+          uri: "/foo%0Abar"
+        output:
+          log_contains: id "921190"
+  -
+    test_title: 921190-2
+    desc: "New line char in request filename (2)"
+    stages:
+    - stage:
+        input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "ModSecurity CRS 3 Tests"
+          port: 80
+          uri: "/foo%0abar"
+        output:
+          log_contains: id "921190"
+  -
+    test_title: 921190-3
+    desc: "FastCGI variable injection: Nginx + PHP-FPM (CVE-2019-11043)"
+    stages:
+    - stage:
+        input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "ModSecurity CRS 3 Tests"
+          port: 80
+          uri: "/index.php/PHP%0Ainfo.php?QQQ"
+        output:
+          log_contains: id "921190"
+  -
+    test_title: 921190-4
+    desc: "PHP Settings injection: Nginx + PHP-FPM (CVE-2019-11043)"
+    stages:
+    - stage:
+        input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "ModSecurity CRS 3 Tests"
+          port: 80
+          uri: "/index.php/PHP_VALUE%0Asession.auto_start=1;;;?QQQ"
+        output:
+          log_contains: id "921190"


### PR DESCRIPTION
Working on a rule able to intercept an exploit against CVE-2019-11043, this new rule aims to block any CR/LF in the `REQUEST_FILENAME` variable.

I've chosen "HTTP Splitting" as the description because it had seemed to me the right categorization for this kind of attack. What do you think about it?

**Regression test:**
```
util/regression-tests/CRS_Tests.py::test_crs[ruleset555-921190.yaml -- 921190-1] PASSED
util/regression-tests/CRS_Tests.py::test_crs[ruleset556-921190.yaml -- 921190-2] PASSED
util/regression-tests/CRS_Tests.py::test_crs[ruleset557-921190.yaml -- 921190-3] PASSED
util/regression-tests/CRS_Tests.py::test_crs[ruleset558-921190.yaml -- 921190-4] PASSED
```

**Reference:**
- https://www.owasp.org/index.php/Testing_for_HTTP_Splitting/Smuggling_(OTG-INPVAL-016)
- https://github.com/yandex/gixy/blob/master/docs/en/plugins/httpsplitting.md
- https://github.com/neex/phuip-fpizdam