### PR TITLE
921140: remove unnecessary transformation

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -125,7 +125,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     phase:2,\
     block,\
     capture,\
-    t:none,t:htmlEntityDecode,t:lowercase,\
+    t:none,t:htmlEntityDecode,\
     msg:'HTTP Header Injection Attack via headers',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\


### PR DESCRIPTION
This PR removes `t:lowercase` from 921140.