### PR TITLE
Rule: 920480. Make rx recognize charset with quotes

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -949,7 +949,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
 #
 # Restrict charset parameter within the content-type header
 #
-SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*\"?\'?([^;\"\s]+)" \
+SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*\"?\'?([^;\"\'\s]+)" \
     "id:920480,\
     phase:1,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -949,7 +949,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
 #
 # Restrict charset parameter within the content-type header
 #
-SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*([^;\s]+)" \
+SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*\"*\'*([^;\"\'\s]+)" \
     "id:920480,\
     phase:1,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -949,7 +949,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
 #
 # Restrict charset parameter within the content-type header
 #
-SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*[\"\']?([^;\"\'\s]+)" \
+SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*[\"']?([^;\"'\s]+)" \
     "id:920480,\
     phase:1,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -949,7 +949,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
 #
 # Restrict charset parameter within the content-type header
 #
-SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*\"?\'?([^;\"\'\s]+)" \
+SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*[\"\']?([^;\"\'\s]+)" \
     "id:920480,\
     phase:1,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -949,7 +949,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
 #
 # Restrict charset parameter within the content-type header
 #
-SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*\"*\'*([^;\"\'\s]+)" \
+SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*\"?\'?([^;\"\s]+)" \
     "id:920480,\
     phase:1,\
     block,\

--- a/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920480.yaml
+++ b/util/regression-tests/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920480.yaml
@@ -192,3 +192,45 @@
     #           data: "test=value"
     #         output:
     #           log_contains: "id \"920480\""
+    - test_title: 920480-14
+      stages:
+        - stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "POST"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "application/x-www-form-urlencoded; charset=\"utf-8\"" # random other IBM charset
+              data: "test=value"
+            output:
+              no_log_contains: "id \"920480\""
+    - test_title: 920480-15
+      stages:
+        - stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "POST"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "application/x-www-form-urlencoded; charset='utf-8'" # random other IBM charset
+              data: "test=value"
+            output:
+              no_log_contains: "id \"920480\""
+    - test_title: 920480-16
+      stages:
+        - stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "POST"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "application/x-www-form-urlencoded; charset=\"garbage\"" # random other IBM charset
+              data: "test=value"
+            output:
+              log_contains: "id \"920480\""


### PR DESCRIPTION
Make rule ID: 920480 recognize not only Content-Type: charset=utf-8 but also charset put in single or double quotes:
Content-Type: charset="utf-8"
Content-Type: charset='utf-8'