### PR TITLE
Fix paranoia-level log description

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -163,7 +163,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #   likely produce a very high number of FPs which have to be
 #   treated before the site can go productive.
 #
-# Rules in paranoia level 2 or higher will log their PL to the audit log;
+# All rules will log their PL to the audit log;
 # example: [tag "paranoia-level/2"]. This allows you to deduct from the
 # audit log how the WAF behavior is affected by paranoia level.
 #


### PR DESCRIPTION
Since we set a tag for PL1 too, this PR changes the description in crs-setup.conf.example.


> ~Rules in paranoia level 2 or higher~ All rules will log their PL to the audit log;
> example: [tag "paranoia-level/2"]. This allows you to deduct from the
> audit log how the WAF behavior is affected by paranoia level.
