### PR TITLE
XenForo: exclude xf_session

### DIFF
--- a/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
@@ -397,6 +397,7 @@ SecAction \
     ctl:ruleRemoveTargetById=942150;REQUEST_COOKIES:xf_emoji_usage,\
     ctl:ruleRemoveTargetById=942410;REQUEST_COOKIES:xf_emoji_usage,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;REQUEST_COOKIES:xf_ls,\
+    ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:xf_session,\
     ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:xf_user"
 
 #


### PR DESCRIPTION
Fixes false positives in `xf_session` cookie.