### PR TITLE
WordPress: also exclude posts/pages endpoint in subdirectories

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -89,7 +89,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-comments-post.php" \
 #
 
 # Gutenberg
-SecRule REQUEST_FILENAME "@rx ^/wp-json/wp/v[0-9]+/(?:posts|pages)" \
+SecRule REQUEST_FILENAME "@rx /wp\-json/wp/v[0-9]+/(?:posts|pages)" \
     "id:9002140,\
     phase:1,\
     pass,\

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -89,7 +89,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-comments-post.php" \
 #
 
 # Gutenberg
-SecRule REQUEST_FILENAME "@rx /wp\-json/wp/v[0-9]+/(?:posts|pages)" \
+SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/(?:posts|pages)" \
     "id:9002140,\
     phase:1,\
     pass,\


### PR DESCRIPTION
Also exclude Gutenberg when WordPress is running in a subdirectory (e.g. /blog/wp-json/wp/v2/posts)