### PR TITLE
Update rx 942450

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1321,7 +1321,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 #
 # -=[ SQL Hex Evasion Methods ]=-
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:\A|[^\d])0x[a-f\d]{3,})" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:\b[^\d]?0x[a-f\d]{3,})" \
     "id:942450,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1321,7 +1321,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 #
 # -=[ SQL Hex Evasion Methods ]=-
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:\b[^\d]?0x[a-f\d]{3,})" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:\b0x[a-f\d]{3,})" \
     "id:942450,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942450.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942450.yaml
@@ -21,3 +21,19 @@
           version: HTTP/1.0
         output:
           log_contains: id "942450"
+  -
+    test_title: 942450-2
+    desc: "SQL Hex Encoding negative"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: POST
+          port: 80
+          data: "var=foo0xf00"
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "942450"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942450.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942450.yaml
@@ -1,6 +1,6 @@
 ---
   meta:
-    author: "Christian S.J. Peron"
+    author: "William Woodson"
     description: None
     enabled: true
     name: 942450.yaml
@@ -13,27 +13,80 @@
       stage:
         input:
           dest_addr: 127.0.0.1
+          port: 80
           headers:
             Host: localhost
           method: POST
-          port: 80
-          data: "var=%5cA0xf00dsdfdsa"
+          uri: "/"
+          data: "var=%5c0xf00dsdfdsa"
           version: HTTP/1.0
         output:
           log_contains: id "942450"
   -
     test_title: 942450-2
-    desc: "SQL Hex Encoding negative"
+    desc: "SQL Hex Encoding"
     stages:
     -
       stage:
         input:
           dest_addr: 127.0.0.1
+          port: 80
           headers:
             Host: localhost
           method: POST
+          uri: "/"
+          data: "var=concat%280x223e3c62723e%2Cversion%28%29%2C0x3c696d67207372633d22%29"
+          version: HTTP/1.0
+        output:
+          log_contains: id "942450"
+  -
+    test_title: 942450-3
+    desc: "SQL Hex Encoding"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
           port: 80
-          data: "var=foo0xf00"
+          headers:
+            Host: localhost
+          method: POST
+          uri: "/"
+          data: "var=select%200x616263"
+          version: HTTP/1.0
+        output:
+          log_contains: id "942450"
+  -
+    test_title: 942450-4
+    desc: "SQL Hex Encoding - negative"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          port: 80
+          headers:
+            Host: localhost
+          method: POST
+          uri: "/"
+          data: "var=IHRlc3Q0xAcF"
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "942450"
+  -
+    test_title: 942450-5
+    desc: "SQL Hex Encoding - negative"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          port: 80
+          headers:
+            Host: localhost
+          method: POST
+          uri: "/"
+          data: "var=9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08"
           version: HTTP/1.0
         output:
           no_log_contains: id "942450"


### PR DESCRIPTION
Update regexp in 942450 to reduce false positives. This is essentially the change to require `\b` before the potential hex string mentioned in https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/833.