### PR TITLE
RE2 compatibility for 920120

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -78,7 +78,22 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
 # These rules check for the existence of the ' " ; = meta-characters in
 # either the file or file name variables.
 # HTML entities may lead to false positives, why they are allowed on PL1.
-# Negative look behind assertions allow frequently used entities &_;
+# Frequently used HTML entities such as &auml; are allowed.
+#
+# To be compatible with non-PCRE regex engines, negative lookbehinds are
+# avoided. Instead the approach described here is used:
+#     http://allanrbo.blogspot.com/2020/01/alternative-to-negative-lookbehinds-in.html
+# with the parameters:
+#     negativePrefixes = [
+#         "&[aAoOuUyY]uml",
+#         "&[aAeEiIoOuU]circ",
+#         "&[eEiIoOuUyY]acute",
+#         "&[aAeEiIoOuU]grave",
+#         "&[cC]cedil",
+#         "&[aAnNoO]tilde",
+#         "&amp",
+#         "&apos",
+#     ]
 #
 # -=[ Targets, characters and html entities ]=-
 #
@@ -90,13 +105,11 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
 # 920121: PL2 : FILES_NAMES, FILES
 #                ['\";=] : ' " ; = meta-characters
 #
-# Not supported by re2 (?<!re).
-#
 # -=[ References ]=-
 # https://www.owasp.org/index.php/ModSecurity_CRS_RuleID-960000
 # http://www.ietf.org/rfc/rfc2183.txt
 #
-SecRule FILES_NAMES|FILES "@rx (?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:[eEiIoOuUyY]acute)|&(?:[aAeEiIoOuU]grave)|&(?:[cC]cedil)|&(?:[aAnNoO]tilde)|&(?:amp)|&(?:apos));|['\"=]" \
+SecRule FILES_NAMES|FILES "@rx (?:(?:^|[^lceps])|(?:^|[^mi])l|(?:^|[^r])c|(?:^|[^tvd])e|(?:^|[^m])p|(?:^|[^o])s|(?:^|[^u])ml|(?:^|[^i])rc|(?:^|[^u])te|(?:^|[^a])ve|(?:^|[^d])il|(?:^|[^l])de|(?:^|[^a])mp|(?:^|[^p])os|(?:^|[^aAoOuUyY])uml|(?:^|[^c])irc|(?:^|[^c])ute|(?:^|[^r])ave|(?:^|[^e])dil|(?:^|[^i])lde|(?:^|[^&])amp|(?:^|[^a])pos|(?:^|[^&])[aAoOuUyY]uml|(?:^|[^aAeEiIoOuU])circ|(?:^|[^a])cute|(?:^|[^g])rave|(?:^|[^c])edil|(?:^|[^t])ilde|(?:^|[^&])apos|(?:^|[^&])[aAeEiIoOuU]circ|(?:^|[^eEiIoOuUyY])acute|(?:^|[^aAeEiIoOuU])grave|(?:^|[^cC])cedil|(?:^|[^aAnNoO])tilde|(?:^|[^&])[eEiIoOuUyY]acute|(?:^|[^&])[aAeEiIoOuU]grave|(?:^|[^&])[cC]cedil|(?:^|[^&])[aAnNoO]tilde);|['\"=]" \
     "id:920120,\
     phase:2,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -81,19 +81,9 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
 # Frequently used HTML entities such as &auml; are allowed.
 #
 # To be compatible with non-PCRE regex engines, negative lookbehinds are
-# avoided. Instead the approach described here is used:
-#     http://allanrbo.blogspot.com/2020/01/alternative-to-negative-lookbehinds-in.html
-# with the parameters:
-#     negativePrefixes = [
-#         "&[aAoOuUyY]uml",
-#         "&[aAeEiIoOuU]circ",
-#         "&[eEiIoOuUyY]acute",
-#         "&[aAeEiIoOuU]grave",
-#         "&[cC]cedil",
-#         "&[aAnNoO]tilde",
-#         "&amp",
-#         "&apos",
-#     ]
+# avoided. Instead the script in util/regexp-negativelookbehind was used to
+# generate an alternative equivalent regex:
+#     ./negativelookbehind.py negativelookbehind-920120.data
 #
 # -=[ Targets, characters and html entities ]=-
 #

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920120.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920120.yaml
@@ -126,7 +126,7 @@
             uri: /
             data:
             - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="fi''le"; filename="test"'
+            - "Content-Disposition: form-data; name=\"fi'le\"; filename=\"test\""
             - 'Content-Type: application/octet-stream'
             - ''
             - 'helloworld'

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920120.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920120.yaml
@@ -109,3 +109,459 @@
             - '-----------------------------265001916915724--'
           output:
             log_contains: id "920120"
+    -
+      test_title: 920120-4
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="fi''le"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-5
+      desc: Attempted multipart/form-data bypass (920120). Negative test.
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="file"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            no_log_contains: id "920120"
+    -
+      test_title: 920120-6
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name=";zzzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-7
+      desc: Attempted multipart/form-data bypass (920120). Negative test.
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="zzz&amp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            no_log_contains: id "920120"
+    -
+      test_title: 920120-8
+      desc: Attempted multipart/form-data bypass (920120). Negative test.
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="zzz&Auml;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            no_log_contains: id "920120"
+    -
+      test_title: 920120-9
+      desc: Attempted multipart/form-data bypass (920120). Negative test.
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="zzz&auml;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            no_log_contains: id "920120"
+    -
+      test_title: 920120-10
+      desc: Attempted multipart/form-data bypass (920120). Negative test.
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="&amp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            no_log_contains: id "920120"
+    -
+      test_title: 920120-11
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="amp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-12
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="mp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-13
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="p;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-14
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="Zamp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-15
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="Zmp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-16
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="Zp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-17
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="Z;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-18
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="ZZZamp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-19
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="ZZZmp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-20
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="ZZZp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-21
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="ZZZ;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-22
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="mZ;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920120.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920120.yaml
@@ -111,30 +111,6 @@
             log_contains: id "920120"
     -
       test_title: 920120-4
-      desc: Attempted multipart/form-data bypass (920120).
-      stages:
-      -
-        stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              User-Agent: "ModSecurity CRS 3 Tests"
-              Host: "localhost"
-              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
-            method: POST
-            port: 80
-            uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - "Content-Disposition: form-data; name=\"fi'le\"; filename=\"test\""
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
-          output:
-            log_contains: id "920120"
-    -
-      test_title: 920120-5
       desc: Attempted multipart/form-data bypass (920120). Negative test.
       stages:
       -
@@ -158,7 +134,7 @@
           output:
             no_log_contains: id "920120"
     -
-      test_title: 920120-6
+      test_title: 920120-5
       desc: Attempted multipart/form-data bypass (920120).
       stages:
       -
@@ -182,7 +158,7 @@
           output:
             log_contains: id "920120"
     -
-      test_title: 920120-7
+      test_title: 920120-6
       desc: Attempted multipart/form-data bypass (920120). Negative test.
       stages:
       -
@@ -206,7 +182,7 @@
           output:
             no_log_contains: id "920120"
     -
-      test_title: 920120-8
+      test_title: 920120-7
       desc: Attempted multipart/form-data bypass (920120). Negative test.
       stages:
       -
@@ -230,7 +206,7 @@
           output:
             no_log_contains: id "920120"
     -
-      test_title: 920120-9
+      test_title: 920120-8
       desc: Attempted multipart/form-data bypass (920120). Negative test.
       stages:
       -
@@ -254,7 +230,7 @@
           output:
             no_log_contains: id "920120"
     -
-      test_title: 920120-10
+      test_title: 920120-9
       desc: Attempted multipart/form-data bypass (920120). Negative test.
       stages:
       -
@@ -278,7 +254,7 @@
           output:
             no_log_contains: id "920120"
     -
-      test_title: 920120-11
+      test_title: 920120-10
       desc: Attempted multipart/form-data bypass (920120).
       stages:
       -
@@ -302,7 +278,7 @@
           output:
             log_contains: id "920120"
     -
-      test_title: 920120-12
+      test_title: 920120-11
       desc: Attempted multipart/form-data bypass (920120).
       stages:
       -
@@ -326,7 +302,7 @@
           output:
             log_contains: id "920120"
     -
-      test_title: 920120-13
+      test_title: 920120-12
       desc: Attempted multipart/form-data bypass (920120).
       stages:
       -
@@ -350,7 +326,7 @@
           output:
             log_contains: id "920120"
     -
-      test_title: 920120-14
+      test_title: 920120-13
       desc: Attempted multipart/form-data bypass (920120).
       stages:
       -
@@ -374,7 +350,7 @@
           output:
             log_contains: id "920120"
     -
-      test_title: 920120-15
+      test_title: 920120-14
       desc: Attempted multipart/form-data bypass (920120).
       stages:
       -
@@ -398,7 +374,7 @@
           output:
             log_contains: id "920120"
     -
-      test_title: 920120-16
+      test_title: 920120-15
       desc: Attempted multipart/form-data bypass (920120).
       stages:
       -
@@ -422,7 +398,7 @@
           output:
             log_contains: id "920120"
     -
-      test_title: 920120-17
+      test_title: 920120-16
       desc: Attempted multipart/form-data bypass (920120).
       stages:
       -
@@ -446,7 +422,7 @@
           output:
             log_contains: id "920120"
     -
-      test_title: 920120-18
+      test_title: 920120-17
       desc: Attempted multipart/form-data bypass (920120).
       stages:
       -
@@ -470,7 +446,7 @@
           output:
             log_contains: id "920120"
     -
-      test_title: 920120-19
+      test_title: 920120-18
       desc: Attempted multipart/form-data bypass (920120).
       stages:
       -
@@ -494,7 +470,7 @@
           output:
             log_contains: id "920120"
     -
-      test_title: 920120-20
+      test_title: 920120-19
       desc: Attempted multipart/form-data bypass (920120).
       stages:
       -
@@ -518,7 +494,7 @@
           output:
             log_contains: id "920120"
     -
-      test_title: 920120-21
+      test_title: 920120-20
       desc: Attempted multipart/form-data bypass (920120).
       stages:
       -
@@ -542,7 +518,7 @@
           output:
             log_contains: id "920120"
     -
-      test_title: 920120-22
+      test_title: 920120-21
       desc: Attempted multipart/form-data bypass (920120).
       stages:
       -

--- a/util/regexp-negativelookbehind/negativelookbehind-920120.data
+++ b/util/regexp-negativelookbehind/negativelookbehind-920120.data
@@ -1,0 +1,8 @@
+&[aAoOuUyY]uml
+&[aAeEiIoOuU]circ
+&[eEiIoOuUyY]acute
+&[aAeEiIoOuU]grave
+&[cC]cedil
+&[aAnNoO]tilde
+&amp
+&apos

--- a/util/regexp-negativelookbehind/negativelookbehind.py
+++ b/util/regexp-negativelookbehind/negativelookbehind.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+
+import fileinput
+
+#
+# This script generates regular expressions that behave like negative lookbehinds without using negative lookbehinds.
+# For example an alternative to "(?<!a[bB]c|1234)" would be "(?:(?:^|[^c4])|(?:^|[^bB])c|(?:^|[^3])4|(?:^|[^a])[bB]c|(?:^|[^2])34|(?:^|[^1])234)".
+# More explanation here: http://allanrbo.blogspot.com/2020/01/alternative-to-negative-lookbehinds-in.html
+#
+# Input (stdin or arg): a file where each line corresponds to an alternative-group in a negative lookbehind.
+#   Example to generate a regex equivalent to "(?<!a[bB]c|1234)":
+#     a[bB]c
+#     1234
+# Output: A regular expression corresponding to the negative lookbehind.
+#
+
+
+# Process lines from input file, or if not specified, standard input
+negativePrefixes = []
+for line in fileinput.input():
+    line = line.rstrip()
+    if line != "":
+      negativePrefixes.append(line)
+
+def removeDuplicateChars(s):
+  return "".join([c for i,c in enumerate(s) if c not in s[:i]])
+
+def removeChars(s, charsToRemove):
+  return "".join([c for i,c in enumerate(s) if c not in charsToRemove])
+
+# Split into arrays of strings. Each string is either a single char, or a char class.
+negativePrefixesSplit = []
+for np in negativePrefixes:
+  npSplit = []
+  curCc = ""
+  inCc = False
+  for c in np:
+    if c == "[":
+      inCc = True
+    elif c == "]":
+      npSplit.append(removeDuplicateChars(curCc))
+      curCc = ""
+      inCc = False
+    else:
+      if inCc:  
+        if c in "-\\":
+          raise "Only really simply char classes are currently supported. No ranges or escapes, sorry."
+        curCc += c
+      else:
+        npSplit.append(c)
+  negativePrefixesSplit.append(npSplit)
+
+allexprs = []
+
+class Expr():
+  pass
+
+suffixLength = 0
+while True:
+  suffixes = []
+  for np in negativePrefixesSplit:
+    if suffixLength < len(np):
+      suffixes.append(np[len(np)-suffixLength-1:])
+
+  if len(suffixes) == 0:
+    break
+
+  exprs = []
+  for suffix in suffixes:
+    curChar = suffix[0]
+    remainder = suffix[1:]
+    expr = Expr()
+    expr.curChar = curChar
+    expr.remainder = remainder
+    exprs.append(expr)
+
+  # Is the remainder a subset of any other suffixes remainders?
+  for i in range(len(exprs)):
+    e1 = exprs[i]
+    for j in range(len(exprs)):
+      e2 = exprs[j]
+      isSubset = True
+      for k in range(len(e1.remainder)):
+        if not set(e1.remainder[k]).issubset(set(e2.remainder[k])):
+          isSubset = False
+          break
+      if isSubset:
+        if e1.curChar == e2.curChar:
+          e1.remainder = e2.remainder
+          continue
+
+        e1.curChar += e2.curChar
+        e1.curChar = removeDuplicateChars(e1.curChar)
+        for k in range(len(e1.remainder)):
+          if len(set(e2.remainder[k]) - set(e1.remainder[k])) > 0:
+            charsInCommon = "".join(set(e2.remainder[k]) & set(e1.remainder[k]))
+            e2.remainder[k] = removeChars(e2.remainder[k], charsInCommon)
+
+  # Remove duplicate expressions
+  exprsFiltered = []
+  for i in range(len(exprs)):
+    e1 = exprs[i]
+    alreadyExists = False
+    for j in range(len(exprs)):
+      if i == j:
+        break
+
+      e2 = exprs[j]
+
+      sameC = set(e1.curChar) == set(e2.curChar)
+      sameR = True
+      for k in range(len(e1.remainder)):
+        if set(e1.remainder[k]) != set(e2.remainder[k]):
+          sameR = False
+          break
+      if sameC and sameR:
+        alreadyExists = True
+        break
+
+    if not alreadyExists:
+      exprsFiltered.append(e1)
+  
+  allexprs.extend(exprsFiltered)
+
+  suffixLength += 1
+  continue
+
+out = "(?:\n"
+for i in range(len(allexprs)):
+  e = allexprs[i]
+  out += ("(?:^|[^" + e.curChar + "])")
+  for c in e.remainder:
+    if len(c) > 1:
+      out += "[" + c + "]"
+    else:
+      out += c
+  if i != len(allexprs)-1:
+    out += "|"
+  out += "\n"
+out += ")"
+
+print("Human readable:")
+print(out)
+print()
+print("Single line:")
+print(out.replace("\n",""))
+
+
+
+


### PR DESCRIPTION
### Problem

Negative lookbehinds are not supported by many regex engines (RE2, Go's regexp, Hyperscan).

My motivation for avoiding this PCRE-specific construct is that I am working on an experimental WAF that uses CRS, but uses Hyperscan and Go's regexp package rather than PCRE. I'm hoping to be able to keep using vanilla CRS, so this is why I'm hoping to get this accepted in upstream. Others who are also doing similar experiments with non-PCRE regex engines will benefit too.

### Suggested rewrite

The goal of the original regex was to disallow semicolon, except if it was preceeded by some strings that make it a well known HTML entity, such as `&auml;`, `&acirc;`, etc.

The approach of my solution is to write alternatives for each possible prefix that is not `&[aAoOuUyY]uml;`, `&[aAeEiIoOuU]circ;`, etc.

I have described the approach in detail here, and posted a Python script I used to generate the final regex: http://allanrbo.blogspot.com/2020/01/alternative-to-negative-lookbehinds-in.html

This is a tough tradeoff in human readability of the rule. If anyone has any ideas for a more readable approach, I'd be very eager to hear.

One alternative approach I've explored but failed at, is to split the rule into multiple chained rules. The first rule in the chain could catch something like `(&[^;]+)?;`. The second rule in the chain could then be a negative check, something like `SecRule TX:1 "!@rx (&[aAoOuUyY]uml;|&[aAeEiIoOuU]circ|...)" ...`. Unfortunately this fails when the input has multiple semicolons. The first semicolon may be preceeded by `&auml`, thereby only evaluating the second chained rule for this TX:1, ignoring subsequent semicolons which may contain the attack.

### Testing

Ran all the FTW regression tests.

Manually tested via regex101.com:
```
file=.txt               shouldMatchTrue
fi=le                   shouldMatchTrue
fi'le                   shouldMatchTrue
file                    shouldMatchFalse
fi;le                   shouldMatchTrue
;zzzz                   shouldMatchTrue
zzz&amp;zzz             shouldMatchFalse
zzz&Auml;zzz            shouldMatchFalse
zzz&auml;zzz            shouldMatchFalse
&amp;zzz                shouldMatchFalse
amp;zzz                 shouldMatchTrue
mp;zzz                  shouldMatchTrue
p;zzz                   shouldMatchTrue
Zamp;zzz                shouldMatchTrue
Zmp;zzz                 shouldMatchTrue
Zp;zzz                  shouldMatchTrue
Z;zzz                   shouldMatchTrue
ZZZamp;zzz              shouldMatchTrue
ZZZmp;zzz               shouldMatchTrue
ZZZp;zzz                shouldMatchTrue
ZZZ;zzz                 shouldMatchTrue
mZ;zzz                  shouldMatchTrue
```

Additionally wrote a little Go program to test against a few different regex engines: https://gist.github.com/allanrbo/93fb64549151169ff3a8a107cce8ce1b