### PR TITLE
Extend sql having in rule 942230

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -218,7 +218,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\s()]case\s*?\(|\)\s*?like\s*?\(|having\s*?[^\s]+\s*?[^\w\s]|if\s?\([\d\w]\s*?[=<>~])" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\s()]case\s*?\(|\)\s*?like\s*?\(|select.*?having\s*?[^\s]+\s*?[^\w\s]|if\s?\([\d\w]\s*?[=<>~])" \
     "id:942230,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942230.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942230.yaml
@@ -1,6 +1,6 @@
 ---
   meta:
-    author: "Christian S.J. Peron"
+    author: "Christian S.J. Peron, Franziska Buehler"
     description: None
     enabled: true
     name: 942230.yaml
@@ -18,6 +18,150 @@
           method: GET
           port: 80
           uri: "/?var=%29%20like%20%28"
+          version: HTTP/1.0
+        output:
+          log_contains: id "942230"
+  -
+    test_title: 942230-2
+    desc: "conditional SQL injection attempts"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          uri: "/?var=%29like%28"
+          version: HTTP/1.0
+        output:
+          log_contains: id "942230"
+  -
+    test_title: 942230-3
+    desc: "conditional SQL injection attempts"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          uri: "/?var=I%20like%20you%21"
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "942230"
+  -
+    test_title: 942230-4
+    desc: "conditional SQL injection attempts"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          uri: "/?var=%20case%20%28"
+          version: HTTP/1.0
+        output:
+          log_contains: id "942230"
+  -
+    test_title: 942230-5
+    desc: "conditional SQL injection attempts"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          uri: "/?var=having%20pain%21"
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "942230"
+  -
+    test_title: 942230-6
+    desc: "conditional SQL injection attempts"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          uri: "/?var=SELECT%20x%20GROUP%20BY%20SOMETHING%20HAVING%20COUNT%28Id%29%20%3E%3D%209"
+          version: HTTP/1.0
+        output:
+          log_contains: id "942230"
+  -
+    test_title: 942230-7
+    desc: "conditional SQL injection attempts"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          uri: "/?var=SELECT%20%2A%20FROM%20%60movies%60%20GROUP%20BY%20%60category_id%60%2C%60year_released%60%20HAVING%20%60category_id%60%20%3D%208%3B"
+          version: HTTP/1.0
+        output:
+          log_contains: id "942230"
+  -
+    test_title: 942230-8
+    desc: "conditional SQL injection attempts"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          uri: "/?var=behaving%20badly%2F"
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "942230"
+  -
+    test_title: 942230-9
+    desc: "conditional SQL injection attempts"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          uri: "/?var=o.havingu%40gmail.com"
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "942230"
+  -
+    test_title: 942230-10
+    desc: "conditional SQL injection attempts"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          uri: "/?var=if%282%3D"
           version: HTTP/1.0
         output:
           log_contains: id "942230"


### PR DESCRIPTION
This PR solves issues  #1607 and #1598 and adds new regression tests.

A "having" SQL statement only makes sense in combination with a SELECT statement somewhere.

The whole new regex is:
`(?i:[\s()]case\s*?\(|\)\s*?like\s*?\(|select.*?having\s*?[^\s]+\s*?[^\w\s]|if\s?\([\d\w]\s*?[=<>~])`

The important part is `select.*?having\s*?[^\s]+\s*?[^\w\s]` (original part was `|having\s*?[^\s]+\s*?[^\w\s]` only)

I'm not quite sure about my `.*?` maybe there would be a better option. But we definitely solve the reported false positives. A word boundary with `\b` would not be sufficient.

For info:
We cover the `having` clause in 5 other rules too:
```
util/regexp-assemble/regexp-942190.data:[\"'`];?\s*?having\b\s*?[^\s]
util/regexp-assemble/regexp-942210.data:\/\w+;?\s+having\W
util/regexp-assemble/regexp-942260.data:[\"'`]\s*?and\s+[\s\w]+=\s*?\w+\s*?having\s+
util/regexp-assemble/regexp-942260.data:[\"'`]\s*?nand\s+[\s\w]+=\s*?\w+\s*?having\s+
util/regexp-assemble/regexp-942260.data:[\"'`]\s*?or\s+[\s\w]+=\s*?\w+\s*?having\s+
util/regexp-assemble/regexp-942260.data:[\"'`]\s*?xor\s+[\s\w]+=\s*?\w+\s*?having\s+
util/regexp-assemble/regexp-942260.data:[\"'`]\s*?xxor\s+[\s\w]+=\s*?\w+\s*?having\s+
util/regexp-assemble/regexp-942260.data:[\"'`]\s*?div\s+[\s\w]+=\s*?\w+\s*?having\s+
util/regexp-assemble/regexp-942260.data:[\"'`]\s*?like\s+[\s\w]+=\s*?\w+\s*?having\s+
util/regexp-assemble/regexp-942260.data:[\"'`]\s*?between\s+[\s\w]+=\s*?\w+\s*?having\s+
util/regexp-assemble/regexp-942260.data:[\"'`]\s*?not\s+[\s\w]+=\s*?\w+\s*?having\s+
util/regexp-assemble/regexp-942260.data:[\"'`]\s*?\|\|\s+[\s\w]+=\s*?\w+\s*?having\s+
util/regexp-assemble/regexp-942260.data:[\"'`]\s*?\&\&\s+[\s\w]+=\s*?\w+\s*?having\s+
util/regexp-assemble/regexp-942380.data:\b(?i:having)\b\s+\d{1,10}\s*?[=<>]
util/regexp-assemble/regexp-942380.data:\b(?i:having)\b\s+'[^=]{1,10}'\s*?[=<>]
util/regexp-assemble/regexp-942380.data:\bhaving\b ?\d{1,10} ?[=<>]+
util/regexp-assemble/regexp-942380.data:\bhaving\b ?[\'\"][^=]{1,10}[\'\" ?[=<>]+
util/regexp-assemble/regexp-942380.data:exists\s\b(?i:having)\b\s+\d{1,10}
util/regexp-assemble/regexp-942480.data:\bgroup\b.*?\bby\b.{1,100}?\bhaving\b
```


