### PR TITLE
Update REQUEST-920-PROTOCOL-ENFORCEMENT.conf

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -885,7 +885,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - text/plain; charset="UTF-8"
 # - multipart/form-data; boundary=----WebKitFormBoundary12345
 #
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:boundary|charset)\s?=\s?['\"\w.()+,/:=?-]+)?$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:boundary|charset|action)\s?=\s?['\"\w.()+,/:=?-]+){0,3}$" \
     "id:920470,\
     phase:1,\
     block,\


### PR DESCRIPTION
According to SOAP 1.2 specification, the optional 'action' parameter is allowed for 'Content-Type' header, see RFC3902:
https://www.ietf.org/rfc/rfc3902.txt

Also, the original regexp was invalid as it was allowing only one parameter to 'Content-Type' header (there were two possible parameters which can be set at once: charset and boundary [now they are three]).