### PR TITLE
Add Content-Type: multipart/mixed as allowed default

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -399,7 +399,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
+#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|multipart/mixed|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
 
 # Allowed HTTP versions.
 # Default: HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0
@@ -626,16 +626,16 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # There are two formats for the GeoIP database. ModSecurity v2 uses GeoLite (.dat files),
 # and ModSecurity v3 uses GeoLite2 (.mmdb files).
 #
-# If you use ModSecurity 3, MaxMind provides a binary for updating GeoLite2 files, 
+# If you use ModSecurity 3, MaxMind provides a binary for updating GeoLite2 files,
 # see https://github.com/maxmind/geoipupdate.
 #
 # Download the package for your OS, and read https://dev.maxmind.com/geoip/geoipupdate/
 # for configuration options.
-# 
+#
 # Warning: GeoLite (not GeoLite2) databases are considered legacy, and not being updated anymore.
 # See https://support.maxmind.com/geolite-legacy-discontinuation-notice/ for more info.
 #
-# Therefore, if you use ModSecurity v2, you need to regenerate updated .dat files 
+# Therefore, if you use ModSecurity v2, you need to regenerate updated .dat files
 # from CSV files first.
 #
 # You can achieve this using https://github.com/sherpya/geolite2legacy

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -168,7 +168,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
+    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|multipart/mixed|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
 
 # Default HTTP policy: allowed_request_content_type_charset (rule 900270)
 SecRule &TX:allowed_request_content_type_charset "@eq 0" \


### PR DESCRIPTION
Found a FP in my testing of the CRS rules with various API Providers thus far:

```
ModSecurity: Warning. Matched "Operator `Rx' with parameter `^application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss- (26 characters omitted)' against variable `TX:0' (Value: `multipart/mixed' ) [file "/usr/local/owasp-modsecurity-crs-3.2.0/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "897"] [id "920420"] [rev ""] [msg "Request content type is not allowed by policy"] [data "multipart/mixed; boundary=7wDtD2f36QXqDv9q435T-jeCQzxvGE2Z_LJ"] [severity "2"] [ver "OWASP_CRS/3.2.0"] [maturity "0"] [accuracy "0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "OWASP_CRS"] [tag "OWASP_CRS/POLICY/CONTENT_TYPE_NOT_ALLOWED"] [tag "WASCTC/WASC-20"] [tag "OWASP_TOP_10/A1"] [tag "OWASP_AppSensor/EE2"] [tag "PCI/12.1"] [hostname "10.131.21.152"] [uri "/api/prf/clm/cirrus/v1.0"] [unique_id "158170398784.305331"] [ref "o0,15v415,61"]
```

Not sure why multipart/mixed was excluded from the base allowed content-types, see RFC on it here:

https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html