### PR TITLE
Ignore check of CT header in POST reqest if protocol is HTTP/2

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -212,36 +212,34 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
 
 #
 # Require Content-Length or Transfer-Encoding to be provided with
-# every POST request.
+# every POST request if the protocol version is older than HTTP/2.
 #
 # -=[ Rule Logic ]=-
-# This chained rule checks if the request method is POST, if so,
-# it checks that a Content-Length or Transfer-Encoding headers are
-# also present.
+# This chained rule checks if the protocol is not HTTP/2, then checks
+# request method is POST, if so, it checks that a Content-Length or
+# Transfer-Encoding headers are also present.
 #
-SecRule REQUEST_METHOD "@rx ^POST$" \
+SecRule REQUEST_PROTOCOL "!@within http/2 http/2.0" \
     "id:920180,\
     phase:2,\
     block,\
-    t:none,\
-    msg:'POST without Content-Length or Transfer-Encoding headers',\
+    t:lowercase,\
+    msg:'POST without Content-Length or Transfer-Encoding headers.',\
     logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.2.0',\
     severity:'WARNING',\
     chain"
-    SecRule &REQUEST_HEADERS:Content-Length "@eq 0" \
-        "chain"
-        SecRule &REQUEST_HEADERS:Transfer-Encoding "@eq 0" \
-            "setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
-
+    SecRule REQUEST_METHOD "@rx ^POST$" "chain"
+        SecRule &REQUEST_HEADERS:Content-Length "@eq 0" "chain"
+            SecRule &REQUEST_HEADERS:Transfer-Encoding "@eq 0" \
+                "setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
 
 #
 # Range Header Check

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920180.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920180.yaml
@@ -65,3 +65,26 @@
             version: HTTP/1.0
           output:
             log_contains: id "920180"
+    -
+      test_title: 920180-4
+      desc: Ignore check of CT header if protocol is HTTP/2
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7
+              Accept-Language: en-us,en;q=0.5
+              Content-Type: application/x-www-form-urlencoded
+              Host: localhost
+              Keep-Alive: '300'
+              Proxy-Connection: keep-alive
+              User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
+            method: POST
+            port: 80
+            uri: /
+            version: HTTP/2.0
+          output:
+            no_log_contains: id "920180"


### PR DESCRIPTION
Fixes #1693.
