### PR TITLE
Fix FP in 941130 and rearrange regex with new regex-assemble file

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -126,7 +126,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 #
 # -=[ XSS Filters - Category 3 ]=-
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\S]((?:x(?:link:href|html|mlns)|!ENTITY.*?(?:SYSTEM|PUBLIC)|data:text\/html|formaction|\@import|base64)\b|pattern\b.*?=)" \
+# Regexp generated from util/regexp-assemble/regexp-941130.data using Regexp::Assemble.
+# To rebuild the regexp:
+#   cd util/regexp-assemble
+#   ./regexp-assemble.pl regexp-941130.data
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\S](?:!ENTITY.*?(?:PUBLIC|SYSTEM)|x(?:link:href|html|mlns)|data:text\/html|pattern\b.*?=|formaction|\@import|;base64)\b" \
     "id:941130,\
     phase:2,\
     block,\

--- a/util/regexp-assemble/regexp-941130.data
+++ b/util/regexp-assemble/regexp-941130.data
@@ -3,8 +3,8 @@
 (?i)[\s\S]xmlns\b
 (?i)[\s\S]!ENTITY.*?SYSTEM\b
 (?i)[\s\S]!ENTITY.*?PUBLIC\b
-(?i)[\s\S]data:text\/html\b
+(?i)[\s\S]data:text/html\b
 (?i)[\s\S]formaction\b
-(?i)[\s\S]\@import\b
+(?i)[\s\S]@import\b
 (?i)[\s\S];base64\b
 (?i)[\s\S]pattern\b.*?=\b

--- a/util/regexp-assemble/regexp-941130.data
+++ b/util/regexp-assemble/regexp-941130.data
@@ -1,0 +1,10 @@
+(?i)[\s\S]xlink:href\b
+(?i)[\s\S]xhtml\b
+(?i)[\s\S]xmlns\b
+(?i)[\s\S]!ENTITY.*?SYSTEM\b
+(?i)[\s\S]!ENTITY.*?PUBLIC\b
+(?i)[\s\S]data:text\/html\b
+(?i)[\s\S]formaction\b
+(?i)[\s\S]\@import\b
+(?i)[\s\S];base64\b
+(?i)[\s\S]pattern\b.*?=\b


### PR DESCRIPTION
This fixes #1582. 

This was done during the 4th CRS / ModSecurity Meetup in Bern (participants: @franbuehler, @theseion, @ZuGao, @srueg, @dune73 and Roger and Marc).

The fix is done on the fact that the base64 string is only useful as an exploit within inline encoding of payloads via base64 and that always starts with `;base64`. We have thus put a semicolon in front.
See for example:  https://www.bigfastblog.com/embed-base64-encoded-images-inline-in-html

Then we rearranged the slightly odd regex with the help of a new regexp-assemble data file.

![tmp](https://user-images.githubusercontent.com/618722/75376810-f5e3a480-58d0-11ea-8451-704a43668c04.jpeg)
