### PR TITLE
Fix typos found by codespell.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -206,7 +206,7 @@ Documentation:
  * Add uploaded file name check; refresh LFI / filename checks (Walter Hop)
  * Introduce critical sibling of 920340 in PL2 (Walter Hop)
  * Fix bypass caused by multiple spaces in RCE rules (Walter Hop)
- * Remove unneded regex capture groups (Federico G. Schwindt)
+ * Remove unneeded regex capture groups (Federico G. Schwindt)
  * Add built-in exceptions for CPanel (Christoph Hansen)
  * Add additional file restrictios for ws_ftp, DS_Store... (Jose Nazario)
  * Fix missing strings in 942410 (Franziska Bühler)
@@ -231,7 +231,7 @@ Documentation:
  * Fixup and small reorg of dokuwiki rule exclusion package (Christian Folini)
  * Make TravisCI tests fail if Apache can't load rules (Felipe Zipitría)
  * Add exclusion rules for Dokuwiki (Matt Bagley, Christian Folini)
- * Inital exclusions for NextCloud installs (Matt Bagley, Christian Folini)
+ * Initial exclusions for NextCloud installs (Matt Bagley, Christian Folini)
  * Added struts-pwn UA to list (Manuel Spartan)
  * Uses MULTIPART_MISSING_SEMICOLON instead of MULTIPART_SEMICOLON_MISSING (Felipe Zimmerle)
  * Add file upload checks (Manuel Spartan)
@@ -250,7 +250,7 @@ Documentation:
  * Syntax fix for setvar crs_exclusions_wordpress (Manuel Spartan)
  * Updated various contributors to developers (Christian Folini)
  * Revise SQL rules by disassembling them into their core protections (Franziska Bühler)
- * Add an exmaple payload to 920220 (coolt)
+ * Add an example payload to 920220 (coolt)
  * Add a missing regex to rule 942310 (Franziska Bühler)
  * Detect GET or HEAD with Transfer-Encoding header (Federico G. Schwindt)
  * Fix broken links in references (Pásztor Gábor)
@@ -269,7 +269,7 @@ Documentation:
  * Updating to reflect OWASP flagship status (Chaim Sanders)
  * Adding Docker support for CRS (Chaim Sanders)
  * Initial Travis deployment (Zack Allen, Walter Hop)
- * Inital commit of regression tests (Chaim Sanders, Walter Hop)
+ * Initial commit of regression tests (Chaim Sanders, Walter Hop)
  * Remove test for 921170 because it won't ever fire (Chaim Sanders, Walter Hop)
  * Update minor incorrectness in asp.net regex (Chaim Sanders, Walter Hop)
  * Add notification for builds against #modsecurity on freenode (Zack Allen, Walter Hop)
@@ -444,7 +444,7 @@ Bug Fixes:
 == Version 2.2.7 - 2012-12-19 ==
 
 Improvements:
-* Added JS Overrides file to identify successfull XSS probes
+* Added JS Overrides file to identify successful XSS probes
 * Added new XSS Detection Rules from Ashar Javed (http://twitter.com/soaj1664ashar)
   - http://jsfiddle.net/U9RmU/4/
 * Updated the SQLi Filters to add in Oracle specific functions
@@ -490,7 +490,7 @@ Security Fixes:
 Improvements:
 * Renamed main config file to modsecurity_crs_10_setup.conf
 * Updated the rule IDs to start from CRS reserved range: 900000
-* Updated rule formatting for readibility
+* Updated rule formatting for readability
 * Updated the CSRF rules to use UNIQUE_ID as the token source
 * Added the zap2modsec.pl script to the /util directory which converts
   OWASP ZAP Scanner XML data into ModSecurity Virtual Patches
@@ -558,7 +558,7 @@ Bug Fixes:
 Improvements:
 * Extensive SQL Injection signature updates as a result of the SQLi Challenge
   http://www.modsecurity.org/demo/challenge.html
-* Updated the SQL Error message detection in reponse bodies
+* Updated the SQL Error message detection in response bodies
 * Updated SQL Injection signatures to include more DB functions
 * Updated the WEAK SQL Injection signatures
 * Added tag AppSensor/RE8 to rule ID 960018
@@ -596,7 +596,7 @@ Improvements:
   http://blog.spiderlabs.com/2011/04/modsecurity-advanced-topic-of-the-week-integrating-content-security-policy-csp.html
 * Global collection in the 10 file now uses the Host Request Header as the collection key.
   This allows for per-site global collections.
-* Added new SpiderLabs Research (SLR) rules directory (slr_rules) for known vulnerabilties.
+* Added new SpiderLabs Research (SLR) rules directory (slr_rules) for known vulnerabilities.
   This includes both converted web rules from Emerging Threats (ET) and from SLR Team.
 * Added new SLR rule packs for known application vulns for WordPress, Joomla and phpBB
 * Added experimental rules for detecting Open Proxy Abuse
@@ -613,7 +613,7 @@ Bug Fixes:
 * Removed rule inversion (!) from rule ID 960902
 * Fixed false negative issue in Response Splitting Rule
 * Fixed false negative issue with @validateByteRange check
-* Updated the TARGETS lising for rule ID 950908
+* Updated the TARGETS listing for rule ID 950908
 * Updated TX data for REQBODY processing
 * Changed the pass action to block in the RFI rules in the 40 generic file
 * Updated RFI regex to catch IP address usage in hostname
@@ -671,7 +671,7 @@ Improvements:
 * Added Credit Card Usage Tracking/Leakage Prevention rule set
 * Added experimental CC Track/PAN Leakage Prevention rule set
 * Added an experimental_rules directory to hold new BETA rules
-* Moved the local exceptions conf file back into base_rules dirctory however
+* Moved the local exceptions conf file back into base_rules directory however
   it has a ".example" extension to prevent overwriting customized versions
   when upgrading
 * Separated out HTTP Parameter Pollution and Restricted Character Anomaly Detection rules to
@@ -736,7 +736,7 @@ Bug Fixes:
 Improvements:
 * Updated the PHPIDS filters
 * Updated the SQL Injection filters to detect boolean attacks (1<2, foo == bar, etc..)
-* Updated the SQL Injection fitlers to account for different quotes
+* Updated the SQL Injection filters to account for different quotes
 * Added UTF-8 encoding validation support to the modsecurity_crs_10_config.conf file
 * Added Rule ID 950109 to detect multiple URL encodings
 * Added two experimental rules to detect anomalous use of special characters
@@ -749,7 +749,7 @@ Bug Fixes:
   https://www.modsecurity.org/tracker/browse/CORERULES-55
 * Fixed the anomaly scoring in the modsecurity_crs_41_phpids_filters.conf file
   https://www.modsecurity.org/tracker/browse/CORERULES-54
-* Updated XSS rule id 958001 to improve the .cookie regex to reduce false postives
+* Updated XSS rule id 958001 to improve the .cookie regex to reduce false positives
   https://www.modsecurity.org/tracker/browse/CORERULES-29
 
 
@@ -1177,7 +1177,7 @@ New Events:
 ModSecurity does not support compressed content at the moment. Thus, the following rules have been added:
 * 960902 - Content-Encoding in request not supported
     Any incoming compressed request will be denied
-* 960903 - Content-Encoding in response not suppoted
+* 960903 - Content-Encoding in response not supported
     An outgoing compressed response will be logged to alert, but ONLY ONCE.
 
 False Positives Fixes:

--- a/KNOWN_BUGS
+++ b/KNOWN_BUGS
@@ -40,7 +40,7 @@ or the CRS Google Group at
   Request Body Processor should also be configured to support this MIME type. Within
   the ModSecurity project, commit 5e4e2af 
   (https://github.com/SpiderLabs/ModSecurity/commit/5e4e2af7a6f07854fee6ed36ef4a381d4e03960e) 
-  has been merged to support this endevour. However, if you are running a modified or
+  has been merged to support this endeavour. However, if you are running a modified or
   preexisting version of the modsecurity.conf provided by this repository, you may
   wish to upgrade rule '200000' accordingly. The rule now appears as follows:
 

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -745,7 +745,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # -- [[ Blocking Based on IP Reputation ]] ------------------------------------
 #
 # Blocking based on reputation is permanent in the CRS. Unlike other rules,
-# which look at the indvidual request, the blocking of IPs is based on
+# which look at the individual request, the blocking of IPs is based on
 # a persistent record in the IP collection, which remains active for a
 # certain amount of time.
 #

--- a/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
@@ -232,7 +232,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
 #   it has 'readdir' and lines that look like sql
 # 942430,942440:  "--- //[[@MAIL@|@NAME@]] @DATE@//"]" in ARGS:config[signature]
 # 951240,953110:  When the page reloads, it triggers
-#   postgress and php code disclosure rules.
+#   postgres and php code disclosure rules.
 
 SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     "id:9004380,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -281,7 +281,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)-(\d+)" \
 
 
 #
-# Broken/Malicous clients often have duplicate or conflicting headers
+# Broken/Malicious clients often have duplicate or conflicting headers
 # Automated programs and bots often do not obey the HTTP RFC
 #
 # -=[ Rule Logic ]=-
@@ -369,7 +369,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded
 
 
 #
-# Check UTF enconding
+# Check UTF encoding
 # We only want to apply this check if UTF-8 encoding is actually used by the site, otherwise
 # it will result in false positives.
 #

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -261,7 +261,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:921016,phase:2,pass,nolog,skipAf
 #
 #
 
-# -=[ HTTP Parameter Polution ]=-
+# -=[ HTTP Parameter Pollution ]=-
 #
 # [ Rule Logic ]
 # These rules look for multiple parameters with the same name.

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -342,7 +342,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # [ Unix shell expressions ]
 #
 # Detects the following patterns which are common in Unix shell scripts
-# and oneliners:
+# and one-liners:
 #
 # $(foo)    Command substitution
 # ${foo}    Parameter expansion

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -790,7 +790,7 @@ SecRule REQUEST_HEADERS:Referer "@detectXSS" \
 
 #
 # -=[ XSS Filters - Category 5 ]=-
-# HTML attribues - src, style and href
+# HTML attributes - src, style and href
 #
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b(?:s(?:tyle|rc)|href)\b[\s\S]*?=" \
     "id:941150,\

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -91,7 +91,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
         "setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-# Magic bytes detected and payload included possibly RCE vulnerable classess detected and process execution methods detected
+# Magic bytes detected and payload included possibly RCE vulnerable classes detected and process execution methods detected
 # anomaly score set to critical as all conditions indicate the request try to perform RCE.
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)" \
@@ -194,7 +194,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
-# Detecting possibe base64 text to match encoded magic bytes \xac\xed\x00\x05 with padding encoded in base64 strings are rO0ABQ KztAAU Cs7QAF
+# Detecting possible base64 text to match encoded magic bytes \xac\xed\x00\x05 with padding encoded in base64 strings are rO0ABQ KztAAU Cs7QAF
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@rx (?:rO0ABQ|KztAAU|Cs7QAF)" \
     "id:944210,\
@@ -276,7 +276,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:944016,phase:2,pass,nolog,skipAf
 #
 # -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
 #
-# Interesting keywords for possibly RCE on vulnerable classess and methods base64 encoded
+# Interesting keywords for possibly RCE on vulnerable classes and methods base64 encoded
 # Keywords = ['runtime', 'processbuilder', 'clonetransformer', 'forclosure', 'instantiatefactory', 'instantiatetransformer', 'invokertransformer', 'prototypeclonefactory', 'prototypeserializationfactory', 'whileclosure']
 #for item in keywords:
 #   pad='\x00'

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933131.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933131.yaml
@@ -1,7 +1,7 @@
 ---
   meta:
     author: csanders-git
-    description: Tests functionality of stricter sibiling 933131
+    description: Tests functionality of stricter sibling 933131
     enabled: true
     name: 933131.yaml
   tests:

--- a/util/crs2-renumbering/update.py
+++ b/util/crs2-renumbering/update.py
@@ -25,7 +25,7 @@ def main():
     args = parser.parse_args()
 
     if not os.path.isfile((args.fname).encode('utf8')):
-        sys.stderr.write("We were unable to find the file you were trying to upate the ID numbers \
+        sys.stderr.write("We were unable to find the file you were trying to update the ID numbers \
             in, please check your path\n")
         sys.exit(1)
 

--- a/util/virtual-patching/arachni2modsec.pl
+++ b/util/virtual-patching/arachni2modsec.pl
@@ -2,7 +2,7 @@
 
 #############################################
 # -=[ Virtual Patching Converter Script ]=- #
-#       Converts arachni XML Ouput          #
+#       Converts arachni XML Output          #
 #    https://github.com/Zapotek/arachni     #
 #                                           #
 #           arachni2modsec.pl               #
@@ -143,7 +143,7 @@ sub parseData
 
 	print URL_LIST "$current_vuln_url\n";
 
-	# Validate url (need seperate sub?)
+	# Validate url (need separate sub?)
 	print "Validating URL: $current_vuln_url\n";
 	if(is_uri(to_string($current_vuln_url))){
 		print "URL is well-formed\n";

--- a/util/virtual-patching/zap2modsec.pl
+++ b/util/virtual-patching/zap2modsec.pl
@@ -2,7 +2,7 @@
 
 #############################################
 # -=[ Virtual Patching Converter Script ]=- #
-#      Converts OWASP ZAP XML Ouput         #
+#      Converts OWASP ZAP XML Output         #
 #   https://code.google.com/p/zaproxy/      #
 #                                           #
 #             zap2modsec.pl                 #
@@ -143,7 +143,7 @@ sub parseData
 
 	print URL_LIST "$current_vuln_url\n";
 
-	# Validate url (need seperate sub?)
+	# Validate url (need separate sub?)
 	print "Validating URL: $current_vuln_url\n";
 	if(is_uri(to_string($current_vuln_url))){
 		print "URL is well-formed\n";


### PR DESCRIPTION
This pull request fixes typos found by codespell. These typos were brought up in issue #1664.

Codespell found more typos than these but the other ones might not be safe and warrant further consideration.

This was done during the 4th CRS / ModSecurity Meetup in Bern :-)