### PR TITLE
Remove MIME Attribute from application/soap+xml Rule 900220

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -399,7 +399,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
+#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
 
 # Allowed HTTP versions.
 # Default: HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0


### PR DESCRIPTION
The current logic only validates Mime Type (`application`) and Sub-Type (`soap`).

The Mime Attribute in `application/soap+xml` prevents the following Content-Types from matching:
`application/soap`
`application/soap+xml`

Whereas the value `application/soap` will allow both:
`application/soap`
`application/soap+xml`