### PR TITLE
Add Content-Type: multipart/related as allowed default

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -388,7 +388,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
 # Content-Types that a client is allowed to send in a request.
-# Default: application/x-www-form-urlencoded|multipart/form-data||multipart/related|\
+# Default: application/x-www-form-urlencoded|multipart/form-data|multipart/related|\
 # text/xml|application/xml|application/soap+xml|application/x-amf|application/json|\
 # application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain
 # Uncomment this rule to change the default.

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -388,10 +388,9 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
 # Content-Types that a client is allowed to send in a request.
-# Default: application/x-www-form-urlencoded|multipart/form-data|text/xml|\
-# application/xml|application/soap+xml|application/x-amf|application/json|\
-# application/octet-stream|application/csp-report|\
-# application/xss-auditor-report|text/plain
+# Default: application/x-www-form-urlencoded|multipart/form-data||multipart/related|\
+# text/xml|application/xml|application/soap+xml|application/x-amf|application/json|\
+# application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain
 # Uncomment this rule to change the default.
 #SecAction \
 # "id:900220,\
@@ -399,7 +398,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
+#  setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|multipart/related|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
 
 # Allowed HTTP versions.
 # Default: HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0
@@ -626,16 +625,16 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # There are two formats for the GeoIP database. ModSecurity v2 uses GeoLite (.dat files),
 # and ModSecurity v3 uses GeoLite2 (.mmdb files).
 #
-# If you use ModSecurity 3, MaxMind provides a binary for updating GeoLite2 files, 
+# If you use ModSecurity 3, MaxMind provides a binary for updating GeoLite2 files,
 # see https://github.com/maxmind/geoipupdate.
 #
 # Download the package for your OS, and read https://dev.maxmind.com/geoip/geoipupdate/
 # for configuration options.
-# 
+#
 # Warning: GeoLite (not GeoLite2) databases are considered legacy, and not being updated anymore.
 # See https://support.maxmind.com/geolite-legacy-discontinuation-notice/ for more info.
 #
-# Therefore, if you use ModSecurity v2, you need to regenerate updated .dat files 
+# Therefore, if you use ModSecurity v2, you need to regenerate updated .dat files
 # from CSV files first.
 #
 # You can achieve this using https://github.com/sherpya/geolite2legacy

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -168,7 +168,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
+    setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|multipart/related|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
 
 # Default HTTP policy: allowed_request_content_type_charset (rule 900270)
 SecRule &TX:allowed_request_content_type_charset "@eq 0" \


### PR DESCRIPTION
Add multipart/related, got hit with a Content-Type block today:

```
ModSecurity: Warning. Matched "Operator `Rx' with parameter `^[\w/.+-]+(?:\s?;\s?(?:boundary|charset)\s?=\s?['\"\w.()+,/:=?-]+)?$' against variable `REQUEST_HEADERS:Content-Type' (Value: `multipart/related; type="text/xml"; start="<rootpart@soapui.org>"; boundary="----=_Part_0_859212417. (14 characters omitted)' ) [file "/usr/local/owasp-modsecurity-crs-3.2.0/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "873"] [id "920470"] [rev ""] [msg "Illegal Content-Type header"] [data "multipart/related; type="text/xml"; start="<rootpart@soapui.org>"; boundary="----=_part_0_859212417.1584040458654""] [severity "2"] [ver "OWASP_CRS/3.2.0"] [maturity "0"] [accuracy "0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "OWASP_CRS"] [tag "OWASP_CRS/PROTOCOL_VIOLATION/CONTENT_TYPE"] [tag "WASCTC/WASC-20"] [tag "OWASP_TOP_10/A1"] [tag "OWASP_AppSensor/EE2"] [tag "PCI/12.1"] [hostname "xxxxx"] [uri "/api/dev/ext/cimdev/service/v1"] [unique_id "158404046346.696874"] [ref "v98,114t:lowercase"]
```

So I did what most do and googled a bit, seems multipart/form-data isn't appropriate for what these folks sent and multipart/related is a real non-deprecated thing? Any issues adding it?

https://stackoverflow.com/questions/39960417/whats-the-difference-between-multipart-related-and-multipart-form-data-and

https://tools.ietf.org/html/rfc2387