### PR TITLE
Make severities and scores consistent

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -61,7 +61,7 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
     tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.2.0',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
+    setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -247,7 +247,7 @@ SecRule REQUEST_PROTOCOL "!@within HTTP/2 HTTP/2.0" \
         SecRule &REQUEST_HEADERS:Content-Length "@eq 0" \
             "chain"
             SecRule &REQUEST_HEADERS:Transfer-Encoding "@eq 0" \
-                "setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
+                "setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 #
 # As per RFC7230 3.3.2: A sender MUST NOT send a Content-Length
@@ -273,7 +273,7 @@ SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
     chain"
     SecRule &REQUEST_HEADERS:Content-Length "!@eq 0" \
         "t:none,\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -517,7 +517,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #


### PR DESCRIPTION
In #610, we found some rules with inconsistent severity level versus scoring.

Reviewed these rules manually and updated the scores to the severity actions - For the affected rules, this seems consistent with surrounding rules and our policy.

Thanks to @airween for making the nice table!