### PR TITLE
Fix content type whitelist

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -918,7 +918,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - text/plain; charset="UTF-8"
 # - multipart/form-data; boundary=----WebKitFormBoundary12345
 #
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w\/.+-]+(?:\s?;\s?(?:action|boundary|charset|type|start(?:-info)?)\s?=\s?['\"\w.()+,/:=?<>@-]+)*$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundary|charset|type|start(?:-info)?)\s?=\s?['\"\w.()+,/:=?<>@-]+)*$" \
     "id:920470,\
     phase:1,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -918,7 +918,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - text/plain; charset="UTF-8"
 # - multipart/form-data; boundary=----WebKitFormBoundary12345
 #
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:boundary|charset)\s?=\s?['\"\w.()+,/:=?-]+)?$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w\/.+-]+(?:\s?;\s?(?:action|boundary|charset|type|start(?:-info)?)\s?=\s?['\"\w.()+,/:=?<>@-]+)*$" \
     "id:920470,\
     phase:1,\
     block,\

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
@@ -1,6 +1,6 @@
 ---
   meta:
-    author: "lifeforms"
+    author: "lifeforms, Franziska Bühler"
     enabled: true
     name: "920470.yaml"
     description: "Content-Type header format checks"
@@ -169,3 +169,32 @@
                   Content-Length: 0
             output:
               log_contains: "id \"920470\""
+    - test_title: 920470-13
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              method: POST
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'multipart/related; type="application/xop+xml"; boundary="uuid:a111aaa1-aa11-1a11-a11a-11a1111aa11a"; start="<root.message@cxf.apache.org>"; start-info="application/soap+xml'
+                  Content-Length: 0
+            output:
+              no_log_contains: "id \"920470\""
+    - test_title: 920470-14
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              method: POST
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'application/soap+xml; action="urn:hl7-org:v3:PRPA_IN201305UV02"; charset=UTF-8'
+                  Content-Length: 0
+            output:
+              no_log_contains: "id \"920470\""
+


### PR DESCRIPTION
Fix issue #1722 and expand content-type whitelisting. 

action, type, start and start-info are allowed too. And these "flags" can  appear several times.

I also added two regression tests that cover the new extensions and the false positives mentioned in the issue.