### PR TITLE
WordPress: exclude additional URL fields in profile editor

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -292,9 +292,14 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
             "t:none,\
             ctl:ruleRemoveTargetById=931130;ARGS:url,\
             ctl:ruleRemoveTargetById=931130;ARGS:facebook,\
-            ctl:ruleRemoveTargetById=931130;ARGS:googleplus,\
             ctl:ruleRemoveTargetById=931130;ARGS:instagram,\
             ctl:ruleRemoveTargetById=931130;ARGS:linkedin,\
+            ctl:ruleRemoveTargetById=931130;ARGS:myspace,\
+            ctl:ruleRemoveTargetById=931130;ARGS:pinterest,\
+            ctl:ruleRemoveTargetById=931130;ARGS:soundcloud,\
+            ctl:ruleRemoveTargetById=931130;ARGS:tumblr,\
+            ctl:ruleRemoveTargetById=931130;ARGS:youtube,\
+            ctl:ruleRemoveTargetById=931130;ARGS:wikipedia,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
@@ -313,6 +318,16 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-edit.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetById=931130;ARGS:url,\
+            ctl:ruleRemoveTargetById=931130;ARGS:url,\
+            ctl:ruleRemoveTargetById=931130;ARGS:facebook,\
+            ctl:ruleRemoveTargetById=931130;ARGS:instagram,\
+            ctl:ruleRemoveTargetById=931130;ARGS:linkedin,\
+            ctl:ruleRemoveTargetById=931130;ARGS:myspace,\
+            ctl:ruleRemoveTargetById=931130;ARGS:pinterest,\
+            ctl:ruleRemoveTargetById=931130;ARGS:soundcloud,\
+            ctl:ruleRemoveTargetById=931130;ARGS:tumblr,\
+            ctl:ruleRemoveTargetById=931130;ARGS:youtube,\
+            ctl:ruleRemoveTargetById=931130;ARGS:wikipedia,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"


### PR DESCRIPTION
Exclude some more profile fields from rule 931130 (RFI), and remove Google Plus which is no longer in WordPress.