### PR TITLE
XenForo: update exclusions

### DIFF
--- a/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
@@ -55,7 +55,7 @@ SecRule REQUEST_FILENAME "@endsWith /proxy.php" \
 #
 # attachment_hash_combined example:
 # {"type":"post","context":{"post_id":12345},"hash":"0123456789abcdef..."}
-SecRule REQUEST_FILENAME "@rx /(?:conversations|(?:conversations|forums|threads)/.*\.\d+)/draft$" \
+SecRule REQUEST_FILENAME "@rx /(?:conversations|(?:conversations|forums|threads)/.*)/draft$" \
     "id:9006110,\
     phase:2,\
     pass,\
@@ -129,6 +129,7 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations|threads)/.*\.\d+/multi-quote$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[9][value]"
 
 # Delete thread
+# POST /xf/threads/thread-title.12345/delete
 SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/delete$" \
     "id:9006150,\
     phase:2,\
@@ -137,9 +138,19 @@ SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/delete$" \
     nolog,\
     ctl:ruleRemoveTargetById=942130;ARGS:starter_alert_reason"
 
+# Feature thread
+# POST /xf/threads/thread-title.12345/feature-edit
+SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/feature-edit$" \
+    "id:9006155,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:feature[feature_excerpt]"
+
 # Inline moderate thread
 # POST /xf/inline-mod/
-SecRule REQUEST_FILENAME "@streq /inline-mod/" \
+SecRule REQUEST_FILENAME "@endsWith /inline-mod/" \
     "id:9006160,\
     phase:2,\
     pass,\
@@ -241,6 +252,16 @@ SecRule REQUEST_FILENAME "@endsWith /register/register" \
     nolog,\
     ctl:ruleRemoveTargetById=942130;ARGS,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:reg_key"
+
+# Confirm account
+# GET /xf/account-confirmation/name.12345/email?c=foo
+SecRule REQUEST_FILENAME "@rx /account-confirmation/.*\.\d+/email$" \
+    "id:9006315,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:c"
 
 # Edit account
 # POST /xf/account/account-details
@@ -399,6 +420,7 @@ SecAction \
     ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:xf_csrf,\
     ctl:ruleRemoveTargetById=942210;REQUEST_COOKIES:xf_csrf,\
     ctl:ruleRemoveTargetById=942440;REQUEST_COOKIES:xf_csrf,\
+    ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:xf_emoji_usage,\
     ctl:ruleRemoveTargetById=942150;REQUEST_COOKIES:xf_emoji_usage,\
     ctl:ruleRemoveTargetById=942410;REQUEST_COOKIES:xf_emoji_usage,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;REQUEST_COOKIES:xf_ls,\
@@ -509,9 +531,11 @@ SecRule REQUEST_URI "@rx /admin\.php\?options/update" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:options[boardInactiveMessage]"
 
-# Edit pages
+# Edit pages/templates
+# POST /xf/admin.php?pages/0/save
 # POST /xf/admin.php?pages/foo.12345/save
-SecRule REQUEST_URI "@rx /admin\.php\?pages/.*\.\d+/save" \
+# POST /xf/admin.php?templates/foo.1234/save
+SecRule REQUEST_URI "@rx /admin\.php\?(?:pages|templates)/.*/save" \
     "id:9006970,\
     phase:2,\
     pass,\


### PR DESCRIPTION
Running on live traffic produced some false positives, which are remedied with this update.

Added a few new endpoints, widened exclusions on some existing patterns, and fixed a bug in 9006160.