### PR TITLE
Make Content-Type case insensitive

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -948,7 +948,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     phase:2,\
     block,\
     capture,\
-    t:none,\
+    t:none,t:lowercase,\
     msg:'Request content type is not allowed by policy',\
     logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920420.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920420.yaml
@@ -218,4 +218,35 @@
               data: "test"
             output:
               no_log_contains: "id \"920420\""
-
+    -
+      test_title: 920420-10
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "HEAD"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "multipart/related"
+              data: "test"
+            output:
+              no_log_contains: "id \"920420\""
+    -
+      test_title: 920420-11
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "HEAD"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "Multipart/Related"
+              data: "test"
+            output:
+              no_log_contains: "id \"920420\""

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920420.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920420.yaml
@@ -1,6 +1,6 @@
 ---
   meta:
-    author: "csanders-git"
+    author: "csanders-git, Franziska Bühler"
     enabled: true
     name: "920420.yaml"
     description: "Description"


### PR DESCRIPTION
The CRS Content-Type check is case sensitive. But request headers should be case insensitive.
This PR adds `t:lowercase` to the rule 920420 that compares the sent Content-Type request header with a list of Content-Types defined in an initialization rule 900220.

This PR also adds a regression test for the new allowed Content-Type `multipart/related` from PR #1721 and a new regression test with a Content-Type starting with an uppercase letter.