### PR TITLE
Suppress rule 200002 when editing contacts in Nextcloud

### DIFF
--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -262,6 +262,17 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
     nolog,\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type}|text/vcard'"
 
+# Allow modifying contacts via the web interface
+SecRule REQUEST_METHOD "@streq PUT" \
+    "id:9003321,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
+        "t:none,\
+        ctl:ruleRemoveById=200002"
 
 # [ Calendar ]
 #


### PR DESCRIPTION
## Issue

Modifying contacts triggers an XML parsing error ([rule 200002 in modsecurity.conf](https://github.com/SpiderLabs/ModSecurity/blob/7e0bc2691727b8c75f74638cdc4d1c45a689a7b6/modsecurity.conf-recommended#L48-L54)) which can be whitelisted in [REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf](https://github.com/SpiderLabs/owasp-modsecurity-crs/blob/v3.3/dev/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf).

## Background

| Sofware     | Version |
| -------     | ------- |
| CRS         | 3.2.0   |
| ModSecurity | 3.0.4   |
| Nextcloud   | 18.0.3  |

## Reproduction

* Open [contacts app](https://apps.nextcloud.com/apps/contacts) in Nextcloud
* Select some contact
* Click on some contact detail (like phone number) to edit it
* Change the value
* "Exit" the contact detail field editing by clicking elsewhere

This will trigger a HTTP PUT request into `/remote.php/dav/addressbooks/users/<username>/contacts/<some-uuid>.vcf` that has `Content-Type: application/xml` and has the contact [vCard](https://en.wikipedia.org/wiki/VCard) (which of course isn't XML) in it's body.

## Fix

This PR disables 200002 with PUT requests into `addressbooks`.