### PR TITLE
Allow REPORT requests without Content-Type header in Nextcloud

### DIFF
--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -141,6 +141,19 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     ctl:ruleRemoveById=953100-953130,\
     ctl:ruleRemoveById=920440"
 
+# Allow REPORT requests without Content-Type header (at least the iOS app does this)
+
+SecRule REQUEST_METHOD "@streq REPORT" \
+    "id:9003121,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
+        "t:none,\
+        ctl:ruleRemoveById=920340"
+
 
 # [ Searchengine ]
 #


### PR DESCRIPTION
## Issue

When the file list in the iOS app is refreshed, it triggers [Missing Content-Type Header with Request Body](https://github.com/SpiderLabs/owasp-modsecurity-crs/blob/cf57fd53de06b87b90d2cc5d61d602df81b2dd70/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf#L673-L709) rule with a `REPORT` request to `/remote.php/dav/files/<username>`

## Background

| Sofware           | Version  |
| -------           | -------  |
| CRS               | 3.2.0    |
| ModSecurity       | 3.0.4    |
| Nextcloud         | 18.0.3   |
| Nextcloud iOS app | 2.25.9.2 |

## Fix

This PR disables rule 920340 with `REPORT` requests to `/remote.php/dav/files/`