### PR TITLE
Added 'ver' action with current version to all necessary rules (fix for #650)

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -58,6 +58,7 @@ SecRule &TX:crs_setup_version "@eq 0" \
     log,\
     auditlog,\
     msg:'ModSecurity Core Rule Set is deployed without configuration! Please copy the crs-setup.conf.example template to crs-setup.conf, and include the crs-setup.conf file in your webserver configuration before including the CRS rules. See the INSTALL file in the CRS directory for detailed instructions',\
+    ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL'"
 
 
@@ -75,6 +76,7 @@ SecRule &TX:inbound_anomaly_score_threshold "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.inbound_anomaly_score_threshold=5'"
 
 # Default Outbound Anomaly Threshold Level (rule 900110 in setup.conf)
@@ -83,6 +85,7 @@ SecRule &TX:outbound_anomaly_score_threshold "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.outbound_anomaly_score_threshold=4'"
 
 # Default Paranoia Level (rule 900000 in setup.conf)
@@ -91,6 +94,7 @@ SecRule &TX:paranoia_level "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.paranoia_level=1'"
 
 # Default Executing Paranoia Level (rule 900000 in setup.conf)
@@ -99,6 +103,7 @@ SecRule &TX:executing_paranoia_level "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.executing_paranoia_level=%{TX.PARANOIA_LEVEL}'"
 
 # Default Sampling Percentage (rule 900400 in setup.conf)
@@ -107,6 +112,7 @@ SecRule &TX:sampling_percentage "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.sampling_percentage=100'"
 
 # Default Anomaly Scores (rule 900100 in setup.conf)
@@ -115,6 +121,7 @@ SecRule &TX:critical_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.critical_anomaly_score=5'"
 
 SecRule &TX:error_anomaly_score "@eq 0" \
@@ -122,6 +129,7 @@ SecRule &TX:error_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.error_anomaly_score=4'"
 
 SecRule &TX:warning_anomaly_score "@eq 0" \
@@ -129,6 +137,7 @@ SecRule &TX:warning_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.warning_anomaly_score=3'"
 
 SecRule &TX:notice_anomaly_score "@eq 0" \
@@ -136,6 +145,7 @@ SecRule &TX:notice_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.notice_anomaly_score=2'"
 
 # Default do_reput_block
@@ -144,6 +154,7 @@ SecRule &TX:do_reput_block "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.do_reput_block=0'"
 
 # Default block duration
@@ -152,6 +163,7 @@ SecRule &TX:reput_block_duration "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.reput_block_duration=300'"
 
 # Default HTTP policy: allowed_methods (rule 900200)
@@ -160,6 +172,7 @@ SecRule &TX:allowed_methods "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
 # Default HTTP policy: allowed_request_content_type (rule 900220)
@@ -168,6 +181,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|multipart/related|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain'"
 
 # Default HTTP policy: allowed_request_content_type_charset (rule 900270)
@@ -176,6 +190,7 @@ SecRule &TX:allowed_request_content_type_charset "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.allowed_request_content_type_charset=utf-8|iso-8859-1|iso-8859-15|windows-1252'"
 
 # Default HTTP policy: allowed_http_versions (rule 900230)
@@ -184,6 +199,7 @@ SecRule &TX:allowed_http_versions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0'"
 
 # Default HTTP policy: restricted_extensions (rule 900240)
@@ -192,6 +208,7 @@ SecRule &TX:restricted_extensions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
 # Default HTTP policy: restricted_headers (rule 900250)
@@ -200,6 +217,7 @@ SecRule &TX:restricted_headers "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.restricted_headers=/proxy/ /lock-token/ /content-range/ /if/'"
 
 # Default HTTP policy: static_extensions (rule 900260)
@@ -208,6 +226,7 @@ SecRule &TX:static_extensions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.static_extensions=/.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/'"
 
 # Default enforcing of body processor URLENCODED
@@ -216,6 +235,7 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.enforce_bodyproc_urlencoded=0'"
 
 #
@@ -233,6 +253,7 @@ SecAction \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.anomaly_score=0',\
     setvar:'tx.anomaly_score_pl1=0',\
     setvar:'tx.anomaly_score_pl2=0',\
@@ -269,6 +290,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^.*$" \
     pass,\
     t:none,t:sha1,t:hexEncode,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.ua_hash=%{MATCHED_VAR}'"
 
 SecAction \
@@ -277,6 +299,7 @@ SecAction \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     initcol:global=global,\
     initcol:ip=%{remote_addr}_%{tx.ua_hash},\
     setvar:'tx.real_ip=%{remote_addr}'"
@@ -347,6 +370,7 @@ SecRule TX:sampling_percentage "@eq 100" \
     phase:1,\
     pass,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-SAMPLING"
 
 SecRule UNIQUE_ID "@rx ^." \
@@ -355,6 +379,7 @@ SecRule UNIQUE_ID "@rx ^." \
     pass,\
     t:sha1,t:hexEncode,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'TX.sampling_rnd100=%{MATCHED_VAR}'"
 
 SecRule DURATION "@rx (..)$" \
@@ -363,6 +388,7 @@ SecRule DURATION "@rx (..)$" \
     pass,\
     capture,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'TX.sampling_rnd100=%{TX.sampling_rnd100}%{TX.1}'"
 
 SecRule TX:sampling_rnd100 "@rx ^[a-f]*([0-9])[a-f]*([0-9])" \
@@ -371,6 +397,7 @@ SecRule TX:sampling_rnd100 "@rx ^[a-f]*([0-9])[a-f]*([0-9])" \
     pass,\
     capture,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'TX.sampling_rnd100=%{TX.1}%{TX.2}'"
 
 SecRule TX:sampling_rnd100 "@rx ^0([0-9])" \
@@ -379,6 +406,7 @@ SecRule TX:sampling_rnd100 "@rx ^0([0-9])" \
     pass,\
     capture,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'TX.sampling_rnd100=%{TX.1}'"
 
 
@@ -403,7 +431,8 @@ SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
     noauditlog,\
     msg:'Sampling: Disable the rule engine based on sampling_percentage \
 %{TX.sampling_percentage} and random number %{TX.sampling_rnd100}',\
-    ctl:ruleEngine=Off"
+    ctl:ruleEngine=Off,\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecMarker "END-SAMPLING"
 
@@ -420,4 +449,5 @@ SecRule TX:executing_paranoia_level "@lt %{tx.paranoia_level}" \
     status:500,\
     t:none,\
     log,\
-    msg:'Executing paranoia level configured is lower than the paranoia level itself. This is illegal. Blocking request. Aborting'"
+    msg:'Executing paranoia level configured is lower than the paranoia level itself. This is illegal. Blocking request. Aborting',\
+    ver:'OWASP_CRS/3.2.0'"

--- a/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
@@ -68,6 +68,7 @@ SecRule &TX:crs_exclusions_drupal|TX:crs_exclusions_drupal "@eq 0" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-DRUPAL-RULE-EXCLUSIONS"
 
 
@@ -104,7 +105,8 @@ SecAction "id:9001100,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetById=942450;REQUEST_COOKIES_NAMES,\
-    ctl:ruleRemoveTargetById=942450;REQUEST_COOKIES"
+    ctl:ruleRemoveTargetById=942450;REQUEST_COOKIES,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 #
@@ -118,7 +120,8 @@ SecRule REQUEST_FILENAME "@endsWith /core/install.php" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:account[pass][pass1],\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:account[pass][pass2]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:account[pass][pass2],\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@endsWith /user/login" \
     "id:9001112,\
@@ -126,7 +129,8 @@ SecRule REQUEST_FILENAME "@endsWith /user/login" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass,\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/people/create" \
     "id:9001114,\
@@ -134,7 +138,8 @@ SecRule REQUEST_FILENAME "@endsWith /admin/people/create" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass1],\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass2]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass2],\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@rx /user/[0-9]+/edit$" \
     "id:9001116,\
@@ -143,7 +148,8 @@ SecRule REQUEST_FILENAME "@rx /user/[0-9]+/edit$" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:current_pass,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass1],\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass2]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass2],\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 #
@@ -162,7 +168,8 @@ SecRule REQUEST_FILENAME "@contains /admin/config/" \
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveById=942430"
+    ctl:ruleRemoveById=942430,\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/people/accounts" \
     "id:9001124,\
@@ -178,7 +185,8 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/people/accounts" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_register_pending_approval_body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_status_activated_body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_status_blocked_body,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_status_canceled_body"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_status_canceled_body,\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/configuration/single/import" \
     "id:9001126,\
@@ -186,14 +194,16 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/development/configuration/sing
     pass,\
     nolog,\
     ctl:ruleRemoveById=920271,\
-    ctl:ruleRemoveById=942440"
+    ctl:ruleRemoveById=942440,\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     "id:9001128,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveById=942440"
+    ctl:ruleRemoveById=942440,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 #
@@ -209,7 +219,8 @@ SecRule REQUEST_FILENAME "@endsWith /contextual/render" \
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetById=942130;ARGS:ids[]"
+    ctl:ruleRemoveTargetById=942130;ARGS:ids[],\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 #
@@ -227,7 +238,8 @@ SecAction "id:9001160,\
     nolog,\
     ctl:ruleRemoveTargetById=942440;ARGS:form_build_id,\
     ctl:ruleRemoveTargetById=942450;ARGS:form_token,\
-    ctl:ruleRemoveTargetById=942450;ARGS:form_build_id"
+    ctl:ruleRemoveTargetById=942450;ARGS:form_build_id,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 #
@@ -243,7 +255,8 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/content/formats/manage/full_ht
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:editor[settings][toolbar][button_groups],\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:filters[filter_html][settings][allowed_html]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:filters[filter_html][settings][allowed_html],\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 #
@@ -261,6 +274,7 @@ SecRule REQUEST_METHOD "@streq POST" \
     t:none,\
     nolog,\
     noauditlog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule REQUEST_FILENAME "@rx /admin/content/assets/add/[a-z]+$" \
         "chain"
@@ -274,6 +288,7 @@ SecRule REQUEST_METHOD "@streq POST" \
     t:none,\
     nolog,\
     noauditlog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule REQUEST_FILENAME "@rx /admin/content/assets/manage/[0-9]+$" \
         "chain"
@@ -291,6 +306,7 @@ SecRule REQUEST_METHOD "@streq POST" \
     t:none,\
     nolog,\
     noauditlog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule REQUEST_FILENAME "@rx /file/ajax/field_asset_[a-z0-9_]+/[ua]nd/0/form-[a-z0-9A-Z_-]+$" \
         "chain"
@@ -317,7 +333,8 @@ SecRule REQUEST_FILENAME "@endsWith /node/add/article" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
-    ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id]"
+    ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id],\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@endsWith /node/add/page" \
     "id:9001202,\
@@ -325,7 +342,8 @@ SecRule REQUEST_FILENAME "@endsWith /node/add/page" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
-    ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id]"
+    ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id],\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@rx /node/[0-9]+/edit$" \
     "id:9001204,\
@@ -334,49 +352,56 @@ SecRule REQUEST_FILENAME "@rx /node/[0-9]+/edit$" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
     ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id],\
-    ctl:ruleRemoveTargetById=932110;ARGS:destination"
+    ctl:ruleRemoveTargetById=932110;ARGS:destination,\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@endsWith /block/add" \
     "id:9001206,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/structure/block/block-content/manage/basic" \
     "id:9001208,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@rx /editor/filter_xss/(?:full|basic)_html$" \
     "id:9001210,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:value"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:value,\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@rx /user/[0-9]+/contact$" \
     "id:9001212,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message[0][value]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message[0][value],\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     "id:9001214,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:maintenance_mode_message"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:maintenance_mode_message,\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/services/rss-publishing" \
     "id:9001216,\
     phase:2,\
     pass,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:feed_description"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:feed_description,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 SecMarker "END-DRUPAL-RULE-EXCLUSIONS"

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -22,6 +22,7 @@ SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-WORDPRESS"
 
 SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
@@ -30,6 +31,7 @@ SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-WORDPRESS"
 
 
@@ -49,7 +51,8 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pwd"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pwd,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Reset password
 SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
@@ -58,6 +61,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@streq resetpass" \
         "t:none,\
@@ -80,7 +84,8 @@ SecRule REQUEST_FILENAME "@endsWith /wp-comments-post.php" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetById=931130;ARGS:url"
+    ctl:ruleRemoveTargetById=931130;ARGS:url,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 #
@@ -96,7 +101,8 @@ SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/(?:posts|pages)" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:content,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.content"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.content,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Gutenberg via rest_route for sites without pretty permalinks
 SecRule REQUEST_FILENAME "@endsWith /index.php" \
@@ -105,6 +111,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule &ARGS:rest_route "@eq 1" \
         "t:none,\
@@ -133,6 +140,7 @@ SecRule ARGS:wp_customize "@streq on" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule &ARGS:action "@eq 0" \
         "t:none,\
@@ -153,6 +161,7 @@ SecRule ARGS:wp_customize "@streq on" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@rx ^(?:|customize_save|update-widget)$" \
         "t:none,\
@@ -192,7 +201,8 @@ SecRule REQUEST_FILENAME "@endsWith /wp-cron.php" \
     t:none,\
     nolog,\
     ctl:ruleRemoveById=920180,\
-    ctl:ruleRemoveById=920300"
+    ctl:ruleRemoveById=920300,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 #
@@ -207,6 +217,7 @@ SecRule REQUEST_COOKIES:_wp_session "@rx ^[0-9a-f]+\|\|\d+\|\|\d+$" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule &REQUEST_COOKIES:_wp_session "@eq 1" \
         "t:none,\
@@ -225,6 +236,7 @@ SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-WORDPRESS-ADMIN"
 
 SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
@@ -233,6 +245,7 @@ SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-WORDPRESS-ADMIN"
 
 
@@ -247,6 +260,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/setup-config.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:step "@streq 2" \
         "t:none,\
@@ -262,6 +276,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/install.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:step "@streq 2" \
         "t:none,\
@@ -284,6 +299,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@streq update" \
         "t:none,\
@@ -306,6 +322,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-edit.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@streq update" \
         "t:none,\
@@ -324,6 +341,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-new.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@streq createuser" \
         "t:none,\
@@ -363,7 +381,8 @@ SecAction \
     ctl:ruleRemoveTargetById=942130;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942200;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942260;ARGS:wp_http_referer,\
-    ctl:ruleRemoveTargetById=942431;ARGS:wp_http_referer"
+    ctl:ruleRemoveTargetById=942431;ARGS:wp_http_referer,\
+    ver:'OWASP_CRS/3.2.0'"
 
 #
 # [ Content editing ]
@@ -380,6 +399,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/post.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@rx ^(?:edit|editpost)$" \
         "t:none,\
@@ -399,6 +419,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@streq heartbeat" \
         "t:none,\
@@ -420,6 +441,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/nav-menus.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@streq update" \
         "t:none,\
@@ -444,6 +466,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@rx ^(?:save-widget|update-widget)$" \
         "t:none,\
@@ -498,6 +521,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@streq widgets-order" \
         "t:none,\
@@ -526,6 +550,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@streq sample-permalink" \
         "t:none,\
@@ -541,6 +566,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@streq add-menu-item" \
         "t:none,\
@@ -556,6 +582,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@streq send-attachment-to-editor" \
         "t:none,\
@@ -576,6 +603,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:option_page "@streq general" \
         "t:none,\
@@ -605,7 +633,8 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options-permalink.php" \
     ctl:ruleRemoveTargetById=920230;ARGS:permalink_structure,\
     ctl:ruleRemoveTargetById=920272;ARGS:permalink_structure,\
     ctl:ruleRemoveTargetById=942431;ARGS:permalink_structure,\
-    ctl:ruleRemoveTargetById=920272;REQUEST_BODY"
+    ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Comments blacklist and moderation list
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
@@ -614,6 +643,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:option_page "@streq discussion" \
         "t:none,\
@@ -636,7 +666,8 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:s"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:s,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 #
@@ -674,7 +705,8 @@ SecRule REQUEST_FILENAME "@rx /wp-admin/load-(?:scripts|styles)\.php$" \
     ctl:ruleRemoveTargetById=942360;ARGS:load[],\
     ctl:ruleRemoveTargetById=942430;ARGS:load[],\
     ctl:ruleRemoveTargetById=942431;ARGS:load[],\
-    ctl:ruleRemoveTargetById=942432;ARGS:load[]"
+    ctl:ruleRemoveTargetById=942432;ARGS:load[],\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 SecMarker "END-WORDPRESS-ADMIN"

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -43,6 +43,7 @@ SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-NEXTCLOUD"
 
 SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
@@ -51,6 +52,7 @@ SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-NEXTCLOUD"
 
 
@@ -71,7 +73,8 @@ SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
     ctl:ruleRemoveById=951000-951999,\
     ctl:ruleRemoveById=953100-953130,\
     ctl:ruleRemoveById=920420,\
-    ctl:ruleRemoveById=920440"
+    ctl:ruleRemoveById=920440,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Skip PUT parsing for invalid encoding / protocol violations in binary files.
 
@@ -81,6 +84,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
         "t:none,\
@@ -98,6 +102,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type}|text/vcard'"
 
 # Allow the data type 'application/octet-stream'
@@ -108,6 +113,7 @@ SecRule REQUEST_METHOD "@rx ^(?:PUT|MOVE)$" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule REQUEST_FILENAME "@rx /remote\.php/dav/(?:files|uploads)/" \
         "setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type}|application/octet-stream'"
@@ -120,6 +126,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule REQUEST_FILENAME "@rx (?:/public\.php/webdav/|/remote\.php/dav/uploads/)" \
         "ctl:ruleRemoveById=920340,\
@@ -139,7 +146,8 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     ctl:ruleRemoveById=930100-930110,\
     ctl:ruleRemoveById=951000-951999,\
     ctl:ruleRemoveById=953100-953130,\
-    ctl:ruleRemoveById=920440"
+    ctl:ruleRemoveById=920440,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 # [ Searchengine ]
@@ -154,7 +162,8 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
     nolog,\
     ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:query,\
     ctl:ruleRemoveTargetById=941000-942999;ARGS:query,\
-    ctl:ruleRemoveTargetById=932000-932999;ARGS:query"
+    ctl:ruleRemoveTargetById=932000-932999;ARGS:query,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 # [ DAV ]
@@ -176,6 +185,7 @@ SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT PATCH CHECKOUT COPY DELETE LOCK MERGE MKACTIVITY MKCOL MOVE PROPFIND PROPPATCH UNLOCK REPORT TRACE jsonp'"
 
 
@@ -189,6 +199,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
 
 
@@ -200,7 +211,8 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetById=932150;ARGS:file"
+    ctl:ruleRemoveTargetById=932150;ARGS:file,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Filepreview for trashbin
 
@@ -211,7 +223,8 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=932150;ARGS:file,\
-    ctl:ruleRemoveTargetById=942190;ARGS:file"
+    ctl:ruleRemoveTargetById=942190;ARGS:file,\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule REQUEST_FILENAME "@rx /index\.php/(?:apps/gallery/thumbnails|logout$)" \
     "id:9003160,\
@@ -219,7 +232,8 @@ SecRule REQUEST_FILENAME "@rx /index\.php/(?:apps/gallery/thumbnails|logout$)" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetById=941120;ARGS:requesttoken"
+    ctl:ruleRemoveTargetById=941120;ARGS:requesttoken,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 # [ Ownnote ]
@@ -230,7 +244,8 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/ownnote/" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveById=941150"
+    ctl:ruleRemoveById=941150,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 # [ Text Editor ]
@@ -247,7 +262,8 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
     ctl:ruleRemoveTargetById=921110-921160;ARGS:filecontents,\
     ctl:ruleRemoveTargetById=932150;ARGS:filename,\
     ctl:ruleRemoveTargetById=920370-920390;ARGS:filecontents,\
-    ctl:ruleRemoveTargetById=920370-920390;ARGS_COMBINED_SIZE"
+    ctl:ruleRemoveTargetById=920370-920390;ARGS_COMBINED_SIZE,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 # [ Address Book ]
@@ -260,6 +276,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type}|text/vcard'"
 
 
@@ -273,6 +290,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type}|text/calendar'"
 
 
@@ -287,7 +305,8 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveByTag=attack-injection-php"
+    ctl:ruleRemoveByTag=attack-injection-php,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 # [ Bookmarks ]
@@ -300,7 +319,8 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveById=931130"
+    ctl:ruleRemoveById=931130,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 #
@@ -318,7 +338,8 @@ SecRule REQUEST_FILENAME "@contains /index.php/login" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=941100;ARGS:requesttoken,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Reset password.
 
@@ -328,6 +349,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:action "@streq resetpass" \
         "t:none,\
@@ -347,7 +369,8 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:newuserpassword,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 SecMarker "END-NEXTCLOUD-ADMIN"

--- a/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
@@ -26,6 +26,7 @@ SecRule &TX:crs_exclusions_dokuwiki|TX:crs_exclusions_dokuwiki "@eq 0" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-DOKUWIKI"
 
 SecRule &TX:crs_exclusions_dokuwiki|TX:crs_exclusions_dokuwiki "@eq 0" \
@@ -34,6 +35,7 @@ SecRule &TX:crs_exclusions_dokuwiki|TX:crs_exclusions_dokuwiki "@eq 0" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-DOKUWIKI"
 
 
@@ -78,6 +80,7 @@ SecRule REQUEST_FILENAME "@rx (?:/doku.php|/lib/exe/ajax.php)$" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule REQUEST_METHOD "@streq POST" \
         "t:none,\
@@ -102,6 +105,7 @@ SecRule REQUEST_FILENAME "@endsWith /lib/exe/ajax.php" \
     t:none,\
     nolog,\
     noauditlog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule REQUEST_METHOD "@streq POST" \
         "t:none,\
@@ -120,6 +124,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:do "@streq index" \
         "t:none,\
@@ -143,6 +148,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:do "@streq login" \
         "t:none,\
@@ -163,6 +169,7 @@ SecRule ARGS:do "!@streq admin" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-DOKUWIKI-ADMIN"
 
 SecRule ARGS:do "!@streq admin" \
@@ -171,6 +178,7 @@ SecRule ARGS:do "!@streq admin" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-DOKUWIKI-ADMIN"
 
 
@@ -185,6 +193,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:do "@streq login" \
         "t:none,\
@@ -210,6 +219,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:page "@streq config" \
         "t:none,\
@@ -241,6 +251,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule ARGS:page "@streq config" \
         "t:none,\

--- a/rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf
@@ -18,6 +18,7 @@ SecRule &TX:crs_exclusions_cpanel|TX:crs_exclusions_cpanel "@eq 0" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-CPANEL"
 
 SecRule &TX:crs_exclusions_cpanel|TX:crs_exclusions_cpanel "@eq 0" \
@@ -26,6 +27,7 @@ SecRule &TX:crs_exclusions_cpanel|TX:crs_exclusions_cpanel "@eq 0" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-CPANEL"
 
 
@@ -50,6 +52,7 @@ SecRule REQUEST_LINE "@rx ^GET /whm-server-status(?:/|/\?auto)? HTTP/[12]\.[01]$
     tag:'language-multi',\
     tag:'platform-apache',\
     tag:'attack-generic',\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
         "t:none,\

--- a/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
@@ -17,6 +17,7 @@ SecRule &TX:crs_exclusions_xenforo|TX:crs_exclusions_xenforo "@eq 0" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-XENFORO"
 
 SecRule &TX:crs_exclusions_xenforo|TX:crs_exclusions_xenforo "@eq 0" \
@@ -25,6 +26,7 @@ SecRule &TX:crs_exclusions_xenforo|TX:crs_exclusions_xenforo "@eq 0" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-XENFORO"
 
 
@@ -45,7 +47,8 @@ SecRule REQUEST_FILENAME "@endsWith /proxy.php" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:image,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:link,\
     ctl:ruleRemoveTargetById=931130;ARGS:referrer,\
-    ctl:ruleRemoveTargetById=942230;ARGS:referrer"
+    ctl:ruleRemoveTargetById=942230;ARGS:referrer,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Store drafts for private message, forum post, thread reply
 # POST /xf/conversations/draft
@@ -68,7 +71,8 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations|(?:conversations|forums|threads)
     ctl:ruleRemoveTargetById=942200;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942260;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942340;ARGS:attachment_hash_combined,\
-    ctl:ruleRemoveTargetById=942370;ARGS:attachment_hash_combined"
+    ctl:ruleRemoveTargetById=942370;ARGS:attachment_hash_combined,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Send PM, edit post, create thread, reply to thread
 # POST /xf/conversations/add
@@ -94,7 +98,8 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations/add(?:-preview)?|conversations/m
     ctl:ruleRemoveTargetById=942200;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942260;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942340;ARGS:attachment_hash_combined,\
-    ctl:ruleRemoveTargetById=942370;ARGS:attachment_hash_combined"
+    ctl:ruleRemoveTargetById=942370;ARGS:attachment_hash_combined,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Quote
 # POST /xf/posts/12345/quote
@@ -104,7 +109,8 @@ SecRule REQUEST_FILENAME "@rx /posts/\d+/quote$" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:quoteHtml"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:quoteHtml,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Multi quote
 # POST /xf/conversations/convo-title.12345/multi-quote
@@ -126,7 +132,8 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations|threads)/.*\.\d+/multi-quote$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[6][value],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[7][value],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[8][value],\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[9][value]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[9][value],\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Delete thread
 SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/delete$" \
@@ -135,7 +142,8 @@ SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/delete$" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetById=942130;ARGS:starter_alert_reason"
+    ctl:ruleRemoveTargetById=942130;ARGS:starter_alert_reason,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Inline moderate thread
 # POST /xf/inline-mod/
@@ -146,7 +154,8 @@ SecRule REQUEST_FILENAME "@streq /inline-mod/" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:author_alert_reason,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Warn member
 # POST /xf/members/name.12345/warn
@@ -158,7 +167,8 @@ SecRule REQUEST_FILENAME "@rx /(?:members/.*\.\d+|posts/\d+)/warn$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:conversation_message,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:notes"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:notes,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Editor
 SecRule REQUEST_URI "@endsWith /index.php?editor/to-html" \
@@ -171,7 +181,8 @@ SecRule REQUEST_URI "@endsWith /index.php?editor/to-html" \
     ctl:ruleRemoveTargetById=942200;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942260;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942340;ARGS:attachment_hash_combined,\
-    ctl:ruleRemoveTargetById=942370;ARGS:attachment_hash_combined"
+    ctl:ruleRemoveTargetById=942370;ARGS:attachment_hash_combined,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Editor
 SecRule REQUEST_URI "@endsWith /index.php?editor/to-bb-code" \
@@ -180,7 +191,8 @@ SecRule REQUEST_URI "@endsWith /index.php?editor/to-bb-code" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:html"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:html,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Post attachment
 # POST /xf/account/avatar
@@ -195,7 +207,8 @@ SecRule REQUEST_FILENAME "@rx /(?:account/avatar|attachments/upload)$" \
     ctl:ruleRemoveTargetById=942220;ARGS:flowChunkSize,\
     ctl:ruleRemoveTargetById=942440;ARGS:flowIdentifier,\
     ctl:ruleRemoveTargetById=942440;ARGS:flowFilename,\
-    ctl:ruleRemoveTargetById=942440;ARGS:flowRelativePath"
+    ctl:ruleRemoveTargetById=942440;ARGS:flowRelativePath,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Media
 # POST /xf/index.php?editor/media
@@ -206,7 +219,8 @@ SecRule REQUEST_URI "@endsWith /index.php?editor/media" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=931130;ARGS:url,\
-    ctl:ruleRemoveTargetById=942130;ARGS:url"
+    ctl:ruleRemoveTargetById=942130;ARGS:url,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Emoji
 # GET /xf/index.php?misc/find-emoji&q=(%0A%0A
@@ -216,7 +230,8 @@ SecRule REQUEST_URI "@rx /index\.php\?misc/find-emoji&q=" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetById=921151;ARGS:q"
+    ctl:ruleRemoveTargetById=921151;ARGS:q,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Login
 # POST /xf/login/login
@@ -226,7 +241,8 @@ SecRule REQUEST_FILENAME "@endsWith /login/login" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Register account
 # POST /xf/register/register
@@ -240,7 +256,8 @@ SecRule REQUEST_FILENAME "@endsWith /register/register" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=942130;ARGS,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:reg_key"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:reg_key,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Edit account
 # POST /xf/account/account-details
@@ -251,7 +268,8 @@ SecRule REQUEST_FILENAME "@endsWith /account/account-details" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=931130;ARGS:custom_fields[picture],\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:about_html"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:about_html,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Lost password
 # POST /xf/lost-password/user-name.12345/confirm?c=foo
@@ -261,7 +279,8 @@ SecRule REQUEST_FILENAME "@rx /lost-password/.*\.\d+/confirm$" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:c"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:c,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Set forum signature
 # POST /xf/account/signature
@@ -271,7 +290,8 @@ SecRule REQUEST_FILENAME "@endsWith /account/signature" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:signature_html"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:signature_html,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Search
 # POST /xf/search/search
@@ -285,7 +305,8 @@ SecRule REQUEST_FILENAME "@endsWith /search/search" \
     ctl:ruleRemoveTargetById=942200;ARGS:constraints,\
     ctl:ruleRemoveTargetById=942260;ARGS:constraints,\
     ctl:ruleRemoveTargetById=942340;ARGS:constraints,\
-    ctl:ruleRemoveTargetById=942370;ARGS:constraints"
+    ctl:ruleRemoveTargetById=942370;ARGS:constraints,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Search within thread
 # GET /xf/threads/foo.12345/page12?highlight=foo
@@ -295,7 +316,8 @@ SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/(?:page\d+)?$" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:highlight"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:highlight,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Search within search result
 # GET /xf/search/12345/?q=foo
@@ -305,7 +327,8 @@ SecRule REQUEST_FILENAME "@rx /search/\d+/$" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:q"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:q,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Contact form
 # POST /xf/misc/contact
@@ -316,7 +339,8 @@ SecRule REQUEST_FILENAME "@endsWith /misc/contact" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:subject"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:subject,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Report post
 # POST /xf/posts/12345/report
@@ -326,7 +350,8 @@ SecRule REQUEST_FILENAME "@rx /posts/\d+/report$" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Alternate thread view route
 # /xf/index.php?threads/title-having-some-sql.12345/
@@ -341,6 +366,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule REQUEST_METHOD "@streq GET" \
         "t:none,\
@@ -363,7 +389,8 @@ SecRule REQUEST_URI "@endsWith /index.php?dbtech-security/fingerprint" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:components[14][value],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:components[15][value],\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:components[16][value]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:components[16][value],\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Get location info
 SecRule REQUEST_FILENAME "@endsWith /misc/location-info" \
@@ -372,7 +399,8 @@ SecRule REQUEST_FILENAME "@endsWith /misc/location-info" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:location"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:location,\
+    ver:'OWASP_CRS/3.2.0'"
 
 #
 # -=[ XenForo Global Exclusions ]=-
@@ -403,7 +431,8 @@ SecAction \
     ctl:ruleRemoveTargetById=942410;REQUEST_COOKIES:xf_emoji_usage,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;REQUEST_COOKIES:xf_ls,\
     ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:xf_session,\
-    ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:xf_user"
+    ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:xf_user,\
+    ver:'OWASP_CRS/3.2.0'"
 
 #
 # -=[ XenForo Administration Back-End ]=-
@@ -417,6 +446,7 @@ SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-XENFORO-ADMIN"
 
 SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
@@ -425,6 +455,7 @@ SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-XENFORO-ADMIN"
 
 # Admin edit user
@@ -436,7 +467,8 @@ SecRule REQUEST_URI "@rx /admin\.php\?users/.*\.\d+/edit$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:profile[about],\
-    ctl:ruleRemoveTargetById=931130;ARGS:profile[website]"
+    ctl:ruleRemoveTargetById=931130;ARGS:profile[website],\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Admin save user
 # POST /xf/admin.php?users/the-user-name.12345/save
@@ -454,7 +486,8 @@ SecRule REQUEST_URI "@rx /admin\.php\?users/.*\.\d+/save$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:profile[signature],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:custom_fields[sexuality],\
     ctl:ruleRemoveTargetById=931130;ARGS:custom_fields[picture],\
-    ctl:ruleRemoveTargetById=931130;ARGS:profile[website]"
+    ctl:ruleRemoveTargetById=931130;ARGS:profile[website],\
+    ver:'OWASP_CRS/3.2.0'"
 
 
 # Admin edit forum notice
@@ -467,7 +500,8 @@ SecRule REQUEST_URI "@rx /admin\.php\?notices/(?:.*\.)?\d+/save$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:title"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:title,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Admin batch thread update
 # POST /xf/admin.php?threads/batch-update/action
@@ -481,7 +515,8 @@ SecRule REQUEST_URI "@rx /admin\.php\?(?:threads|users)/batch-update/action$" \
     ctl:ruleRemoveTargetById=942260;ARGS:criteria,\
     ctl:ruleRemoveTargetById=942330;ARGS:criteria,\
     ctl:ruleRemoveTargetById=942340;ARGS:criteria,\
-    ctl:ruleRemoveTargetById=942370;ARGS:criteria"
+    ctl:ruleRemoveTargetById=942370;ARGS:criteria,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Edit forum theme
 # POST /xf/admin.php?styles/title.1234/style-properties/group&group=basic
@@ -497,7 +532,8 @@ SecRule REQUEST_URI "@rx /admin\.php\?styles/" \
     ctl:ruleRemoveTargetById=942330;ARGS:json,\
     ctl:ruleRemoveTargetById=942340;ARGS:json,\
     ctl:ruleRemoveTargetById=942370;ARGS:json,\
-    ctl:ruleRemoveTargetById=942440;ARGS:json"
+    ctl:ruleRemoveTargetById=942440;ARGS:json,\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Set forum options
 # POST /xf/admin.php?options/update
@@ -507,7 +543,8 @@ SecRule REQUEST_URI "@rx /admin\.php\?options/update" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:options[boardInactiveMessage]"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:options[boardInactiveMessage],\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Edit pages
 # POST /xf/admin.php?pages/foo.12345/save
@@ -517,7 +554,8 @@ SecRule REQUEST_URI "@rx /admin\.php\?pages/.*\.\d+/save" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:template"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:template,\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecMarker "END-XENFORO-ADMIN"
 

--- a/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+++ b/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
@@ -23,6 +23,7 @@ SecRule REQUEST_LINE "@streq GET /" \
     tag:'language-multi',\
     tag:'platform-apache',\
     tag:'attack-generic',\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
         "t:none,\
@@ -42,6 +43,7 @@ SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
     tag:'language-multi',\
     tag:'platform-apache',\
     tag:'attack-generic',\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@endsWith (internal dummy connection)" \
         "t:none,\

--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -40,6 +40,7 @@ SecRule TX:DO_REPUT_BLOCK "@eq 1" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
+    ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:BEGIN-REQUEST-BLOCKING-EVAL"
@@ -68,6 +69,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!@rx ^$" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     chain"
     SecRule TX:REAL_IP "@geoLookup" \
@@ -121,6 +123,7 @@ SecRule IP:PREVIOUS_RBL_CHECK "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-RBL-LOOKUP"
 
 #
@@ -143,6 +146,7 @@ SecRule &TX:block_suspicious_ip "@eq 0" \
     t:none,\
     nolog,\
     tag:'paranoia-level/1',\
+    ver:'OWASP_CRS/3.2.0',\
     chain,\
     skipAfter:END-RBL-CHECK"
     SecRule &TX:block_harvester_ip "@eq 0" \
@@ -163,6 +167,7 @@ SecRule TX:REAL_IP "@rbl dnsbl.httpbl.org" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.httpbl_msg=%{tx.0}',\
     chain"
     SecRule TX:httpbl_msg "@rx RBL lookup of .*?.dnsbl.httpbl.org succeeded at TX:checkip. (.*?): .*" \
@@ -182,6 +187,7 @@ SecRule TX:block_search_ip "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:END-RBL-CHECK"
@@ -204,6 +210,7 @@ SecRule TX:block_spammer_ip "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:END-RBL-CHECK"
@@ -226,6 +233,7 @@ SecRule TX:block_suspicious_ip "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:END-RBL-CHECK"
@@ -248,6 +256,7 @@ SecRule TX:block_harvester_ip "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:END-RBL-CHECK"
@@ -270,6 +279,7 @@ SecAction \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'ip.previous_rbl_check=1',\
     expirevar:'ip.previous_rbl_check=86400'"
 

--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -69,6 +69,7 @@ SecRule &TX:dos_burst_time_slice "@eq 0" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain,\
     skipAfter:END-DOS-PROTECTION-CHECKS"
     SecRule &TX:dos_counter_threshold "@eq 0" \
@@ -81,6 +82,7 @@ SecRule &TX:dos_burst_time_slice "@eq 0" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.2.0',\
     chain,\
     skipAfter:END-DOS-PROTECTION-CHECKS"
     SecRule &TX:dos_counter_threshold "@eq 0" \
@@ -111,6 +113,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'platform-multi',\
     tag:'paranoia-level/1',\
     tag:'attack-dos',\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule &IP:DOS_BLOCK_FLAG "@eq 0" \
         "setvar:'ip.dos_block_counter=+1',\
@@ -134,6 +137,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'platform-multi',\
     tag:'paranoia-level/1',\
     tag:'attack-dos',\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'ip.dos_block_counter=+1'"
 
 
@@ -155,6 +159,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'platform-multi',\
     tag:'paranoia-level/1',\
     tag:'attack-dos',\
+    ver:'OWASP_CRS/3.2.0',\
     skipAfter:END-DOS-PROTECTION-CHECKS"
 
 
@@ -173,6 +178,7 @@ SecRule REQUEST_BASENAME "@rx .*?(\.[a-z0-9]{1,10})?$" \
     tag:'platform-multi',\
     tag:'paranoia-level/1',\
     tag:'attack-dos',\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.extension=/%{TX.1}/',\
     chain"
     SecRule TX:EXTENSION "!@within %{tx.static_extensions}" \
@@ -202,6 +208,7 @@ SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
     tag:'platform-multi',\
     tag:'paranoia-level/1',\
     tag:'attack-dos',\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule &IP:DOS_BURST_COUNTER "@eq 0" \
         "setvar:'ip.dos_burst_counter=1',\
@@ -220,6 +227,7 @@ SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
     tag:'platform-multi',\
     tag:'paranoia-level/1',\
     tag:'attack-dos',\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule &IP:DOS_BURST_COUNTER "@ge 1" \
         "setvar:'ip.dos_burst_counter=2',\
@@ -244,6 +252,7 @@ SecRule IP:DOS_BURST_COUNTER "@ge 2" \
     tag:'platform-multi',\
     tag:'paranoia-level/1',\
     tag:'attack-dos',\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'ip.dos_block=1',\
     expirevar:'ip.dos_block=%{tx.dos_block_timeout}'"
 
@@ -275,6 +284,7 @@ SecRule IP:DOS_BURST_COUNTER "@ge 1" \
     tag:'platform-multi',\
     tag:'attack-dos',\
     tag:'paranoia-level/2',\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'ip.dos_block=1',\
     expirevar:'ip.dos_block=%{tx.dos_block_timeout}'"
 

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -698,6 +698,7 @@ SecRule ARGS "@rx (?:/|\\\\)(?:[\?\*]+[a-z/\\\\]+|[a-z/\\\\]+[\?\*]+)" \
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -68,6 +68,7 @@ SecRule IP:REPUT_BLOCK_FLAG "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
+    ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     chain"
     SecRule TX:DO_REPUT_BLOCK "@eq 1" \
@@ -87,6 +88,7 @@ SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-generic',\
+    ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}'"
 

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -72,6 +72,7 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     t:none,\
     msg:'Outbound Anomaly Score Exceeded (Total Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
     tag:'anomaly-evaluation',\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score}'"
 
 

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -29,6 +29,7 @@ SecRule &TX:'/LEAKAGE\\\/ERRORS/' "@ge 1" \
     log,\
     msg:'Correlated Successful Attack Identified: (Total Score: %{tx.anomaly_score}) Inbound Attack (Inbound Anomaly Score: %{TX.INBOUND_ANOMALY_SCORE}) + Outbound Data Leakage (Outbound Anomaly Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
     tag:'event-correlation',\
+    ver:'OWASP_CRS/3.2.0',\
     severity:'EMERGENCY',\
     chain,\
     skipAfter:END-CORRELATION"
@@ -45,6 +46,7 @@ SecRule &TX:'/AVAILABILITY\\\/APP_NOT_AVAIL/' "@ge 1" \
     log,\
     msg:'Correlated Attack Attempt Identified: (Total Score: %{tx.anomaly_score}) Inbound Attack (Inbound Anomaly Score: %{TX.INBOUND_ANOMALY_SCORE}) + Outbound Application Error (Outbound Anomaly Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
     tag:'event-correlation',\
+    ver:'OWASP_CRS/3.2.0',\
     severity:'ALERT',\
     chain,\
     skipAfter:END-CORRELATION"
@@ -58,6 +60,7 @@ SecAction \
     t:none,\
     nolog,\
     noauditlog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.executing_anomaly_score=%{tx.anomaly_score_pl1}',\
     setvar:'tx.executing_anomaly_score=+%{tx.anomaly_score_pl2}',\
     setvar:'tx.executing_anomaly_score=+%{tx.anomaly_score_pl3}',\
@@ -72,6 +75,7 @@ SecRule TX:INBOUND_ANOMALY_SCORE "@lt %{tx.inbound_anomaly_score_threshold}" \
     noauditlog,\
     msg:'Inbound Anomaly Score (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{TX.ANOMALY_SCORE_PL1}, %{TX.ANOMALY_SCORE_PL2}, %{TX.ANOMALY_SCORE_PL3}, %{TX.ANOMALY_SCORE_PL4}',\
     tag:'event-correlation',\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule TX:MONITOR_ANOMALY_SCORE "@gt 1"
 
@@ -83,7 +87,8 @@ SecRule TX:INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     log,\
     noauditlog,\
     msg:'Inbound Anomaly Score Exceeded (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{TX.ANOMALY_SCORE_PL1}, %{TX.ANOMALY_SCORE_PL2}, %{TX.ANOMALY_SCORE_PL3}, %{TX.ANOMALY_SCORE_PL4}',\
-    tag:'event-correlation'"
+    tag:'event-correlation',\
+    ver:'OWASP_CRS/3.2.0'"
 
 SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     "id:980140,\
@@ -93,7 +98,8 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     log,\
     noauditlog,\
     msg:'Outbound Anomaly Score Exceeded (score %{TX.OUTBOUND_ANOMALY_SCORE}): individual paranoia level scores: %{TX.OUTBOUND_ANOMALY_SCORE_PL1}, %{TX.OUTBOUND_ANOMALY_SCORE_PL2}, %{TX.OUTBOUND_ANOMALY_SCORE_PL3}, %{TX.OUTBOUND_ANOMALY_SCORE_PL4}',\
-    tag:'event-correlation'"
+    tag:'event-correlation',\
+    ver:'OWASP_CRS/3.2.0'"
 
 # Creating a total sum of all triggered outbound rules, including the ones only being monitored
 SecAction \
@@ -103,6 +109,7 @@ SecAction \
     t:none,\
     nolog,\
     noauditlog,\
+    ver:'OWASP_CRS/3.2.0',\
     setvar:'tx.executing_anomaly_score=%{tx.outbound_anomaly_score_pl1}',\
     setvar:'tx.executing_anomaly_score=+%{tx.outbound_anomaly_score_pl2}',\
     setvar:'tx.executing_anomaly_score=+%{tx.outbound_anomaly_score_pl3}',\
@@ -117,6 +124,7 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@lt %{tx.outbound_anomaly_score_threshold}" \
     noauditlog,\
     msg:'Outbound Anomaly Score (Total Outbound Score: %{TX.OUTBOUND_ANOMALY_SCORE}): individual paranoia level scores: %{TX.OUTBOUND_ANOMALY_SCORE_PL1}, %{TX.OUTBOUND_ANOMALY_SCORE_PL2}, %{TX.OUTBOUND_ANOMALY_SCORE_PL3}, %{TX.OUTBOUND_ANOMALY_SCORE_PL4}',\
     tag:'event-correlation',\
+    ver:'OWASP_CRS/3.2.0',\
     chain"
     SecRule TX:MONITOR_ANOMALY_SCORE "@gt 1"
 


### PR DESCRIPTION
This PR fixes #650.

A small footnote for this modification: I generated a [spreadsheet](https://docs.google.com/spreadsheets/d/1x6tg8RyAELw0h4y1uoMEi3rPiLfrNFpK598kyXLtogs/edit#gid=1586050007) for the better visibility of changes.

The column E/F contains the status of actions before, J/K after the modification. The `PL control` is a formula, if the `id` of the rule is ended up with `...011`, `...012`. If it's "yes", then `Need 'ver' act.` is "no". This means the `PL control` rules didn't got the `ver` action now.

`Need to add` column is "yes" if the action should be at rule (it's not PL control rule) but there isn't yet. If this is "yes" the script added it.

If the rule needs the `ver` and contains it after the modification, then the `Check` field is `OK` - but doesn't matter that the action was present or not. All fields must be `OK` in this column.

The `Changed` fields indicates that a change has been made (was not present before - it present after).

Definition of `PL control`: 
```
id < 1000000 and (id % 1000 >= 100 or id % 1000 <= 10)
  or
id > 1000000
```
I think this form describes the rules with `skipAfter` actions and doesn't affect exclusion rules. The modification affects all other `SecRule` and `SecAction` entries.

Let me know if there are still missing any `ver` action, or if it's unnecessary.

Note, of course, the modification follows the [expected sequence of actions](https://github.com/SpiderLabs/owasp-modsecurity-crs/wiki/Order-of-ModSecurity-Actions-in-CRS-rules).